### PR TITLE
Emscripten support for 2.1 frontend

### DIFF
--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -21,7 +21,7 @@ import subprocess
 from ambuild2 import util
 from ambuild2.frontend.v2_1.cpp import vendor, compiler
 from ambuild2.frontend.v2_1.cpp.msvc import MSVC
-from ambuild2.frontend.v2_1.cpp.gcc import GCC, Clang
+from ambuild2.frontend.v2_1.cpp.gcc import GCC, Clang, Emscripten
 from ambuild2.frontend.v2_1.cpp.sunpro import SunPro
 
 class CommandAndVendor(object):
@@ -119,6 +119,8 @@ int main()
 {
 #if defined __ICC
   printf("icc %d\\n", __ICC);
+#elif defined(__EMSCRIPTEN__)
+  printf("emscripten %d.%d\\n", __clang_major__, __clang_minor__);
 #elif defined __clang__
 # if defined(__clang_major__) && defined(__clang_minor__)
 #  if defined(__apple_build_version__)
@@ -199,6 +201,8 @@ int main()
   vendor, version = lines[0].split(' ')
   if vendor == 'gcc':
     v = GCC(version)
+  elif vendor == 'emscripten':
+    v = Emscripten(version)
   elif vendor == 'apple-clang':
     v = Clang(version, 'apple')
   elif vendor == 'clang':

--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -165,7 +165,7 @@ int main()
     argv += ['-s', 'NO_EXIT_RUNTIME=0']
     executable += '.js'
   else:
-    util.ExecutableSuffix
+    executable += util.ExecutableSuffix
 
   # Make sure the exe is gone.
   if os.path.exists(executable):

--- a/ambuild2/frontend/v2_1/cpp/gcc.py
+++ b/ambuild2/frontend/v2_1/cpp/gcc.py
@@ -102,3 +102,35 @@ class Clang(GCCLookalike):
   @property
   def debugInfoArgv(self):
     return ['-g3']
+
+class Emscripten(Clang):
+  def __init__(self, version):
+    # Set this first, since the constructor will need it.
+    super(Emscripten, self).__init__(version, 'emscripten')
+
+  def nameForExecutable(self, name):
+    return name + '.js'
+
+  def nameForSharedLibrary(self, name):
+    return name + '.bc'
+
+  def nameForStaticLibrary(self, name):
+    return util.StaticLibPrefix + name + '.a'
+
+  @property
+  def name(self):
+    return 'emscripten'
+
+  @property
+  def family(self):
+    return 'emscripten'
+
+  def like(self, name):
+    return name == 'gcc' or name == 'clang' or name == 'emscripten-clang' or name == 'emscripten'
+
+  @property
+  def debugInfoArgv(self):
+    return ['-g3']
+
+  def staticLinkArgv(self, files, outputFile):
+    return ['emar', 'rcs', outputFile] + files


### PR DESCRIPTION
This is implemented to be compatible for user-code with the 2.0 frontend, if scrapping that it could be a vendor for Clang instead. The other quirk here is that the version reported is the Clang version rather than the Emscripten version, I can't think of much use for the Emscripten version and it makes version tests for flags a lot simpler to write (it would be nice for AMBuild to have something to help manage that in the future though).

The 2nd commit here makes ambuild able to be used without the `emconfigure` wrapper, which is just a bit simpler to use (and makes auto-reconfigure work correctly) - it'd be nice if it could be less strict about when it is used (passing a full path to `emcc` doesn't work currently for instance), but I think it would be more annoying than useful to default to Emscripten just because you've got the EMSDK set up. It is still a lot less hacky than the 2.0 code was.

Example with emconfigure:
```
$ emconfigure python ../configure.py --build=spcomp,vm,test --enable-optimize
  emconfigure is a helper for configure, setting various environment
  variables so that emcc etc. are used. Typical usage:
    emconfigure ./configure [FLAGS]
  (but you can run any command instead of configure)
  
Checking CC compiler (vendor test gcc)... ['python', '/root/code/emsdk-portable/emscripten/1.37.33/emcc.py', 'test.c', '-o', 'test']
found emscripten version 5.0
Checking CXX compiler (vendor test gcc)... ['python', '/root/code/emsdk-portable/emscripten/1.37.33/em++.py', 'test.cpp', '-o', 'testp']
found emscripten version 5.0
```

Example with native support: (same invocation as 2.0 frontend)
```
$ CC=emcc CXX=em++ python ../configure.py --build=spcomp,vm,test --enable-optimize
Checking CC compiler (vendor test emscripten)... ['emcc', '-s', 'NO_EXIT_RUNTIME=0', 'test.c', '-o', 'test.js']
found emscripten version 5.0
Checking CXX compiler (vendor test emscripten)... ['em++', '-s', 'NO_EXIT_RUNTIME=0', 'test.cpp', '-o', 'testp.js']
found emscripten version 5.0
```