### PR TITLE
Fix colored text on Windows when using Python 3.x.

### DIFF
--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -334,6 +334,10 @@ if IsUnixy():
 elif IsWindows():
   def SwitchColor(fp, color):
     from ambuild2.ipc import winapi
+    
+    # Ensure previously colored text is flushed before changing colors again. Otherwise text may
+    # not be colored as expected
+    fp.flush()
 
     std = None
     if fp == sys.stdout:


### PR DESCRIPTION
If you run AMBuild on Windows using Python 3, text is not being colored. It works fine with Python 2, however.

This is because IO buffering is handled differently between Python 2 and Python 3. In Python 2, stdout is unbuffered by default (in a tty) because that's how the CRT handles it. Python 3 does its own buffering which appears to be line buffered by default.

This is discussed in this Python bug report: https://bugs.python.org/issue11633

So because it's line buffered, only the last call per line to `SetConsoleTextAttribute` has any effect which is often just the default text color (ConsoleNormal).