### PR TITLE
python3 fix

### DIFF
--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -376,7 +376,7 @@ def IsLambda(v):
   return type(v) == LambdaType
 
 def IsString(v):
-  return isinstance(v, basestring)
+  return isinstance(v, str)
 
 class Expando(object):
   pass


### PR DESCRIPTION
in python3.4:

NameError: name 'basestring' is not defined