### PR TITLE
AMBuild API 2.1 fixes

### DIFF
--- a/ambuild2/frontend/paths.py
+++ b/ambuild2/frontend/paths.py
@@ -50,6 +50,13 @@ def Join(*nodes):
   return os.path.join(*paths)
 
 def IsSubPath(other, folder):
-  folder = os.path.normpath(folder) + os.sep
-  other = os.path.normpath(other) + os.sep
-  return other.startswith(folder)
+  other = os.path.abspath(other)
+  folder = os.path.abspath(folder)
+
+  relative = os.path.relpath(other, folder)
+  if relative.startswith(os.pardir): # Short-circuit on '..' -OR- '../', this is always pointing outside of "folder".
+    return False
+  elif relative.startswith(os.curdir): # Short-circuit on '.' -OR- './', this is always pointing to a child item.
+    return True
+
+  return other.startswith(folder) # In most cases, we shouldn't ever arrive to this point.

--- a/ambuild2/frontend/v2_1/base/gen.py
+++ b/ambuild2/frontend/v2_1/base/gen.py
@@ -70,8 +70,8 @@ class BaseGenerator(object):
     return self.importScriptImpl(context, path, vars)
 
   def evalScript(self, context, path, vars={}):
-    obj = self.importScriptImpl(self, context, path, vars)
-    return obj.get('rvalue', None)
+    obj = self.importScriptImpl(context, path, vars)
+    return getattr(obj, 'rvalue', None)
 
   def runBuildScript(self, context, path, vars={}):
     if not isinstance(path, util.StringType()):

--- a/ambuild2/frontend/v2_1/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_1/vs/export_vcxproj.py
@@ -123,8 +123,8 @@ def export_configuration_user_props(node, xml):
 def export_configuration_paths(node, xml):
   for builder in node.project.builders_:
     condition = condition_for(builder)
-    xml.tag('OutDir', "$(Configuration)\\", Condition = condition)
-    xml.tag('IntDir', "$(Configuration)\\", Condition = condition)
+    xml.tag('OutDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
+    xml.tag('IntDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
     if '/INCREMENTAL:NO' not in builder.compiler.linkflags and '/INCREMENTAL:NO' not in builder.compiler.postlink:
       xml.tag('LinkIncremental', 'true', Condition = condition)
     xml.tag('TargetName', builder.name_, Condition = condition)
@@ -219,6 +219,9 @@ def export_configuration_options(node, xml, builder):
     elif '/W4' in flags:
       xml.tag('WarningLevel', 'Level4')
 
+    if '/WX' in flags:
+      xml.tag('TreatWarningAsError', 'true')
+
     if '/Od' in flags:
       xml.tag('DebugInformationFormat', 'EditAndContinue')
     else:
@@ -268,8 +271,8 @@ def export_configuration_options(node, xml, builder):
       else:
         libs.append(Dep.resolve(node.context, builder, flag))
 
-    if '/WX' in flags:
-      xml.tag('TreatWarningsAsError', 'true')
+    if '/WX' in link_flags:
+      xml.tag('TreatLinkerWarningAsErrors', 'true')
 
     xml.tag('AdditionalDependencies', ';'.join(libs))
     xml.tag('OutputFile', '$(OutDir)$(TargetFileName)')


### PR DESCRIPTION
getattr(obj, 'rvalue', None) -- Expando has no "get" attribute method.

Changes to paths.IsSubPath -- Previous implementation raises a false negative under certain values.

NOTE: This is a repaired version of #42, pulling and moving commits from upstream resulted in broken PR.