### PR TITLE
Add Emscripten support.

### DIFF
--- a/ambuild2/frontend/cpp/builders.py
+++ b/ambuild2/frontend/cpp/builders.py
@@ -54,7 +54,7 @@ class BuilderProxy(object):
 
   @property
   def outputFile(self):
-    return self.constructor_.buildName(self.name_)
+    return self.constructor_.buildName(self.compiler, self.name_)
 
   @property
   def localFolder(self):
@@ -149,7 +149,7 @@ class BinaryBuilder(object):
 
   @property
   def outputFile(self):
-    return self.buildName(self.name_)
+    return self.buildName(self.compiler, self.name_)
 
   def generate(self, generator, cx):
     return generator.addCxxTasks(cx, self)
@@ -313,8 +313,8 @@ class Program(BinaryBuilder):
     super(Program, self).__init__(compiler, name)
 
   @staticmethod
-  def buildName(name):
-    return name + util.ExecutableSuffix()
+  def buildName(compiler, name):
+    return compiler.nameForExecutable(name)
 
   @property
   def type(self):
@@ -345,8 +345,8 @@ class Library(BinaryBuilder):
     super(Library, self).__init__(compiler, name)
 
   @staticmethod
-  def buildName(name):
-    return name + util.SharedLibSuffix()
+  def buildName(compiler, name):
+    return compiler.nameForSharedLibrary(name)
 
   @property
   def type(self):
@@ -382,8 +382,8 @@ class StaticLibrary(BinaryBuilder):
     super(StaticLibrary, self).__init__(compiler, name)
 
   @staticmethod
-  def buildName(name):
-    return util.StaticLibPrefix() + name + util.StaticLibSuffix()
+  def buildName(compiler, name):
+    return compiler.nameForStaticLibrary(name)
 
   @property
   def type(self):

--- a/ambuild2/frontend/cpp/compilers.py
+++ b/ambuild2/frontend/cpp/compilers.py
@@ -149,3 +149,11 @@ class CxxCompiler(Compiler):
   @property
   def debug_symbols(self):
     return self.cxx.parse_debuginfo(self.debuginfo)
+
+  # Internal API.
+  def nameForStaticLibrary(self, name):
+    return self.cxx.nameForStaticLibrary(name)
+  def nameForSharedLibrary(self, name):
+    return self.cxx.nameForSharedLibrary(name)
+  def nameForExecutable(self, name):
+    return self.cxx.nameForExecutable(name)

--- a/ambuild2/frontend/cpp/detect.py
+++ b/ambuild2/frontend/cpp/detect.py
@@ -189,9 +189,9 @@ int main()
 """)
   file.close()
   if mode == 'CC':
-    executable = 'test' + util.ExecutableSuffix()
+    executable = 'test' + util.ExecutableSuffix
   elif mode == 'CXX':
-    executable = 'testp' + util.ExecutableSuffix()
+    executable = 'testp' + util.ExecutableSuffix
 
   # Make sure the exe is gone.
   if os.path.exists(executable):

--- a/ambuild2/frontend/cpp/vendors.py
+++ b/ambuild2/frontend/cpp/vendors.py
@@ -16,6 +16,7 @@
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from ambuild2 import util
 from ambuild2.frontend.version import Version
 
 class Vendor(object):
@@ -28,6 +29,15 @@ class Vendor(object):
     self.debuginfo_argv = []
     self.extra_props = {}
     self.versionObject = Version('{0}-{1}'.format(name, self.version))
+
+  def nameForExecutable(self, name):
+    return name + util.ExecutableSuffix
+
+  def nameForSharedLibrary(self, name):
+    return name + util.SharedLibSuffix
+
+  def nameForStaticLibrary(self, name):
+    return util.StaticLibPrefix + name + util.StaticLibSuffix
 
 class MSVC(Vendor):
   def __init__(self, command, version):
@@ -112,6 +122,9 @@ class Emscripten(Clang):
     if name == 'emscripten':
       return true
     return super(Emscripten, self).like(name)
+
+  def nameForExecutable(self, name):
+    return name + '.js'
 
 class SunPro(Vendor):
   def __init__(self, command, version):

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -64,30 +64,27 @@ def IsUnixy():
 def IsBSD():
   return IsMac() or IsFreeBSD() or IsOpenBSD() or IsNetBSD()
 
-def ExecutableSuffix():
-  if IsWindows():
-    return '.exe'
-  else:
-    return ''
+if IsWindows():
+  ExecutableSuffix = '.exe'
+else:
+  ExecutableSuffix = ''
 
-def SharedLibSuffix():
-  if IsWindows():
-    return '.dll'
-  elif sys.platform == 'darwin':
-    return '.dylib'
-  else:
-    return '.so'
+if IsWindows():
+  SharedLibSuffix = '.dll'
+elif sys.platform == 'darwin':
+  SharedLibSuffix = '.dylib'
+else:
+  SharedLibSuffix = '.so'
 
-def StaticLibSuffix():
-  if IsUnixy():
-    return '.a'
-  return '.lib'
+if IsUnixy():
+  StaticLibSuffix = '.a'
+else:
+  StaticLibSuffix = '.lib'
 
-def StaticLibPrefix():
-  if IsWindows():
-    return ''
-  else:
-    return 'lib'
+if IsWindows():
+  StaticLibPrefix = ''
+else:
+  StaticLibPrefix = 'lib'
 
 def WaitForProcess(process):
   out, err = process.communicate()


### PR DESCRIPTION
This required a little refactoring, and it only supports the js output mode. Since Emscripten no longer generates an executable, I hacked detection in by sniffing the output of $CXX -dM -E.
