### PR TITLE
Handle `gcc -H` PCH prefixes properly in ParseGCCDeps

### DIFF
--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -209,7 +209,7 @@ def ParseGCCDeps(text):
   state = sReadIncludes
   for line in re.split('\n+', text):
     if state == sReadIncludes:
-      m = re.match('\.+\s+(.+)\s*$', line)
+      m = re.match('[\.!x]\.*\s+(.+)\s*$', line)
       if m == None:
         state = sLookForIncludeGuard
       else:


### PR DESCRIPTION
When using a precompiled header, `gcc -H` will output a line starting with '!' for the PCH:

```
g++ -O0 -H -c main.c
! precompiled.h.gch
 main.c
. normal.h
.. x.h
Multiple include guards may be useful for:
normal.h
x.h
```

Also, in the circumstance where the PCH is incompatible with the source file (e.g. due to compiling with different options), `gcc -H` will output a line starting with 'x' for the PCH:

```
g++ -O1 -H -c main.c
x precompiled.h.gch
. precompiled.h
.. y.h
. normal.h
.. x.h
Multiple include guards may be useful for:
normal.h
precompiled.h
x.h
y.h
```

Without this patch, AMBuild fails to realize that the '.h.gch' file is a dependency of the source file, so it won't set up the proper dependency relationships to ensure that the dependent source files are rebuilt when the '.h' file is modified (assuming that the user has set up a manual build command to generate the '.h.gch' file from the '.h' file).

Also, without this patch, AMBuild lets the '!'/'x' lines from `gcc -H` through to the actual stderr, cluttering up the output.

Incidentally, I'm not entirely clear on why gcc decides to print a line with ' main.c' in only those cases where the precompiled header is successfully included. Might be worth looking into, to see whether ParseGCCDeps handles that in a sane manner. Nothing seemed awry from what I could see, but you never know.