### PR TITLE
Fix apple-clang vendor prefix in 2.1 API.

### DIFF
--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -200,7 +200,7 @@ int main()
   if vendor == 'gcc':
     v = GCC(version)
   elif vendor == 'apple-clang':
-    v = Clang(version, 'apple-clang')
+    v = Clang(version, 'apple')
   elif vendor == 'clang':
     v = Clang(version)
   elif vendor == 'msvc':


### PR DESCRIPTION
When using the 2.1 API, the cxx.version for Apple's clang ends up becoming apple-clang-clang-\<major\>.\<minor\>. So clang is repeated in the name twice. This was not the case with the 2.0 API.