### PR TITLE
dont use mutables as a default value

### DIFF
--- a/ambuild2/frontend/amb2/gen.py
+++ b/ambuild2/frontend/amb2/gen.py
@@ -436,11 +436,13 @@ class Generator(BaseGenerator):
     raise Exception('Tried to use non-file node as a file path')
 
   def addCommand(self, context, node_type, folder, data, inputs, outputs,
-                 weak_inputs=[], shared_outputs=[]):
+                 weak_inputs=None, shared_outputs=None):
     assert not folder or isinstance(folder, nodetypes.Entry)
 
     # Build the set of weak links.
     weak_links = set()
+    weak_inputs = []
+    shared_outputs = []
     for weak_input in weak_inputs:
       assert type(weak_input) is nodetypes.Entry
       assert weak_input.type != nodetypes.Source
@@ -732,8 +734,8 @@ class Generator(BaseGenerator):
                       outputs,
                       folder=-1,
                       dep_type=None,
-                      weak_inputs=[],
-                      shared_outputs=[]):
+                      weak_inputs=None,
+                      shared_outputs=None):
     if folder is -1:
       folder = context.localFolder
 

--- a/ambuild2/frontend/base/gen.py
+++ b/ambuild2/frontend/base/gen.py
@@ -103,13 +103,13 @@ class Context(object):
       self.compiler = self.generator.detectCompilers().clone()
     return self.compiler
 
-  def ImportScript(self, file, vars={}):
+  def ImportScript(self, file, vars=None):
     return self.generator.importScript(self, file, vars)
 
-  def RunScript(self, file, vars={}):
+  def RunScript(self, file, vars=None):
     return self.generator.evalScript(file, vars)
 
-  def RunBuildScripts(self, files, vars={}):
+  def RunBuildScripts(self, files, vars=None):
     if util.IsString(files):
       self.generator.evalScript(files, vars)
     else:
@@ -132,8 +132,8 @@ class Context(object):
   def AddCopy(self, source, output_path):
     return self.generator.addCopy(self, source, output_path)
 
-  def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=[],
-                 shared_outputs=[]):
+  def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=None,
+                 shared_outputs=None):
     return self.generator.addShellCommand(
       self,
       inputs,
@@ -204,11 +204,11 @@ class BaseGenerator(object):
 
       return compile(chars, path, 'exec')
 
-  def importScript(self, context, file, vars={}):
+  def importScript(self, context, file, vars=None):
     path = os.path.normpath(os.path.join(context.sourcePath, file))
     self.addConfigureFile(context, path)
 
-    new_vars = copy.copy(vars)
+    new_vars = copy.copy(vars or {})
     new_vars['builder'] = context
 
     code = self.compileScript(path)
@@ -222,7 +222,7 @@ class BaseGenerator(object):
   def Context(self, name):
     return AutoContext(self, self.contextStack_[-1], name)
 
-  def evalScript(self, file, vars={}):
+  def evalScript(self, file, vars=None):
     file = os.path.normpath(file)
 
     cx = Context(self, self.contextStack_[-1], file)
@@ -232,7 +232,7 @@ class BaseGenerator(object):
 
     self.addConfigureFile(cx, full_path)
 
-    new_vars = copy.copy(vars)
+    new_vars = copy.copy(vars or {})
     new_vars['builder'] = cx
 
     # Run it.
@@ -294,7 +294,7 @@ all:
     raise Exception('Must be implemented!')
 
   def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
+                      weak_inputs=None, shared_outputs=None):
     raise Exception('Must be implemented!')
 
   def addConfigureFile(self, context, path):

--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -153,7 +153,7 @@ class Generator(BaseGenerator):
 
   # Overridden.
   def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
+                      weak_inputs=None, shared_outputs=None):
     print(inputs, argv, outputs, folder, dep_type, weak_inputs, shared_outputs)
 
   def addOutput(self, context, path, parent):


### PR DESCRIPTION
Hi,
the main motivation for creating this PR is a number of places where a mutable variable is used as a default value for a function params. I believe it's a widely known thing, but I'll put here an example anyway:

```
>>> def append_to(element, to=[]):
...     to.append(element)
...     return to
>>> print append_to(1)
[1]
>>> print append_to(2) # a sane output would be [1] 
[1, 2]
```

^ if this behaviour is utilized on purpose, then... I'm not sure if that's a good design, as it doesnt make the code easy to follow.
