### PR TITLE
Fix AMBuild 2.1 and minor changes

### DIFF
--- a/ambuild2/frontend/paths.py
+++ b/ambuild2/frontend/paths.py
@@ -52,4 +52,11 @@ def Join(*nodes):
 def IsSubPath(other, folder):
   folder = os.path.normpath(folder) + os.sep
   other = os.path.normpath(other) + os.sep
-  return other.startswith(folder)
+  # if other starts with '..', we immediately assume it's not longer a subpath.
+  # Cases of <x number of '..'>/<path back to where we just were>/<subpath> is just dumb, so we just False it.
+  if other.startswith('..'):
+    return False
+  elif other.startswith(folder):
+    return True
+  elif folder == '.' + os.sep and not os.path.isabs(other):
+    return True

--- a/ambuild2/frontend/v2_1/base/gen.py
+++ b/ambuild2/frontend/v2_1/base/gen.py
@@ -70,8 +70,8 @@ class BaseGenerator(object):
     return self.importScriptImpl(context, path, vars)
 
   def evalScript(self, context, path, vars={}):
-    obj = self.importScriptImpl(self, context, path, vars)
-    return obj.get('rvalue', None)
+    obj = self.importScriptImpl(context, path, vars)
+    return getattr(obj, 'rvalue', None)
 
   def runBuildScript(self, context, path, vars={}):
     if not isinstance(path, util.StringType()):

--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -95,7 +95,7 @@ def TryVerifyCompiler(env, mode, cmd, assumed_family):
       util.ConsoleHeader,
       'Compiler {0} for {1} failed: '.format(cmd, mode),
       util.ConsoleRed,
-      e.message,
+      str(e),
       util.ConsoleNormal
     )
     return None

--- a/ambuild2/frontend/v2_1/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_1/vs/export_vcxproj.py
@@ -28,9 +28,9 @@ def export_fp(node, fp):
   xml = XmlBuilder(fp)
 
   version = node.project.compiler.version 
-  if version >= 1600 and version < 1800:
+  if version >= 'msvc-1600' and version < 'msvc-1800':
     toolsVersion = '4.0'
-  elif version >= 1800:
+  elif version >= 'msvc-1800':
     toolsVersion = '12.0'
 
   scope = xml.block('Project',
@@ -95,9 +95,9 @@ def export_configuration_properties(node, xml):
         xml.tag('WholeProgramOptimization', 'true')
       
       version = builder.compiler.version
-      if version >= 1700 and version < 1800:
+      if version >= 'msvc-1700' and version < 'msvc-1800':
         xml.tag('PlatformToolset', 'v110')
-      elif version >= 1800:
+      elif version >= 'msvc-1800':
         xml.tag('PlatformToolset', 'v120')
 
 def export_configuration_user_props(node, xml):
@@ -113,8 +113,8 @@ def export_configuration_user_props(node, xml):
 def export_configuration_paths(node, xml):
   for builder in node.project.builders_:
     condition = condition_for(builder)
-    xml.tag('OutDir', "$(Configuration)\\", Condition = condition)
-    xml.tag('IntDir', "$(Configuration)\\", Condition = condition)
+    xml.tag('OutDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
+    xml.tag('IntDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
     if '/INCREMENTAL:NO' not in builder.compiler.linkflags and '/INCREMENTAL:NO' not in builder.compiler.postlink:
       xml.tag('LinkIncremental', 'true', Condition = condition)
     xml.tag('TargetName', builder.name_, Condition = condition)
@@ -209,6 +209,9 @@ def export_configuration_options(node, xml, builder):
     elif '/W4' in flags:
       xml.tag('WarningLevel', 'Level4')
 
+    if '/WX' in flags:
+      xml.tag('TreatWarningAsError', 'true')
+
     if '/Od' in flags:
       xml.tag('DebugInformationFormat', 'EditAndContinue')
     else:
@@ -261,7 +264,7 @@ def export_configuration_options(node, xml, builder):
     xml.tag('AdditionalDependencies', ';'.join(libs))
     xml.tag('OutputFile', '$(OutDir)$(TargetFileName)')
     xml.tag('IgnoreSpecificDefaultLibraries', ';'.join(ignore_libs))
-    if compiler.debuginfo is None:
+    if compiler.symbol_files is None:
       xml.tag('GenerateDebugInformation', 'false')
     else:
       xml.tag('GenerateDebugInformation', 'true')

--- a/ambuild2/frontend/v2_1/vs/gen.py
+++ b/ambuild2/frontend/v2_1/vs/gen.py
@@ -22,6 +22,7 @@ from ambuild2.frontend import paths
 from ambuild2.frontend.v2_1.vs import cxx
 from ambuild2.frontend.v2_1.vs import nodes
 from ambuild2.frontend.v2_1.base import BaseGenerator
+from ambuild2.frontend.v2_1.cpp.msvc import MSVC
 
 SupportedVersions = ['10', '11', '12']
 YearMap = {
@@ -95,7 +96,7 @@ class Generator(BaseGenerator):
   # Overridden.
   def detectCompilers(self):
     if not self.compiler:
-      self.base_compiler = cxx.Compiler(cxx.Compiler.GetVersionFromVS(self.vs_version))
+      self.base_compiler = cxx.Compiler(MSVC(cxx.Compiler.GetVersionFromVS(self.vs_version)))
       self.compiler = self.base_compiler.clone()
     return self.compiler
 
@@ -118,7 +119,7 @@ class Generator(BaseGenerator):
 
   # Overridden.
   def getLocalFolder(self, context):
-    if type(context.localFolder_) is nodes.FolderNode or context.localFolder_ is None:
+    if type(context.localFolder_) is nodes.FolderNode:
       return context.localFolder_
 
     if not len(context.buildFolder):


### PR DESCRIPTION
The major part of this PR is to fix the 2.1 API as I went along building a build script off of it ( https://github.com/WildCard65/Compressor/commit/e00740659ad172278ea5e98dec866efadce592b1 ), majority of fixes was for VS project generation (Bug 6511) and some blockers found in base and amb2 generators also.

This PR also includes some minor changes (added on my local copy of AMBuild) to VS project exporter (Adds /WX support and sync output folder for project with gen'd folder)