### PR TITLE
Propagate changes to localFolder after Project.Configure has been called

### DIFF
--- a/ambuild2/frontend/v2_1/cpp/builders.py
+++ b/ambuild2/frontend/v2_1/cpp/builders.py
@@ -77,6 +77,7 @@ class Project(object):
   def finish(self, cx):
     for task in self.proxies_:
       builder = task.constructor_(task.compiler, task.name_)
+      builder.localFolder = task.localFolder
       builder.sources = task.sources
       builder.custom = task.custom
       builder.finish(cx)


### PR DESCRIPTION
Changes to localFolder aren't seen after _Project.Configure_ is called because the BuilderProxy constructor is called again in _finish_.