### PR TITLE
Prevent conflicting AMBuild installations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ AMBuild requires Python 2.6 or higher, or Python 3.1 or higher.
 
 For more information, see: https://wiki.alliedmods.net/AMBuild
 
+# Installation
+
+```
+git clone https://github.com/alliedmodders/ambuild
+pip install ./ambuild
+```
+
 # AMBuild 2
 
 AMBuild 2 is a highly efficient build system designed to replace ["Alpha"-generation tools][1], such as SCons or Make. It is not a replacement for IDE project files, nor is it a front-end tool for generating other build system files, such as CMake. AMBuild is designed with three features in mind:

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -15,6 +15,10 @@ try:
 except ImportError:
   import pickle
 
+# When present, we know this was not installed with distutils, because
+# distutils is no longer supported.
+INSTALLED_BY_PIP_OR_SETUPTOOLS = True
+
 def NormalizeArchString(arch):
   # We normalize platforms across different operating systems.
   if arch in ['x86_64', 'AMD64', 'x64', 'amd64']:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # vim: set ts=2 sw=2 tw=99 et: 
+import multiprocessing as mp
+import os
 import sys
 from setuptools import setup, find_packages
 
@@ -7,6 +9,40 @@ try:
   import sqlite3
 except:
   raise SystemError('py-sqlite3 must be installed')
+
+def child_main():
+  import sys
+  sys.path.pop(0)
+  try:
+    import ambuild2.util
+  except:
+    sys.exit(2)
+  if getattr(ambuild2.util, 'INSTALLED_BY_PIP_OR_SETUPTOOLS', False):
+    sys.exit(1)
+  sys.exit(0)
+
+proc = mp.Process(target = child_main)
+proc.start()
+proc.join()
+
+if not proc.exitcode:
+  sys.stderr.write("You have a previous installation of AMBuild. AMBuild must\n")
+  sys.stderr.write("now be installed by pip (see README.md). To prevent\n")
+  sys.stderr.write("conflicts, please remove the old distutils install. You can\n")
+  sys.stderr.write("do this by inspecting the following locations and removing\n")
+  sys.stderr.write("any ambuild folders:\n\n")
+  for path in sys.path[1:]:
+    candidates = [ os.path.join(path, "ambuild"), os.path.join(path, "ambuild2") ]
+    found = False
+    for candidate in candidates:
+      if os.path.exists(candidate):
+        found = True
+        break
+    if found:
+      sys.stderr.write("\t" + path + "\n")
+  sys.stderr.write("\nAborting installation.\n")
+  sys.stderr.flush()
+  sys.exit(1)
   
 amb_scripts = []
 if sys.platform != 'win32':


### PR DESCRIPTION
This detects older AMBuild installs that may have been installed with
distutils, and forces their removal.