### PR TITLE
Add an ALWAYS_RUN bit to support prebuild steps.

### DIFF
--- a/ambuild2/damage.py
+++ b/ambuild2/damage.py
@@ -51,8 +51,8 @@ def ComputeDirty(node):
     dirty = ComputeCopyFolderDirty(node)
   else:
     raise Exception('cannot compute dirty bit for node type: ' + node.type)
-  if dirty:
-    node.dirty |= nodetypes.NewDirty
+  if dirty == nodetypes.DIRTY:
+    node.newlyDirty = True
   return dirty
 
 def ComputeDamageGraph(database, only_changed = False):
@@ -78,7 +78,7 @@ def ComputeDamageGraph(database, only_changed = False):
     return dirty
 
   def add_dirty(entry):
-    if entry.dirty == nodetypes.NewDirty:
+    if entry.newlyDirty:
       # Mark this node as dirty in the DB so we don't have to check the
       # filesystem next time.
       database.mark_dirty(entry)
@@ -86,7 +86,7 @@ def ComputeDamageGraph(database, only_changed = False):
     graph.addEntry(entry)
 
   for entry in dirty:
-    if (entry.type == nodetypes.Output) and (entry.dirty == nodetypes.NewDirty):
+    if (entry.type == nodetypes.Output) and entry.newlyDirty:
       # Ensure that our command has been marked as dirty.
       incoming = database.query_strong_inputs(entry)
       incoming |= database.query_dynamic_inputs(entry)
@@ -107,7 +107,7 @@ def ComputeDamageGraph(database, only_changed = False):
   # Find all leaf commands in the graph and mark them as dirty. This ensures
   # that we'll include them in the next damage graph.
   def finish_mark_dirty(entry):
-    if entry.dirty == nodetypes.NotDirty:
+    if entry.dirty == nodetypes.NOT_DIRTY:
       # Mark this node as dirty in the DB so we don't have to check the
       # filesystem next time.
       database.mark_dirty(entry)

--- a/ambuild2/damage.py
+++ b/ambuild2/damage.py
@@ -47,12 +47,8 @@ def ComputeDirty(node):
     dirty = ComputeSourceDirty(node)
   elif node.type == nodetypes.Output:
     dirty = ComputeOutputDirty(node)
-  elif node.type == nodetypes.CopyFolder:
-    dirty = ComputeCopyFolderDirty(node)
   else:
     raise Exception('cannot compute dirty bit for node type: ' + node.type)
-  if dirty == nodetypes.DIRTY:
-    node.newlyDirty = True
   return dirty
 
 def ComputeDamageGraph(database, only_changed = False):
@@ -69,6 +65,7 @@ def ComputeDamageGraph(database, only_changed = False):
 
   def maybe_dirty(node):
     if ComputeDirty(node):
+      node.newlyDirty = True
       dirty.append(node)
 
   database.query_known_dirty(known_dirty)

--- a/ambuild2/frontend/v2_0/amb2/gen.py
+++ b/ambuild2/frontend/v2_0/amb2/gen.py
@@ -497,9 +497,11 @@ class Generator(BaseGenerator):
                    util.ConsoleNormal)
       raise Exception('An output has been duplicated as a shared output.')
 
+    dirty = nodetypes.DIRTY
+
     if cmd_entry:
       # Update the entry in the database.
-      self.db.update_command(cmd_entry, node_type, folder, data, self.refactoring)
+      self.db.update_command(cmd_entry, node_type, folder, data, dirty, self.refactoring)
 
       # Disconnect any outputs that are no longer connected to this output.
       # It's okay to use output_links since there should never be duplicate
@@ -524,7 +526,7 @@ class Generator(BaseGenerator):
     else:
       # Note that if there are no outputs, we will always add a new command,
       # and the old (identical) command will be deleted.
-      cmd_entry = self.db.add_command(node_type, folder, data)
+      cmd_entry = self.db.add_command(node_type, folder, data, dirty)
 
     # Local helper function to warn about refactoring problems.
     def refactoring_error(node):

--- a/ambuild2/frontend/v2_1/base/context.py
+++ b/ambuild2/frontend/v2_1/base/context.py
@@ -93,6 +93,9 @@ class EmptyContext(BaseContext):
 
 # Access to input- and output-oriented API.
 class BuildContext(BaseContext):
+  # This nonce is an input flag to AddCommand.
+  ALWAYS_DIRTY = object()
+
   def __init__(self, generator, parent, vars, script, sourceFolder, buildFolder):
     super(BuildContext, self).__init__(generator, parent, vars, script)
     self.localFolder_ = None

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -86,9 +86,8 @@ def IsCommand(type):
 def HasAutoDependencies(type):
   return type == CopyFolder or type == Cxx
 
-NotDirty = 0
-KnownDirty = (1 << 0)   # Node was known to be dirty.
-NewDirty = (1 << 1)     # Node was just computed to be dirty.
+NOT_DIRTY = 0
+DIRTY = 1
 
 # The basic properties of a node as it exists in the database.
 class Entry(object):
@@ -118,9 +117,7 @@ class Entry(object):
     # Last modification time.
     self.stamp = stamp
 
-    # 0 if the node was not dirty in the database.
-    # 1 if the node was dirty in the database.
-    # 2 if the node has become dirty in the meantime.
+    # See the DIRTY values above.
     self.dirty = dirty
 
     #########################################
@@ -135,6 +132,10 @@ class Entry(object):
     self.weak_inputs = None
 
     self.outgoing = None
+
+    # True if the node was not dirty when originally pulled from the DB, but is
+    # now actually dirty.
+    self.newlyDirty = False
     
   def isCommand(self):
     return IsCommand(self.type)

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -88,6 +88,7 @@ def HasAutoDependencies(type):
 
 NOT_DIRTY = 0
 DIRTY = 1
+ALWAYS_DIRTY = 2
 
 # The basic properties of a node as it exists in the database.
 class Entry(object):

--- a/tests/always_dirty/AMBuildScript
+++ b/tests/always_dirty/AMBuildScript
@@ -1,0 +1,8 @@
+# vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
+import os
+
+_, outputs = builder.AddCommand(
+  inputs = builder.ALWAYS_DIRTY,
+  outputs = ['sample.h'],
+  argv = ['python', os.path.join(builder.sourcePath, 'generate.py')]
+)

--- a/tests/always_dirty/configure.py
+++ b/tests/always_dirty/configure.py
@@ -1,0 +1,15 @@
+# vim: set sts=2 ts=8 sw=2 tw=99 et:
+API_VERSION = '2.1'
+
+import sys
+try:
+  from ambuild2 import run
+  if not run.HasAPI(API_VERSION):
+    raise Exception()
+except:
+  sys.stderr.write('AMBuild {0} must be installed to build this project.\n'.format(API_VERSION))
+  sys.stderr.write('http://www.alliedmods.net/ambuild\n')
+  sys.exit(1)
+
+builder = run.BuildParser(sourcePath = sys.path[0], api=API_VERSION)
+builder.Configure()

--- a/tests/always_dirty/generate.py
+++ b/tests/always_dirty/generate.py
@@ -1,0 +1,9 @@
+# vim: set ts=2 sw=2 tw=99 et:
+import datetime
+
+def main():
+  with open('sample.h', 'w') as fp:
+    fp.write("const char* DATE = {0};\n".format(datetime.datetime.now()))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Right now AMBuild does not support prebuild steps - something that runs before every build, no matter what. Arbitrary steps are sort of contrary to our design, since we don't want to mess with the output folder outside of AMBuild's graph structure.

However we can introduce the concept of a command that is "always dirty". Like normal commands, these would still have outputs and still be well-ordered with respect to their dependent commands. However they would be guaranteed to run on every build, and their dirty bit would never be removed. 

This patch introduces an `ALWAYS_DIRTY` nonce on `Context` objects, which can be passed to the `input` parameter of `AddCommand`. Always-dirty commands will not necessarily run as the first step on every build, but they will *always* run. Like normal commands they'll also run in parallel with non-dependent tasks.

The flag is experimental and may be deprecated for something better - at the moment, I'm hesitant to wrap this in a new API call, names like "AddPrebuildStep" would imply an ordering. But the flag works for now and would not be removed from the 2.1 API.