### PR TITLE
Fix MSVC shared PDB name on VS2015+

### DIFF
--- a/ambuild2/frontend/v2_0/cpp/builders.py
+++ b/ambuild2/frontend/v2_0/cpp/builders.py
@@ -188,8 +188,10 @@ class BinaryBuilder(object):
 
     shared_cc_outputs = []
     if self.compiler.debug_symbols and self.compiler.cc.behavior == 'msvc':
-      cl_version = int(self.compiler.cc.version) - 600
-      shared_pdb = 'vc{0}.pdb'.format(int(cl_version / 10))
+      cl_version = (int(int(self.compiler.cc.version) / 100) - 6) * 10
+      if cl_version >= 130:
+        cl_version += 10
+      shared_pdb = 'vc{0}.pdb'.format(cl_version)
       shared_cc_outputs += [shared_pdb]
 
     self.objects = []

--- a/ambuild2/frontend/v2_1/cpp/msvc.py
+++ b/ambuild2/frontend/v2_1/cpp/msvc.py
@@ -126,5 +126,17 @@ class MSVC(Vendor):
   ##
   @property
   def shared_pdb_name(self):
-    cl_version = int(self.version_string) - 600
-    return 'vc{0}.pdb'.format(int(cl_version / 10))
+    cl_version = int(self.version_string)
+
+    # Truncate down to the major version then correct the offset
+    # There is some evidence that the first digit of the minor version can be used for the PDB, but I can't reproduce it
+    cl_version = int(cl_version / 100) - 6
+
+    # Microsoft introduced a discontinuity with vs2015
+    if cl_version >= 13:
+      cl_version += 1
+
+    # Pad it back out again
+    cl_version *= 10
+
+    return 'vc{0}.pdb'.format(cl_version)


### PR DESCRIPTION
Microsoft skipped vc130 and went straight to vc140 with 2015, and from
2017 started using minor version numbers which we weren't handling.