### PR TITLE
Fix a quirk with encodings on Windows

### DIFF
--- a/ambuild/osutil.py
+++ b/ambuild/osutil.py
@@ -40,8 +40,8 @@ def StaticLibPrefix():
 
 def WaitForProcess(process):
 	out, err = process.communicate()
-	process.stdoutText = out.decode()
-	process.stderrText = err.decode()
+	process.stdoutText = out.decode(sys.stdout.encoding)
+	process.stderrText = err.decode(sys.stderr.encoding)
 	return process.returncode
 
 def CreateProcess(argv, executable = None):


### PR DESCRIPTION
On (non-english?) Windows systems attempting to decode certain output 'utf-8' as the default will fail. This change fixes those issues.