### PR TITLE
[AMB1] Fix MSVC error output

### DIFF
--- a/ambuild/cpp.py
+++ b/ambuild/cpp.py
@@ -302,25 +302,27 @@ class CompileCommand(command.Command):
 			if p.returncode != 0:
 				raise Exception('terminated with non-zero return code {0}'.format(p.returncode))
 			deps = self.ParseDepsGCC()
+
 		elif isinstance(self.vendor, MSVC):
 			runner.PrintOut(' '.join([i for i in self.argv]))
-			p = subprocess.Popen(self.argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+			p = subprocess.Popen(self.argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 			out, err = p.communicate()
-			if p.returncode != 0:
-				self.stderr = osutil.DecodeConsoleText(sys.stderr, err)
-				raise Exception('terminated with non-zero return code {0}'.format(p.returncode))
 			out = osutil.DecodeConsoleText(sys.stdout, out)
+			self.stderr = osutil.DecodeConsoleText(sys.stderr, err)
+
 			deps = []
 			self.stdout = ''
-			self.stderr = ''
-			temp = ''
 			for line in out.split('\n'):
 				m = re.match('Note: including file:\s+(.+)$', line)
 				if m != None:
 					file = m.groups()[0].strip()
 					deps.append(file)
 				else:
-					temp += line
+					self.stdout += line
+
+			if p.returncode != 0:
+				raise Exception('terminated with non-zero return code {0}'.format(p.returncode))
+
 		job.CacheVariable(self.objFile, deps)
 	
 	def ParseDepsGCC(self):


### PR DESCRIPTION
Before:

    cl /MT /W3 /nologo /Zi /Ox /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /DNDEBUG /DWIN32 /D_WINDOWS /DSOURCEMOD_BUILD /DSM_GENERATED_BUILD /I ..\includes /EHsc /TP /I ..\..\breakpad\src\src /showIncludes /c C:\projects\accelerator\test\test.cpp /Fotest_test.obj
    Job failed: 'NoneType' object has no attribute 'decode'
    Traceback (most recent call last):
      File "C:\python27\lib\site-packages\ambuild\job.py", line 21, in run
        self.task.run(self.master, self.job)
      File "C:\python27\lib\site-packages\ambuild\cpp.py", line 310, in run
        self.stderr = osutil.DecodeConsoleText(sys.stderr, err)
      File "C:\python27\lib\site-packages\ambuild\osutil.py", line 52, in DecodeConsoleText
        return text.decode('utf8', 'replace')
    AttributeError: 'NoneType' object has no attribute 'decode'

The problem here is that stderr is being piped to stdout in the call to `subprocess.Popen`, which will always return `None` according to the Python documentation.

After changing Popen to pipe stderr, we don't get an exception here, but the command output is still missing:

    cl /MT /W3 /nologo /Zi /Ox /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /DNDEBUG /DWIN32 /D_WINDOWS /DSOURCEMOD_BUILD /DSM_GENERATED_BUILD /I ..\includes /EHsc /TP /I ..\..\breakpad\src\src /showIncludes /c C:\projects\accelerator\test\test.cpp /Fotest_test.obj
    Job failed: terminated with non-zero return code 2
    Traceback (most recent call last):
      File "C:\python27\lib\site-packages\ambuild\job.py", line 21, in run
        self.task.run(self.master, self.job)
      File "C:\python27\lib\site-packages\ambuild\cpp.py", line 312, in run
        raise Exception('terminated with non-zero return code {0}'.format(p.returncode))
    Exception: terminated with non-zero return code 2

It looks like `cl` always outputs to stdout, after reordering the code to always process stdout and store the output inside the job, everything works fine:

    cl /MT /W3 /nologo /Zi /Ox /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /DNDEBUG /DWIN32 /D_WINDOWS /DSOURCEMOD_BUILD /DSM_GENERATED_BUILD /I ..\includes /EHsc /TP /I ..\..\breakpad\src\src /showIncludes /c C:\projects\accelerator\test\test.cpp /Fotest_test.obj
    C:\projects\accelerator\breakpad\src\src\client/linux/handler/exception_handler.h(36): fatal error C1083: Cannot open include file: 'sys/ucontext.h': No such file or directory
    Job failed: terminated with non-zero return code 2
    Traceback (most recent call last):
      File "C:\python27\lib\site-packages\ambuild\job.py", line 21, in run
        self.task.run(self.master, self.job)
      File "C:\python27\lib\site-packages\ambuild\cpp.py", line 323, in run
        raise Exception('terminated with non-zero return code {0}'.format(p.returncode))
    Exception: terminated with non-zero return code 2

Initially encountered on Python 2.7 with MSVC 2015, fix tested on 2.7 and 3.4.