### PR TITLE
dont use mutables as default values, DRY POSIX IPC

### DIFF
--- a/ambuild2/builder.py
+++ b/ambuild2/builder.py
@@ -1,10 +1,9 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
-import sys
-import os, errno
-import traceback
+import os
+from collections import deque
+
 from ambuild2 import util
 from ambuild2 import nodetypes
-from collections import deque
 from ambuild2.task import Task, TaskMasterParent
 
 # Given the partial command DAG, compute a task tree we can send to the task

--- a/ambuild2/context.py
+++ b/ambuild2/context.py
@@ -14,13 +14,12 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
-import time
 import traceback
-import os, sys, imp
+import os, sys
 from ambuild2 import util, database, damage
 from ambuild2.builder import Builder
 from ambuild2.ipc import ProcessManager, MessagePump
-from optparse import OptionParser
+
 
 class Context(object):
   def __init__(self, buildPath, options, args):

--- a/ambuild2/frontend/amb2/gen.py
+++ b/ambuild2/frontend/amb2/gen.py
@@ -317,7 +317,7 @@ class Generator(BaseGenerator):
     raise Exception('illegal path component')
 
   def parseOutput(self, cwd_entry, path, kind):
-    if path[-1] == os.sep or path[-1] == os.altsep or path == '.' or path == '':
+    if path in ('.', '') or path[-1] in (os.sep, os.altsep):
       util.con_err(util.ConsoleRed, 'Path "',
                    util.ConsoleBlue, path,
                    util.ConsoleRed, '" looks like a folder; a folder was not expected.',
@@ -325,7 +325,6 @@ class Generator(BaseGenerator):
       raise Exception('Expected folder, but path has a trailing slash')
 
     path = os.path.normpath(path)
-
     path, name = os.path.split(path)
     path = nodetypes.combine(cwd_entry, path)
 
@@ -436,8 +435,10 @@ class Generator(BaseGenerator):
     raise Exception('Tried to use non-file node as a file path')
 
   def addCommand(self, context, node_type, folder, data, inputs, outputs,
-                 weak_inputs=[], shared_outputs=[]):
+                 weak_inputs=None, shared_outputs=None):
     assert not folder or isinstance(folder, nodetypes.Entry)
+    weak_inputs = weak_inputs or []
+    shared_outputs = shared_outputs or []
 
     # Build the set of weak links.
     weak_links = set()
@@ -655,9 +656,9 @@ class Generator(BaseGenerator):
     # slash or '.'/'' indicating the context folder.
     detected_folder = None
     if util.IsString(output_path):
-      if output_path[-1] == os.sep or output_path[-1] == os.altsep:
+      if output_path[-1] in (os.sep, os.altsep):
         detected_folder = os.path.join(context.buildFolder, os.path.normpath(output_path))
-      elif output_path == '.' or output_path == '':
+      elif output_path in ('.', ''):
         detected_folder = context.buildFolder
 
       # Since we're building something relative to the context folder, ensure
@@ -725,15 +726,8 @@ class Generator(BaseGenerator):
   def addFolder(self, context, folder):
     return self.generateFolder(context.localFolder, folder)
 
-  def addShellCommand(self,
-                      context,
-                      inputs,
-                      argv,
-                      outputs,
-                      folder=-1,
-                      dep_type=None,
-                      weak_inputs=[],
-                      shared_outputs=[]):
+  def addShellCommand(self, context, inputs, argv, outputs, folder=-1,
+                      dep_type=None, weak_inputs=None, shared_outputs=None):
     if folder is -1:
       folder = context.localFolder
 

--- a/ambuild2/frontend/base/gen.py
+++ b/ambuild2/frontend/base/gen.py
@@ -92,7 +92,7 @@ class Context(object):
     return self.generator.backend
 
   def SetBuildFolder(self, folder):
-    if folder == '/' or folder == '.' or folder == './':
+    if folder in ('/', '.', './'):
       self.buildFolder = ''
     else:
       self.buildFolder = os.path.normpath(folder)
@@ -103,13 +103,13 @@ class Context(object):
       self.compiler = self.generator.detectCompilers().clone()
     return self.compiler
 
-  def ImportScript(self, file, vars={}):
+  def ImportScript(self, file, vars=None):
     return self.generator.importScript(self, file, vars)
 
-  def RunScript(self, file, vars={}):
+  def RunScript(self, file, vars=None):
     return self.generator.evalScript(file, vars)
 
-  def RunBuildScripts(self, files, vars={}):
+  def RunBuildScripts(self, files, vars=None):
     if util.IsString(files):
       self.generator.evalScript(files, vars)
     else:
@@ -132,17 +132,17 @@ class Context(object):
   def AddCopy(self, source, output_path):
     return self.generator.addCopy(self, source, output_path)
 
-  def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=[],
-                 shared_outputs=[]):
+  def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=None,
+                 shared_outputs=None):
     return self.generator.addShellCommand(
       self,
       inputs,
       argv,
       outputs,
-      folder = folder,
-      dep_type = dep_type,
-      weak_inputs = weak_inputs,
-      shared_outputs = shared_outputs
+      folder=folder,
+      dep_type=dep_type,
+      weak_inputs=weak_inputs or [],
+      shared_outputs=shared_outputs or []
     )
 
   def AddConfigureFile(self, path):
@@ -199,16 +199,15 @@ class BaseGenerator(object):
       chars = fp.read()
 
       # Python 2.6 can't compile() with Windows line endings?!?!!?
-      chars = chars.replace('\r\n', '\n')
-      chars = chars.replace('\r', '\n')
+      chars = chars.replace('\r\n', '\n').replace('\r', '\n')
 
       return compile(chars, path, 'exec')
 
-  def importScript(self, context, file, vars={}):
+  def importScript(self, context, file, vars=None):
     path = os.path.normpath(os.path.join(context.sourcePath, file))
     self.addConfigureFile(context, path)
 
-    new_vars = copy.copy(vars)
+    new_vars = copy.copy(vars or {})
     new_vars['builder'] = context
 
     code = self.compileScript(path)
@@ -222,7 +221,7 @@ class BaseGenerator(object):
   def Context(self, name):
     return AutoContext(self, self.contextStack_[-1], name)
 
-  def evalScript(self, file, vars={}):
+  def evalScript(self, file, vars=None):
     file = os.path.normpath(file)
 
     cx = Context(self, self.contextStack_[-1], file)
@@ -232,7 +231,7 @@ class BaseGenerator(object):
 
     self.addConfigureFile(cx, full_path)
 
-    new_vars = copy.copy(vars)
+    new_vars = copy.copy(vars or {})
     new_vars['builder'] = cx
 
     # Run it.
@@ -294,7 +293,7 @@ all:
     raise Exception('Must be implemented!')
 
   def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
+                      weak_inputs=None, shared_outputs=None):
     raise Exception('Must be implemented!')
 
   def addConfigureFile(self, context, path):

--- a/ambuild2/frontend/cpp/compilers.py
+++ b/ambuild2/frontend/cpp/compilers.py
@@ -59,7 +59,7 @@ class Compiler(object):
   def inherit(self, other):
     self.debuginfo = other.debuginfo
     for attr in self.attrs:
-      setattr(self, attr, copy.copy(getattr(other, attr)))
+      setattr(self, attr, copy.deepcopy(getattr(other, attr)))
 
   def clone(self):
     raise Exception('Must be implemented!')

--- a/ambuild2/frontend/cpp/vendors.py
+++ b/ambuild2/frontend/cpp/vendors.py
@@ -111,7 +111,7 @@ class Clang(CompatGCC):
     self.debuginfo_argv = ['-g3']
 
   def like(self, name):
-    return name == 'gcc' or name == 'clang' or name == self.vendor_name
+    return name in ('gcc', 'clang', self.vendor_name)
 
 class Emscripten(Clang):
   def __init__(self, command, version):

--- a/ambuild2/frontend/vs/export_vcxproj.py
+++ b/ambuild2/frontend/vs/export_vcxproj.py
@@ -236,11 +236,9 @@ def export_configuration_options(node, xml, builder):
     libs = ['%(AdditionalDependencies)']
     ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
     machine = 'X86'
-    subsystem = 'Windows'
     for flag in link_flags:
       if util.IsString(flag):
         if flag == '/SUBSYSTEM:CONSOLE':
-          subsystem = 'Console'
           continue
 
         if '.lib' in flag:

--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -17,7 +17,6 @@
 import os, errno
 import uuid as uuids
 from ambuild2 import util
-from ambuild2 import nodetypes
 from ambuild2.frontend import paths
 from ambuild2.frontend.vs import cxx
 from ambuild2.frontend.vs import nodes
@@ -153,7 +152,7 @@ class Generator(BaseGenerator):
 
   # Overridden.
   def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
+                      weak_inputs=None, shared_outputs=None):
     print(inputs, argv, outputs, folder, dep_type, weak_inputs, shared_outputs)
 
   def addOutput(self, context, path, parent):

--- a/ambuild2/ipc/winapi.py
+++ b/ambuild2/ipc/winapi.py
@@ -16,7 +16,6 @@
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import ctypes
 import os, sys
-import tempfile
 from ambuild2 import util
 
 handle_t = ctypes.c_void_p

--- a/ambuild2/ipc/windows.py
+++ b/ambuild2/ipc/windows.py
@@ -384,7 +384,7 @@ class MessagePump(process.MessagePump):
     return key
 
   def addChannel(self, channel, listener):
-    key = self.registerChannel(channel, listener)
+    self.registerChannel(channel, listener)
 
     # On Windows, we must initiate a recv() that would block in order to
     # receive io completion events. Since that could return actual data,

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -153,9 +153,9 @@ class Entry(object):
     return self.folder.path
 
   def format(self):
-    if self.type == Source or self.type == Output or self.type == SharedOutput:
+    if self.type in (Source, Output, SharedOutput):
       return self.path
-    text = ''
+
     if self.type == Mkdir:
       return 'mkdir -p ' + self.path
     if self.type == Symlink:
@@ -168,7 +168,8 @@ class Entry(object):
       return ' '.join([arg for arg in self.blob['cl_argv']]) + ' && ' + ' '.join([arg for arg in self.blob['rc_argv']])
     if self.type == Group:
       return 'group "{0}"'.format(self.path)
-    return (' '.join([arg for arg in self.blob]))
+
+    return ' '.join([arg for arg in self.blob])
 
 def combine(a, b):
   if type(a) is Entry:

--- a/ambuild2/task.py
+++ b/ambuild2/task.py
@@ -2,13 +2,12 @@
 import errno
 import shutil
 import os, sys
-import traceback
 import multiprocessing as mp
 from ambuild2 import util
 from ambuild2 import nodetypes
 from ambuild2.ipc import ParentProcessListener, ChildProcessListener
-from ambuild2.ipc import ProcessManager, MessageListener, Error
-from ambuild2.ipc import Channel
+from ambuild2.ipc import ProcessManager, Error
+
 
 class Task(object):
   def __init__(self, id, entry, outputs):
@@ -34,14 +33,13 @@ class Task(object):
     return self.folder
 
   def format(self):
-    text = ''
     if self.type == nodetypes.Cxx:
       return '[' + self.data['type'] + ']' + ' -> ' + (' '.join([arg for arg in self.data['argv']]))
     if self.type == nodetypes.Symlink:
       return 'ln -s "{0}" "{1}"'.format(self.data[0], os.path.join(self.folder_name, self.data[1]))
     if self.type == nodetypes.Copy:
       return 'cp "{0}" "{1}"'.format(self.data[0], os.path.join(self.folder_name, self.data[1]))
-    return (' '.join([arg for arg in self.data]))
+    return ' '.join([arg for arg in self.data])
 
 class WorkerChild(ChildProcessListener):
   def __init__(self, pump, channel, vars):
@@ -66,12 +64,6 @@ class WorkerChild(ChildProcessListener):
     })
 
   def receiveTask(self, channel, message):
-    task_id = message['task_id']
-    task_type = message['task_type']
-    task_folder = message['task_folder']
-    if not task_folder:
-      task_folder = '.'
-
     # Remove all outputs.
     for output in message['task_outputs']:
       try:
@@ -90,7 +82,7 @@ class WorkerChild(ChildProcessListener):
       message['task_folder'] = '.'
 
     # Do the task.
-    response = self.taskMap[task_type](message)
+    response = self.taskMap[message['task_type']](message)
     return self.issueResponse(message, response)
 
   def issueResponse(self, message, response):

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -52,7 +52,7 @@ def IsCygwin():
   return sys.platform == 'cygwin'
 
 def IsMac():
-  return sys.platform == 'darwin' or sys.platform[0:6] == 'Darwin'
+  return sys.platform[:6].lower() == 'darwin'
 
 def IsSolaris():
   return sys.platform[0:5] == 'sunos'
@@ -92,11 +92,12 @@ def WaitForProcess(process):
   return process.returncode
 
 def CreateProcess(argv, executable = None):
-  pargs = { 'args': argv }
-  pargs['stdout'] = subprocess.PIPE
-  pargs['stderr'] = subprocess.PIPE
-  if executable != None:
-    pargs['executable'] = executable
+  pargs = {
+    'args': argv,
+    'stdout': subprocess.PIPE,
+    'stderr': subprocess.PIPE,
+    'executable': executable,
+  }
   try:
     process = subprocess.Popen(**pargs)
   except:


### PR DESCRIPTION
Hi,
the main motivation for creating this PR is a number of places where a mutable variable is used as a default value for a function params. I believe it's a widely known thing, but I'll put here an example anyway:
``` 
>>> def append_to(element, to=[]):
...     to.append(element)
...     return to
>>> print append_to(1)
[1]
>>> print append_to(2) # a sane output would be [1] 
[1, 2]
```
^ if this behaviour is utilized on purpose, then... I'm not sure if that's a good design, as it doesnt make the code easy to follow.

other things done here:
- some unused pieces of code are removed
- added missing `super()` call where it would make sense
- DRY duplicite code in POSIX IPC

I've "tested" the result code to build SM on OSX, and Linux

Regards,
yed_