### PR TITLE
Fixed the vs generator linker dependencies.

### DIFF
--- a/ambuild2/frontend/vs/export_vcxproj.py
+++ b/ambuild2/frontend/vs/export_vcxproj.py
@@ -237,7 +237,6 @@ def export_configuration_options(node, xml, builder):
     ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
     machine = 'X86'
     subsystem = 'Windows'
-    dependencies = []
     for flag in link_flags:
       if util.IsString(flag):
         if flag == '/SUBSYSTEM:CONSOLE':
@@ -245,7 +244,7 @@ def export_configuration_options(node, xml, builder):
           continue
 
         if '.lib' in flag:
-          dependencies.append(flag)
+          libs.append(flag)
           continue
 
         m = re.match('/NODEFAULTLIB:(.+)', flag)


### PR DESCRIPTION
I might be crazy, but the VS generator seemed to build a set of
linker dependencies and then just throw them away, making it
impossible to build generated projects.

Feel free to ignore this pull request if it is invalid.
## 

Commit message:

The vs generator seemed to build a set of linker dependencies
but never added them to the 'Additional Dependencies' property.
This caused the generator to generate VS projects without
linker dependencies.

Removed the dependencies variable and added directly to the libs
variable since it isn't used for anything else anyway.
