### PR TITLE
Add the ability to specify custom CXX tools.

### DIFF
--- a/ambuild2/frontend/v2_1/amb2/gen.py
+++ b/ambuild2/frontend/v2_1/amb2/gen.py
@@ -611,7 +611,7 @@ class Generator(BaseGenerator):
     _, (cxxNode,) = self.addCommand(
       context = cx,
       weak_inputs = obj.sourcedeps,
-      inputs = [obj.sourceFile],
+      inputs = [obj.inputObj],
       outputs = [obj.outputFile],
       node_type = nodetypes.Cxx,
       folder = folder,
@@ -627,7 +627,7 @@ class Generator(BaseGenerator):
     _, (_, rcNode) = self.addCommand(
       context = cx,
       weak_inputs = obj.sourcedeps,
-      inputs = [obj.sourceFile],
+      inputs = [obj.inputObj],
       outputs = [obj.preprocFile, obj.outputFile],
       node_type = nodetypes.Rc,
       folder = folder,
@@ -759,6 +759,9 @@ class Generator(BaseGenerator):
         'type': dep_type,
         'argv': argv,
       }
+
+    if argv is None:
+      raise Exception('argv cannot be None')
 
     return self.addCommand(
       context = context,


### PR DESCRIPTION
This PR adds a few new features.

One is "Custom C++ Tools", which have just been added to the documentation [1]. The intent of this feature is to add HLSL support to AMBuild.

The other feature is that source files can now be outputs in addition to inputs. That means C++ files can now be exported from a previous build step and then directly used in a BinaryBuilder, without requiring wrapper files that `#include` it.

[1] https://wiki.alliedmods.net/AMBuild_API#Custom_C.2B.2B_Tools