### PR TITLE
Fix --symbol-files option in 2.1 API.

### DIFF
--- a/ambuild2/frontend/v2_1/amb2/gen.py
+++ b/ambuild2/frontend/v2_1/amb2/gen.py
@@ -193,7 +193,7 @@ class Generator(BaseGenerator):
   def detectCompilers(self):
     if not self.compiler:
       with util.FolderChanger(self.cacheFolder):
-        self.base_compiler = detect.DetectCxx(self.target, os.environ)
+        self.base_compiler = detect.DetectCxx(self.target, os.environ, self.options)
         self.compiler = self.base_compiler.clone()
 
     return self.compiler

--- a/ambuild2/frontend/v2_1/cpp/compiler.py
+++ b/ambuild2/frontend/v2_1/cpp/compiler.py
@@ -52,11 +52,14 @@ class Compiler(object):
     'weaklinkdeps',
   ]
 
-  def __init__(self, vendor):
+  def __init__(self, vendor, options = None):
     self.vendor = vendor
     for attr in self.attrs_:
       setattr(self, attr, [])
-    self.symbol_files = 'bundled'
+    if getattr(options, 'symbol_files', False):
+      self.symbol_files = 'separate'
+    else:
+      self.symbol_files = 'bundled'
 
   def inherit(self, other):
     for attr in self.attrs_:
@@ -135,8 +138,8 @@ class Compiler(object):
     return builders.Dep(text, node)
 
 class CliCompiler(Compiler):
-  def __init__(self, vendor, cc_argv, cxx_argv):
-    super(CliCompiler, self).__init__(vendor)
+  def __init__(self, vendor, cc_argv, cxx_argv, options = None):
+    super(CliCompiler, self).__init__(vendor, options)
     self.cc_argv = cc_argv
     self.cxx_argv = cxx_argv
     self.found_pkg_config_ = False

--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -50,7 +50,7 @@ CompilerSearch = {
   }
 }
 
-def DetectCxx(target, env):
+def DetectCxx(target, env, options):
   cc = DetectCxxCompiler(env, 'CC')
   cxx = DetectCxxCompiler(env, 'CXX')
 
@@ -70,7 +70,7 @@ def DetectCxx(target, env):
   # :TODO: Check that the arch is == to target. We don't do this yet since
   # on Windows we can't use platform.architecture().
 
-  return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv)
+  return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, options)
 
 def DetectCxxCompiler(env, var):
   if var in env:


### PR DESCRIPTION
The --symbol-files option doesn't work when using the 2.1 API. There is no chance of setting symbol_files to "separate" because the compiler object has no access to the current context's options.