### PR TITLE
Make ambuild script use #/usr/bin/env python

### DIFF
--- a/scripts/ambuild
+++ b/scripts/ambuild
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: set sts=2 ts=8 sw=2 tw=99 et:
 import os, sys
 from ambuild2 import run


### PR DESCRIPTION
I don't think this needs much explanation, but this little change will make the ambuild script use the first `python` executable in the `$PATH` variable.
Yes, i know that the shebang is changed when using `setup.py` and this script  usually isn't executed  directly from the command line.
