### PR TITLE
Fix Python 3 compatibility bug.

### DIFF
--- a/ambuild2/frontend/version.py
+++ b/ambuild2/frontend/version.py
@@ -14,9 +14,11 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
+from ambuild2 import util
 
-class Version(object):
+class Version(util.Orderable):
   def __init__(self, string):
+    super(Version, self).__init__()
     if type(string) is int:
       self.string = str(string)
       self.components = [string]
@@ -39,4 +41,4 @@ class Version(object):
     else:
       components = Version.split(str(other))
 
-    return cmp(self.components, components)
+    return util.compare(self.components, components)

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -411,3 +411,34 @@ def WriteEncodedText(fd, text):
   if not hasattr(fd, 'encoding') or fd.encoding == None:
     text = text.encode(locale.getpreferredencoding(), 'replace')
   fd.write(text)
+
+class CmpOrderable(object):
+  def __init__(self):
+    super(CmpOrderable, self).__init__()
+
+  def __lt__(self, other):
+    return self.__cmp__(other) < 0
+
+  def __le__(self, other):
+    return self.__cmp__(other) <= 0
+
+  def __eq__(self, other):
+    return self.__cmp__(other) == 0
+
+  def __ne__(self, other):
+    return self.__cmp__(other) != 0
+
+  def __gt__(self, other):
+    return self.__cmp__(other) > 0
+
+  def __ge__(self, other):
+    return self.__cmp__(other) >= 0
+
+if str == bytes:
+  class Orderable(object):
+    pass
+  compare = cmp
+else:
+  class Orderable(CmpOrderable):
+    pass
+  compare = lambda a, b: (a > b) - (a < b)


### PR DESCRIPTION
Python 3 is annoying enough to consider dropping support for it entirely. But we've got it mostly working, so maybe that's too drastic. The problem here is that Python removed `__cmp__` support, so you have to implement all six comparators. There's a decorator to only implement two, but even that's just silly.

Python 3 also removed the `cmp()` builtin.

This patch adds Python 3 specific shims for cmp() and a class you can inherit to make `__cmp__` work.
