### PR TITLE
Make splitting of debugging symbols optional.

### DIFF
--- a/ambuild2/frontend/base_gen.py
+++ b/ambuild2/frontend/base_gen.py
@@ -233,6 +233,8 @@ all:
       cc = cpp.DetectCompiler(self, os.environ, 'CC')
       cxx = cpp.DetectCompiler(self, os.environ, 'CXX')
     self.compiler = cpp.Compiler(cc, cxx)
+    if self.options.symbol_files:
+      self.compiler.debuginfo = 'separate'
     return self.compiler
 
   def getLocalFolder(self, context):

--- a/ambuild2/frontend/cpp.py
+++ b/ambuild2/frontend/cpp.py
@@ -301,7 +301,7 @@ class Compiler(object):
   def __init__(self, cc, cxx):
     self.cc = cc
     self.cxx = cxx
-    self.debuginfo = True
+    self.debuginfo = 'bundled'
     for attr in Compiler.attrs:
       setattr(self, attr, [])
 
@@ -498,7 +498,7 @@ class BinaryBuilder(object):
         self.linker_outputs += [self.name_ + '.lib']
         self.linker_outputs += [self.name_ + '.exp']
 
-    if self.compiler.debuginfo:
+    if self.compiler.debuginfo == 'separate':
       self.perform_symbol_steps(cx)
 
   def perform_symbol_steps(self, cx):
@@ -543,7 +543,10 @@ class BinaryBuilder(object):
       shared_outputs = shared_outputs
     )
     if not self.debug_entry and self.compiler.debuginfo:
-      self.debug_entry = outputs[-1]
+      if self.linker_.behavior != 'msvc' and self.compiler.debuginfo == 'bundled':
+        self.debug_entry = outputs[0]
+      else:
+        self.debug_entry = outputs[-1]
     return outputs[0], self.debug_entry
 
 class Program(BinaryBuilder):

--- a/ambuild2/frontend/prep.py
+++ b/ambuild2/frontend/prep.py
@@ -36,6 +36,8 @@ class Preparer(object):
                             help="Generate extra command-line files for building (build.py, Makefile).")
     self.options.add_option("--no-color", action="store_true", dest="no_color", default=False,
                             help="Disable color output in the terminal.")
+    self.options.add_option("--symbol-files", action="store_true", dest="symbol_files", default=False,
+                            help="Split debugging symbols from binaries into separate symbol files.")
 
   @staticmethod
   def default_build_folder(prep):


### PR DESCRIPTION
This adds the --symbol-files configure option to turn this back on.
