### PR TITLE
Fix .pdb files not being added to the DAG when debuginfo is "bundled".

### DIFF
--- a/ambuild2/frontend/cpp/builders.py
+++ b/ambuild2/frontend/cpp/builders.py
@@ -103,7 +103,7 @@ class ArgBuilder(object):
   def __init__(self, outputPath, config, compiler):
     args = compiler.command.split(' ')
     args += config.cflags
-    if config.debuginfo:
+    if config.debug_symbols:
       args += compiler.debuginfo_argv
     if compiler == config.cxx:
       args += config.cxxflags
@@ -185,7 +185,7 @@ class BinaryBuilder(object):
     self.default_cxx_env = ArgBuilder(self.outputPath, self.compiler, self.compiler.cxx)
 
     shared_cc_outputs = []
-    if self.compiler.debuginfo and self.compiler.cc.behavior == 'msvc':
+    if self.compiler.debug_symbols and self.compiler.cc.behavior == 'msvc':
       cl_version = int(self.compiler.cc.version) - 600
       shared_pdb = 'vc{0}.pdb'.format(int(cl_version / 10))
       shared_cc_outputs += [shared_pdb]
@@ -255,7 +255,7 @@ class BinaryBuilder(object):
         self.linker_outputs += [self.name_ + '.lib']
         self.linker_outputs += [self.name_ + '.exp']
 
-    if self.compiler.debuginfo == 'separate':
+    if self.compiler.debug_symbols == 'separate':
       self.perform_symbol_steps(cx)
 
   def perform_symbol_steps(self, cx):
@@ -299,8 +299,8 @@ class BinaryBuilder(object):
       folder = folder,
       shared_outputs = shared_outputs
     )
-    if not self.debug_entry and self.compiler.debuginfo:
-      if self.linker_.behavior != 'msvc' and self.compiler.debuginfo == 'bundled':
+    if not self.debug_entry and self.compiler.debug_symbols:
+      if self.linker_.behavior != 'msvc' and self.compiler.debug_symbols == 'bundled':
         self.debug_entry = outputs[0]
       else:
         self.debug_entry = outputs[-1]
@@ -330,7 +330,7 @@ class Program(BinaryBuilder):
         '/OUT:' + self.outputFile,
         '/nologo',
       ]
-      if self.compiler.debuginfo:
+      if self.compiler.debug_symbols:
         argv += ['/DEBUG', '/PDB:"' + self.name_ + '.pdb"']
     else:
       argv.extend(self.linkFlags(cx))
@@ -363,7 +363,7 @@ class Library(BinaryBuilder):
         '/nologo',
         '/DLL',
       ]
-      if self.compiler.debuginfo:
+      if self.compiler.debug_symbols:
         argv += ['/DEBUG', '/PDB:"' + self.name_ + '.pdb"']
     elif isinstance(self.linker_, CompatGCC):
       argv.extend(self.linkFlags(cx))

--- a/ambuild2/frontend/cpp/compilers.py
+++ b/ambuild2/frontend/cpp/compilers.py
@@ -143,3 +143,7 @@ class CxxCompiler(Compiler):
   def argv(self):
     return self.cxx.command.split(' ')
 
+  # Returns the debuginfo modulo what the underlying vendor's compiler supports.
+  @property
+  def debug_symbols(self):
+    return self.cxx.parse_debuginfo(self.debuginfo)

--- a/ambuild2/frontend/cpp/vendors.py
+++ b/ambuild2/frontend/cpp/vendors.py
@@ -40,6 +40,11 @@ class MSVC(Vendor):
   def like(self, name):
     return name == 'msvc'
 
+  def parse_debuginfo(self, debuginfo):
+    if debuginfo == 'bundled':
+      return 'separate'
+    return debuginfo
+
   @staticmethod
   def IncludePath(outputPath, includePath):
     # Hack - try and get a relative path because CL, with either 
@@ -76,6 +81,9 @@ class CompatGCC(Vendor):
 
   def objectArgs(self, sourceFile, objFile):
     return ['-H', '-c', sourceFile, '-o', objFile]
+
+  def parse_debuginfo(self, debuginfo):
+    return debuginfo
 
 class GCC(CompatGCC):
   def __init__(self, command, version):


### PR DESCRIPTION
The `debuginfo` property doesn't take into account that MSVC cannot bundle symbol information. It always generates a .pdb. This introduces a new property, `debug_symbols`, which first asks the vendor what it will actually do.
