### PR TITLE
Fix import of deleted ipc module in task.py

### DIFF
--- a/ambuild2/task.py
+++ b/ambuild2/task.py
@@ -4,7 +4,6 @@ import multiprocessing as mp
 import shutil
 import os, sys
 import traceback
-from ambuild2 import ipc
 from ambuild2 import util
 from ambuild2 import nodetypes
 from ambuild2 import process_manager


### PR DESCRIPTION
Looked into why my build in sourcepawn failed it is due to still importing the ipc module in task.py so just put up this to fix.