### PR TITLE
Implement somewhat hacky GCC precompiled header support

### DIFF
--- a/ambuild2/damage.py
+++ b/ambuild2/damage.py
@@ -51,8 +51,8 @@ def ComputeDirty(node):
     dirty = ComputeCopyFolderDirty(node)
   else:
     raise Exception('cannot compute dirty bit for node type: ' + node.type)
-  if dirty:
-    node.dirty |= nodetypes.NewDirty
+  if dirty == nodetypes.DIRTY:
+    node.newlyDirty = True
   return dirty
 
 def ComputeDamageGraph(database, only_changed = False):
@@ -78,7 +78,7 @@ def ComputeDamageGraph(database, only_changed = False):
     return dirty
 
   def add_dirty(entry):
-    if entry.dirty == nodetypes.NewDirty:
+    if entry.newlyDirty:
       # Mark this node as dirty in the DB so we don't have to check the
       # filesystem next time.
       database.mark_dirty(entry)
@@ -86,7 +86,7 @@ def ComputeDamageGraph(database, only_changed = False):
     graph.addEntry(entry)
 
   for entry in dirty:
-    if (entry.type == nodetypes.Output) and (entry.dirty == nodetypes.NewDirty):
+    if (entry.type == nodetypes.Output) and entry.newlyDirty:
       # Ensure that our command has been marked as dirty.
       incoming = database.query_strong_inputs(entry)
       incoming |= database.query_dynamic_inputs(entry)
@@ -107,7 +107,7 @@ def ComputeDamageGraph(database, only_changed = False):
   # Find all leaf commands in the graph and mark them as dirty. This ensures
   # that we'll include them in the next damage graph.
   def finish_mark_dirty(entry):
-    if entry.dirty == nodetypes.NotDirty:
+    if entry.dirty == nodetypes.NOT_DIRTY:
       # Mark this node as dirty in the DB so we don't have to check the
       # filesystem next time.
       database.mark_dirty(entry)

--- a/ambuild2/damage.py
+++ b/ambuild2/damage.py
@@ -47,12 +47,8 @@ def ComputeDirty(node):
     dirty = ComputeSourceDirty(node)
   elif node.type == nodetypes.Output:
     dirty = ComputeOutputDirty(node)
-  elif node.type == nodetypes.CopyFolder:
-    dirty = ComputeCopyFolderDirty(node)
   else:
     raise Exception('cannot compute dirty bit for node type: ' + node.type)
-  if dirty == nodetypes.DIRTY:
-    node.newlyDirty = True
   return dirty
 
 def ComputeDamageGraph(database, only_changed = False):
@@ -69,6 +65,7 @@ def ComputeDamageGraph(database, only_changed = False):
 
   def maybe_dirty(node):
     if ComputeDirty(node):
+      node.newlyDirty = True
       dirty.append(node)
 
   database.query_known_dirty(known_dirty)

--- a/ambuild2/frontend/v2_0/amb2/gen.py
+++ b/ambuild2/frontend/v2_0/amb2/gen.py
@@ -497,9 +497,11 @@ class Generator(BaseGenerator):
                    util.ConsoleNormal)
       raise Exception('An output has been duplicated as a shared output.')
 
+    dirty = nodetypes.DIRTY
+
     if cmd_entry:
       # Update the entry in the database.
-      self.db.update_command(cmd_entry, node_type, folder, data, self.refactoring)
+      self.db.update_command(cmd_entry, node_type, folder, data, dirty, self.refactoring)
 
       # Disconnect any outputs that are no longer connected to this output.
       # It's okay to use output_links since there should never be duplicate
@@ -524,7 +526,7 @@ class Generator(BaseGenerator):
     else:
       # Note that if there are no outputs, we will always add a new command,
       # and the old (identical) command will be deleted.
-      cmd_entry = self.db.add_command(node_type, folder, data)
+      cmd_entry = self.db.add_command(node_type, folder, data, dirty)
 
     # Local helper function to warn about refactoring problems.
     def refactoring_error(node):

--- a/ambuild2/frontend/v2_0/amb2/gen.py
+++ b/ambuild2/frontend/v2_0/amb2/gen.py
@@ -608,14 +608,21 @@ class Generator(BaseGenerator):
     self.parseCxxDeps(cx, binary, inputs, binary.compiler.linkflags)
     self.parseCxxDeps(cx, binary, inputs, binary.compiler.postlink)
 
+    pch_nodes = []
+    for obj in binary.objects:
+      if obj.type == 'pch':
+        pch_nodes.append(self.addCxxObjTask(cx, binary.shared_cc_outputs, obj.folderNode, obj))
+
     for objfile in binary.objects:
       cxxData = {
         'argv': objfile.argv,
         'type': binary.linker.behavior
       }
+      sourcedeps = binary.compiler.sourcedeps
+      sourcedeps += pch_nodes
       cxxCmd, (cxxNode,) = self.addCommand(
         context = cx,
-        weak_inputs = binary.compiler.sourcedeps,
+        weak_inputs = sourcedeps,
         inputs = [objfile.sourceFile],
         outputs = [objfile.outputFile],
         node_type = nodetypes.Cxx,

--- a/ambuild2/frontend/v2_0/cpp/vendors.py
+++ b/ambuild2/frontend/v2_0/cpp/vendors.py
@@ -39,6 +39,17 @@ class Vendor(object):
   def nameForStaticLibrary(self, name):
     return util.StaticLibPrefix + name + util.StaticLibSuffix
 
+  @property
+  def pchSuffix(self):
+    raise Exception("Must be implemented")
+
+  def pchCArgs(self, headerFile, pchFile):
+    raise Exception("Must be implemented")
+
+  def pchCxxArgs(self, headerFile, pchFile):
+    raise Exception("Must be implemented")
+
+
 class MSVC(Vendor):
   def __init__(self, command, version):
     super(MSVC, self).__init__('msvc', version, 'msvc', command, '.obj')
@@ -90,7 +101,7 @@ class CompatGCC(Vendor):
     return ['-I', os.path.normpath(includePath)]
 
   def objectArgs(self, sourceFile, objFile):
-    return ['-H', '-c', sourceFile, '-o', objFile]
+    return ['-MP', '-fpch-deps', '-c', sourceFile, '-o', objFile]
 
   def parse_debuginfo(self, debuginfo):
     return debuginfo
@@ -102,6 +113,17 @@ class GCC(CompatGCC):
 
   def like(self, name):
     return name == 'gcc'
+
+  @property
+  def pchSuffix(self):
+    return '.gch'
+
+  def pchCArgs(self, headerFile, pchFile):
+    return ['-MP', '-fpch-deps', '-x', 'c-header', headerFile, '-o', pchFile]
+
+  def pchCxxArgs(self, headerFile, pchFile):
+    return ['-MP', '-fpch-deps', '-x', 'c++-header', headerFile, '-o', pchFile]
+
 
 class Clang(CompatGCC):
   def __init__(self, vendor_name, command, version):

--- a/ambuild2/frontend/v2_0/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_0/vs/export_vcxproj.py
@@ -30,8 +30,10 @@ def export_fp(node, fp):
   version = node.project.compiler.version 
   if version >= 1600 and version < 1800:
     toolsVersion = '4.0'
-  elif version >= 1800:
+  elif version >= 1800 and version < 2000:
     toolsVersion = '12.0'
+  elif version >= 2000:
+    toolsVersion = '14.0'
 
   scope = xml.block('Project',
     DefaultTargets = 'Build',
@@ -97,8 +99,10 @@ def export_configuration_properties(node, xml):
       version = builder.compiler.version
       if version >= 1700 and version < 1800:
         xml.tag('PlatformToolset', 'v110')
-      elif version >= 1800:
+      elif version >= 1800 and version < 2000:
         xml.tag('PlatformToolset', 'v120')
+      elif version >= 2000:
+        xml.tag('PlatformToolset', 'v140')
 
 def export_configuration_user_props(node, xml):
   for builder in node.project.builders_:

--- a/ambuild2/frontend/v2_0/vs/gen.py
+++ b/ambuild2/frontend/v2_0/vs/gen.py
@@ -23,11 +23,12 @@ from ambuild2.frontend.v2_0.vs import cxx
 from ambuild2.frontend.v2_0.vs import nodes
 from ambuild2.frontend.v2_0.base import BaseGenerator
 
-SupportedVersions = ['10', '11', '12']
+SupportedVersions = ['10', '11', '12', '14']
 YearMap = {
   '2010': 10,
   '2012': 11,
   '2013': 12,
+  '2015': 14,
 }
 
 class Generator(BaseGenerator):

--- a/ambuild2/frontend/v2_1/amb2/gen.py
+++ b/ambuild2/frontend/v2_1/amb2/gen.py
@@ -626,9 +626,15 @@ class Generator(BaseGenerator):
     self.parseCxxDeps(cx, binary, inputs, binary.compiler.linkflags)
     self.parseCxxDeps(cx, binary, inputs, binary.compiler.postlink)
 
+    pch_nodes = []
+    for obj in binary.objects:
+      if obj.type == 'pch':
+        pch_nodes.append(self.addCxxObjTask(cx, binary.shared_cc_outputs, obj.folderNode, obj))
+
     # Add object files.
     for obj in binary.objects:
       if obj.type == 'object':
+        obj.sourcedeps += pch_nodes
         inputs.append(self.addCxxObjTask(cx, binary.shared_cc_outputs, obj.folderNode, obj))
       elif obj.type == 'resource':
         inputs.append(self.addCxxRcTask(cx, obj.folderNode, obj))

--- a/ambuild2/frontend/v2_1/base/context.py
+++ b/ambuild2/frontend/v2_1/base/context.py
@@ -93,6 +93,9 @@ class EmptyContext(BaseContext):
 
 # Access to input- and output-oriented API.
 class BuildContext(BaseContext):
+  # This nonce is an input flag to AddCommand.
+  ALWAYS_DIRTY = object()
+
   def __init__(self, generator, parent, vars, script, sourceFolder, buildFolder):
     super(BuildContext, self).__init__(generator, parent, vars, script)
     self.localFolder_ = None

--- a/ambuild2/frontend/v2_1/cpp/gcc.py
+++ b/ambuild2/frontend/v2_1/cpp/gcc.py
@@ -35,6 +35,10 @@ class GCCLookalike(Vendor):
     return '.o'
 
   @property
+  def pchSuffix(self):
+    return '.gch'
+
+  @property
   def debugInfoArgv(self):
     return []
 
@@ -47,8 +51,14 @@ class GCCLookalike(Vendor):
   def preprocessArgs(self, sourceFile, outFile):
     return ['-I', os.path.normpath(includePath)]
 
+  def pchCArgs(self, headerFile, pchFile):
+    return ['-MP', '-fpch-deps', '-x', 'c-header', headerFile, '-o', pchFile]
+
+  def pchCxxArgs(self, headerFile, pchFile):
+    return ['-MP', '-fpch-deps', '-x', 'c++-header', headerFile, '-o', pchFile]
+
   def objectArgs(self, sourceFile, objFile):
-    return ['-H', '-c', sourceFile, '-o', objFile]
+    return ['-MP', '-fpch-deps', '-c', sourceFile, '-o', objFile]
 
   def staticLinkArgv(self, files, outputFile):
     return ['ar', 'rcs', outputFile] + files

--- a/ambuild2/frontend/v2_1/cpp/vendor.py
+++ b/ambuild2/frontend/v2_1/cpp/vendor.py
@@ -67,6 +67,10 @@ class Vendor(object):
     raise Exception("Must be implemented")
 
   @property
+  def pchSuffix(self):
+    raise Exception("Must be implemented")
+
+  @property
   def debugInfoArgv(self):
     raise Exception("Must be implemented")
 
@@ -74,6 +78,12 @@ class Vendor(object):
     raise Exception("Must be implemented")
 
   def formatInclude(self, outputPath, includePath):
+    raise Exception("Must be implemented")
+
+  def pchCArgs(self, headerFile, pchFile):
+    raise Exception("Must be implemented")
+
+  def pchCxxArgs(self, headerFile, pchFile):
     raise Exception("Must be implemented")
 
   def objectArgs(self, sourceFile, objFile):

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -86,9 +86,8 @@ def IsCommand(type):
 def HasAutoDependencies(type):
   return type == CopyFolder or type == Cxx
 
-NotDirty = 0
-KnownDirty = (1 << 0)   # Node was known to be dirty.
-NewDirty = (1 << 1)     # Node was just computed to be dirty.
+NOT_DIRTY = 0
+DIRTY = 1
 
 # The basic properties of a node as it exists in the database.
 class Entry(object):
@@ -118,9 +117,7 @@ class Entry(object):
     # Last modification time.
     self.stamp = stamp
 
-    # 0 if the node was not dirty in the database.
-    # 1 if the node was dirty in the database.
-    # 2 if the node has become dirty in the meantime.
+    # See the DIRTY values above.
     self.dirty = dirty
 
     #########################################
@@ -135,6 +132,10 @@ class Entry(object):
     self.weak_inputs = None
 
     self.outgoing = None
+
+    # True if the node was not dirty when originally pulled from the DB, but is
+    # now actually dirty.
+    self.newlyDirty = False
     
   def isCommand(self):
     return IsCommand(self.type)

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -88,6 +88,7 @@ def HasAutoDependencies(type):
 
 NOT_DIRTY = 0
 DIRTY = 1
+ALWAYS_DIRTY = 2
 
 # The basic properties of a node as it exists in the database.
 class Entry(object):

--- a/ambuild2/task.py
+++ b/ambuild2/task.py
@@ -202,11 +202,13 @@ class WorkerChild(ChildProcessListener):
 
         if cc_type == 'gcc':
           d_path = tempfile.mktemp()
+#          print('{}'.format(d_path))
           os.mkfifo(d_path)
           env = os.environ.copy()
           env['SUNPRO_DEPENDENCIES'] = d_path
           d_file = open(d_path, 'r+')
           fcntl.fcntl(d_file, fcntl.F_SETFL, os.O_NONBLOCK)
+          fcntl.fcntl(d_file, 1031, 1048576) # F_SETPIPE_SZ
 
         p, out, err = util.Execute(argv, env=env)
         if cc_type == 'gcc':
@@ -216,6 +218,18 @@ class WorkerChild(ChildProcessListener):
           except IOError as e:
             if e.errno != errno.EWOULDBLOCK:
               raise
+#          d_str = ''
+#          while True:
+#            try:
+#              chunk = d_file.read(64)
+#              if chunk == '':
+#                print('done')
+#                break
+#              print('loop: {} "{}"'.format(len(chunk), chunk))
+#              d_str += chunk
+#            except IOError as e:
+#              if e.errno != errno.EWOULDBLOCK:
+#                raise
           deps = util.ParseGCCDeps(d_str)
           d_file.close()
           os.unlink(d_path)

--- a/scripts/ambuild
+++ b/scripts/ambuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set sts=2 ts=8 sw=2 tw=99 et:
 import os, sys
 from ambuild2 import run

--- a/tests/always_dirty/AMBuildScript
+++ b/tests/always_dirty/AMBuildScript
@@ -1,0 +1,8 @@
+# vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
+import os
+
+_, outputs = builder.AddCommand(
+  inputs = builder.ALWAYS_DIRTY,
+  outputs = ['sample.h'],
+  argv = ['python', os.path.join(builder.sourcePath, 'generate.py')]
+)

--- a/tests/always_dirty/configure.py
+++ b/tests/always_dirty/configure.py
@@ -1,0 +1,15 @@
+# vim: set sts=2 ts=8 sw=2 tw=99 et:
+API_VERSION = '2.1'
+
+import sys
+try:
+  from ambuild2 import run
+  if not run.HasAPI(API_VERSION):
+    raise Exception()
+except:
+  sys.stderr.write('AMBuild {0} must be installed to build this project.\n'.format(API_VERSION))
+  sys.stderr.write('http://www.alliedmods.net/ambuild\n')
+  sys.exit(1)
+
+builder = run.BuildParser(sourcePath = sys.path[0], api=API_VERSION)
+builder.Configure()

--- a/tests/always_dirty/generate.py
+++ b/tests/always_dirty/generate.py
@@ -1,0 +1,9 @@
+# vim: set ts=2 sw=2 tw=99 et:
+import datetime
+
+def main():
+  with open('sample.h', 'w') as fp:
+    fp.write("const char* DATE = {0};\n".format(datetime.datetime.now()))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I spent a few hours today messing around with the code, trying to get some kind of rudimentary GCC PCH support to work. I eventually managed to come up with something that works.

It's somewhat rough. I didn't entirely understand what I was doing, and I don't do that much Python, so some parts are probably tacked on in a way that doesn't actually make sense with how the class hierarchy is meant to operate. But it's enough to essentially work.

I implemented it so that '.h' and '.hpp' files in Compiler.sources are treated as headers that you want to be precompiled. (I'm fairly certain this is actually not the way it should be, but it made certain things a bit easier.)

The headers are actually precompiled twice: once with the C compiler, and once with the C++ compiler; this is necessary since the GCH files aren't compatible between the two. Assuming a header filename of 'header.h', GCC will only look for 'header.h.gch', and we can't have two files named that in the same directory, so the solution is to make a couple of subdirectories in the module's build directory: 'pch_c' and 'pch_cxx'.

One problem I ran into is that the `gcc -H` method of dependency generation doesn't actually work well enough to use for PCH's; I think GCC wouldn't actually print out the header trace until the GCH file is actually included, instead of printing it out when the GCH file is being precompiled. But GCC's Makefile dependency generation flags (`-MD` and friends) do work the way we want them to. So I rewrote ParseGCCDeps to parse those instead of scraping `gcc -H`; frankly it's less of a hack to do it this way anyhow.

I was planning on telling GCC to output the dependencies to stdout with `-MF /dev/stdout`, since it normally prints all its other messages to stderr, but that didn't end up working out; it seems that they close the file descriptor for stdout (but only sometimes). I didn't want to dump the deps to stderr, since that would put us back in screen-scraping territory; so the best option seemed to be to create a temporary file as a named pipe and tell GCC to write the dependencies to that "file". It works great, but I can't imagine I covered all the possible error cases.

One feature I wanted to have, but didn't end up implementing, was to properly replicate the directory tree for the headers: e.g. with `a/b/header.h` in the source dir, instead of generating `pch_cxx/header.h.gch`, we'd generate `pch_cxx/a/b/header.h.gch`, meaning that source files could do `#include "a/b/header.h"` and have it work as expected, instead of having to do `#include "header.h"`. Setting up the output directory tree was relatively easy; but the problem I ran into was that for source files partway into the directory tree, like `a/source.cpp`, the include path that we prepend to the compiler flags needs to be adjusted so that it's `-I pch_cxx/a` instead of `-I pch_cxx`, because the source file might do something like `#include "b/header.h"`, assuming its relative location in the hierarchy. Couldn't think of a non-ugly way to make that work, so I shelved it for the time being.

I put a bunch of GitHub commit comments throughout.

One more thing: I haven't tested this at all to see if it breaks MSVC or Clang. So this is more of a "take a look at this and test it out" pull request than a "merge this into master" pull request, if you know what I mean.
