### PR TITLE
Automatically detect Microsoft Visual C++.

### DIFF
--- a/ambuild2/frontend/msvc_utils.py
+++ b/ambuild2/frontend/msvc_utils.py
@@ -1,0 +1,200 @@
+# vim: set ts=8 sts=2 sw=2 tw=99 et:
+#
+# This file is part of AMBuild.
+# 
+# AMBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# AMBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
+import collections
+import json
+import os
+import platform
+import subprocess
+import tempfile
+from ambuild2 import util
+from ambuild2.frontend.version import Version
+try:
+    import winreg
+except:
+    try:
+        import _winreg
+    except:
+        winreg = None
+
+class MSVCInstall(object):
+    def __init__(self, version, path):
+        self.version = Version(version)
+        self.path = path
+        self.vcvars = {}
+
+class MSVCFinder(object):
+    def __init__(self):
+        self.installs_ = []
+
+    def find_all(self):
+        self.find_old()
+        self.find_new()
+
+        def sort_by_version(install):
+            return install.version
+        self.installs_.sort(key = sort_by_version, reverse = True)
+
+        return self.installs_
+
+    def find_old(self):
+        kCandidates = ['14.0']
+        for version in kCandidates:
+            self.find_old_install(version)
+
+    def find_new(self):
+        program_files = os.environ.get('PROGRAMFILES(X86)')
+        if not program_files:
+            program_files = os.environ.get('PROGRAMFILES')
+        if not program_files:
+            return
+        vswhere = os.path.join(program_files, 'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+        if not os.path.exists(vswhere):
+            return
+        argv = [
+            vswhere,
+            '-format', 'json',
+            '-products', '*',
+            '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+        ]
+        try:
+            output = subprocess.check_output(argv)
+        except:
+            return
+        data = json.loads(output.decode('utf-8'))
+        for obj in data:
+            version_parts = obj['installationVersion'].split('.')
+            version = version_parts[0] + '.0'
+            install_path = obj['installationPath']
+            install = MSVCInstall(version, os.path.join(install_path, 'VC'))
+            build_path = os.path.join(install.path, 'Auxiliary', 'Build')
+
+            candidates = []
+
+            cpu = util.NormalizeArchString(platform.machine())
+            if cpu == 'x86':
+                candidates.append(('x86', 'vcvars32.bat'))
+                candidates.append(('x86_64', 'vcvarsx86_amd64.bat'))
+                candidates.append(('arm', 'vcvarsx86_arm.bat'))
+                candidates.append(('arm64', 'vcvarsx86_arm64.bat'))
+            elif cpu == 'x86_64':
+                candidates.append(('x86', 'vcvarsamd64_x86.bat'))
+                candidates.append(('x86_64', 'vcvars64.bat'))
+                candidates.append(('arm', 'vcvarsamd64_arm.bat'))
+                candidates.append(('arm64', 'vcvarsamd64_arm64.bat'))
+
+            for target, bat_file in candidates:
+                path = os.path.join(build_path, bat_file)
+                if os.path.exists(path):
+                    install.vcvars[target] = path
+
+            if len(install.vcvars):
+                self.installs_.append(install)
+
+    def find_old_install(self, version):
+        path = "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VC7"
+        sam = winreg.KEY_WOW64_32KEY | winreg.KEY_QUERY_VALUE
+        try:
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, path, 0, sam) as key:
+                path_value, reg_type = winreg.QueryValueEx(key, version)
+            if reg_type != winreg.REG_SZ:
+                return
+            install = MSVCInstall(version, path_value)
+        except:
+            return
+
+        candidates = []
+
+        cpu = util.NormalizeArchString(platform.machine())
+        if cpu == 'x86':
+            candidates.append(('x86', 'vcvars32.bat'))
+            candidates.append(('x86_64', os.path.join('x86_amd64', 'vcvarsx86_amd64.bat')))
+            candidates.append(('arm', os.path.join('arm', 'vcvarsx86_arm.bat')))
+        elif cpu == 'x86_64':
+            candidates.append(('x86', os.path.join('amd64_x86', 'vcvarsamd64_x86.bat')))
+            candidates.append(('x86_64', os.path.join('amd64', 'vcvars64.bat')))
+            candidates.append(('arm', os.path.join('amd64_arm', 'vcvarsamd64_arm.bat')))
+
+        for target, bat_file in candidates:
+            path = os.path.join(path_value, 'bin', bat_file)
+            if os.path.exists(path):
+                install.vcvars[target] = path
+
+        if len(install.vcvars):
+            self.installs_.append(install)
+
+def parse_env(text):
+    env = {}
+    lines = text.split('\r\n')
+    for line in lines:
+        first_eq = line.find('=')
+        if first_eq == -1:
+            env[line.upper()] = ''
+        else:
+            key = line[0 : first_eq]
+            value = line[first_eq + 1:]
+            env[key.upper()] = value
+    return env
+
+def find_env_changes(env1, env2):
+    # Important: use OrderedDict, so that we have stable results across
+    # builds. Otherwise we could accidentally invalidate.
+    replace = collections.OrderedDict()
+    add = collections.OrderedDict()
+    for key in env2:
+        if key not in env1:
+            replace[key] = env2[key]
+            continue
+        old_value = env1[key]
+        new_value = env2[key]
+        if old_value == new_value:
+            continue
+        if not new_value.startswith(old_value):
+            replace[key] = new_value
+        else:
+            add[key] = new_value[len(old_value):]
+    return replace, add
+
+def run_batch(contents):
+    fp = tempfile.NamedTemporaryFile(suffix = '.bat', delete = False)
+    try:
+        fp.write(contents.encode('ascii'))
+        fp.close()
+        return subprocess.check_output([fp.name]).decode('utf-8')
+    finally:
+        os.unlink(fp.name)
+
+def DeduceEnv(vcvars_file):
+    contents = "SET\n"
+    env_before = parse_env(run_batch(contents))
+
+    contents = "@echo off\n" + \
+               "CALL \"{}\" 1>NUL\n".format(vcvars_file) + \
+               "@echo on\n" + \
+               "SET\n"
+    env_after = parse_env(run_batch(contents))
+
+    replace, add = find_env_changes(env_before, env_after)
+    env_commands = []
+    for key, value in replace.items():
+        env_commands.append(('replace', key, value))
+    for key, value in add.items():
+        env_commands.append(('add', key, value))
+
+    # Explicitly use tuples because this object gets attached to many commands
+    # and is better left immutable. This also lets us hash it for reverse
+    # lookup.
+    return tuple(env_commands)

--- a/ambuild2/frontend/v2_1/base/context.py
+++ b/ambuild2/frontend/v2_1/base/context.py
@@ -17,6 +17,7 @@
 import os
 import sys, copy
 from ambuild2.frontend.v2_1 import tools
+from ambuild2.frontend.version import Version
 
 # AMBuild 2 scripts are parsed recursively. Each script is supplied with a
 # "builder" object, which maps to a Context object. Each script gets its own
@@ -78,6 +79,10 @@ class BaseContext(object):
   def buildPath(self):
     return self.generator_.buildPath
 
+  @property
+  def apiVersion(self):
+    return Version('2.1.1')
+
   def Import(self, path, vars={}):
     return self.generator_.importScript(self, path, vars)
 
@@ -124,10 +129,12 @@ class BuildContext(BaseContext):
   def Build(self, path, vars={}):
     return self.generator_.runBuildScript(self, path, vars)
 
-  def DetectCxx(self):
+  # Any consumed options will be removed from the given dictionary. Callers
+  # can detect unconsumed options by inspecting the dictionary after.
+  def DetectCxx(self, options = {}):
     # Only the top-level build script should be detecting compilers.
     if self.cxx_ is None and self.parent_ is None:
-      self.cxx_ = self.generator_.detectCompilers().clone()
+      self.cxx_ = self.generator_.detectCompilers(options).clone()
     return self.cxx_
 
   @property
@@ -155,7 +162,7 @@ class BuildContext(BaseContext):
     return self.generator_.addCopy(self, source, output_path)
 
   def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=[],
-                 shared_outputs=[]):
+                 shared_outputs=[], env_data=None):
     return self.generator_.addShellCommand(
       self,
       inputs,
@@ -164,8 +171,8 @@ class BuildContext(BaseContext):
       folder = folder,
       dep_type = dep_type,
       weak_inputs = weak_inputs,
-      shared_outputs = shared_outputs
-    )
+      shared_outputs = shared_outputs,
+      env_data = env_data)
 
   def Context(self, name):
     return self.generator_.Context(name)

--- a/ambuild2/frontend/v2_1/base/gen.py
+++ b/ambuild2/frontend/v2_1/base/gen.py
@@ -227,7 +227,7 @@ all:
     raise Exception('Must be implemented!')
 
   def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
+                      weak_inputs=[], shared_outputs=[], env_data=None):
     raise Exception('Must be implemented!')
 
   def addConfigureFile(self, context, path):

--- a/ambuild2/frontend/v2_1/cpp/builders.py
+++ b/ambuild2/frontend/v2_1/cpp/builders.py
@@ -101,6 +101,7 @@ def NameForObjectFile(file):
 class ObjectFileBase(object):
   def __init__(self, parent, inputObj, outputFile):
     super(ObjectFileBase, self).__init__()
+    self.env_data = parent.env_data
     self.folderNode = parent.localFolderNode
     self.inputObj = inputObj
     self.outputFile = outputFile
@@ -145,6 +146,7 @@ class ObjectArgvBuilder(object):
     self.resources = []
     self.used_cxx = False
     self.sourcedeps = []
+    self.env_data = None
 
   def setOutputs(self, localFolderNode, outputFolder, outputPath):
     self.outputFolder = outputFolder
@@ -175,6 +177,8 @@ class ObjectArgvBuilder(object):
     self.cxx_argv += [self.vendor.definePrefix + define for define in compiler.cxxdefines]
     for include in compiler.includes + compiler.cxxincludes + addl_include_dirs:
       self.cxx_argv += self.vendor.formatInclude(self.outputPath, include)
+
+    self.env_data = compiler.env_data
 
     # Set up source dependencies.
     self.sourcedeps += compiler.sourcedeps + addl_source_deps
@@ -515,8 +519,8 @@ class BinaryBuilder(object):
       outputs = self.linker_outputs,
       folder = folder,
       weak_inputs = self.compiler.weaklinkdeps,
-      shared_outputs = shared_outputs
-    )
+      shared_outputs = shared_outputs,
+      env_data = self.compiler.env_data)
     if not self.debug_entry and self.compiler.symbol_files:
       if self.linker_.behavior != 'msvc' and self.compiler.symbol_files == 'bundled':
         self.debug_entry = outputs[0]

--- a/ambuild2/frontend/v2_1/cpp/compiler.py
+++ b/ambuild2/frontend/v2_1/cpp/compiler.py
@@ -66,6 +66,7 @@ class Compiler(object):
   def inherit(self, other):
     for attr in self.attrs_:
       setattr(self, attr, copy.copy(getattr(other, attr)))
+
     self.symbol_files_ = other.symbol_files_
 
   def clone(self):
@@ -140,16 +141,21 @@ class Compiler(object):
     return builders.Dep(text, node)
 
 class CliCompiler(Compiler):
-  def __init__(self, vendor, cc_argv, cxx_argv, options = None):
+  def __init__(self, vendor, cc_argv, cxx_argv, options = None, env_data = None):
     super(CliCompiler, self).__init__(vendor, options)
     self.cc_argv = cc_argv
     self.cxx_argv = cxx_argv
     self.found_pkg_config_ = False
+    self.env_data = env_data
 
   def clone(self):
     cc = CliCompiler(self.vendor, self.cc_argv, self.cxx_argv)
     cc.inherit(self)
     return cc
+
+  def inherit(self, other):
+    super(CliCompiler, self).inherit(other)
+    self.env_data = other.env_data
 
   def Program(self, name):
     return builders.Program(self.clone(), name)

--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -15,13 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
-import os, re
-import tempfile
+import os
+import re
+import shlex
 import subprocess
+import tempfile
 from ambuild2 import util
+from ambuild2.frontend import msvc_utils
 from ambuild2.frontend.v2_1.cpp import vendor, compiler
-from ambuild2.frontend.v2_1.cpp.msvc import MSVC
 from ambuild2.frontend.v2_1.cpp.gcc import GCC, Clang, Emscripten
+from ambuild2.frontend.v2_1.cpp.msvc import MSVC
 from ambuild2.frontend.v2_1.cpp.sunpro import SunPro
 
 class CommandAndVendor(object):
@@ -30,88 +33,201 @@ class CommandAndVendor(object):
     self.vendor = vendor
     self.arch = None
 
-def FindCompiler(env, mode, cmd):
-  if "EMSDK" in os.environ and cmd[:2] == 'em':
-    result = TryVerifyCompiler(env, mode, cmd, 'emscripten')
-    if result is not None:
-      return result
-  if util.IsWindows():
-    result = TryVerifyCompiler(env, mode, cmd, 'msvc')
-    if result is not None:
-      return result
-  return TryVerifyCompiler(env, mode, cmd, 'gcc')
+class CompilerNotFoundException(Exception):
+  def __init__(self, message):
+    super(CompilerNotFoundException, self).__init__(message)
 
-CompilerSearch = {
-  'CC': {
-    'mac': ['cc', 'clang', 'gcc', 'icc'],
-    'windows': ['cl'],
-    'default': ['cc', 'gcc', 'clang', 'icc']
-  },
-  'CXX': {
-    'mac': ['c++', 'clang++', 'g++', 'icc'],
-    'windows': ['cl'],
-    'default': ['c++', 'g++', 'clang++', 'icc']
-  }
-}
+kClangTuple = ('clang', 'clang++', 'gcc')
+kGccTuple = ('gcc', 'g++', 'gcc')
+kIntelTuple = ('icc', 'icc', 'gcc')
+kMsvcTuple = ('cl', 'cl', 'msvc')
 
-def DetectCxx(target, env, options):
-  cc = DetectCxxCompiler(env, 'CC')
-  cxx = DetectCxxCompiler(env, 'CXX')
+def FindToolsInEnv(env, tools):
+  found = {}
+  paths = env.get('PATH', '').split(';')
+  for path in paths:
+    for tool in tools:
+      if tool in found:
+        continue
+      candidate = os.path.join(path, tool)
+      if os.path.exists(candidate):
+        found[tool] = candidate
+    if len(found) == len(tools):
+      return found, True
+  return found, False
 
-  # Ensure that the two compilers have the same vendor.
-  if not cxx.vendor.equals(cc.vendor):
-    message = 'C and C++ compiler are different: CC={0}, CXX={1}'
-    message = message.format(cc.vendor, cxx.vendor)
+def AutoDetectCxx(target, gen_options, detect_options):
+  locator = CompilerLocator(target, gen_options, detect_options)
+  return locator.detect()
 
-    util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
-    raise Exception(message)
+class CompilerLocator(object):
+  def __init__(self, target, gen_options, detect_options):
+    self.target_ = target
+    self.gen_options_ = gen_options
+    self.detect_options_ = detect_options
 
-  if cxx.arch != cc.arch:
-    message = "C architecture {0} does not match C++ architecture {1}".format(cc.arch, cxx.arch)
-    util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
-    raise Exception(message)
+  def detect(self):
+    if 'CC' in os.environ or 'CXX' in os.environ:
+      return self.detect_from_env()
 
-  # :TODO: Check that the arch is == to target. We don't do this yet since
-  # on Windows we can't use platform.architecture().
+    if util.Platform() == 'windows':
+      compiler = self.detect_msvc()
+      if compiler:
+        return compiler
 
-  return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, options)
+    return self.detect_defaults()
 
-def DetectCxxCompiler(env, var):
-  if var in env:
-    trys = [env[var]]
-  else:
-    if util.Platform() in CompilerSearch[var]:
-      trys = CompilerSearch[var][util.Platform()]
-    else:
-      trys = CompilerSearch[var]['default']
-  for i in trys:
-    result = FindCompiler(env, var, i)
-    if result is not None:
-      return result
+  def detect_defaults(self):
+    cc, cxx = self.find_default_compiler()
+    return self.create_cli(cc, cxx)
 
-  raise Exception('Unable to find a suitable ' + var + ' compiler')
+  def detect_from_env(self):
+    if 'CC' not in os.environ:
+      raise Exception('CXX set in environment, but not CC')
+    if 'CXX' not in os.environ:
+      raise Exception('CC set in environment, but not CXX')
 
-def TryVerifyCompiler(env, mode, cmd, assumed_family):
-  try:
-    return VerifyCompiler(env, mode, cmd, assumed_family)
-  except Exception as e:
-    util.con_out(
-      util.ConsoleHeader,
-      'Compiler {0} for {1} failed: '.format(cmd, mode),
-      util.ConsoleRed,
-      str(e),
-      util.ConsoleNormal
+    cc = self.find_compiler(os.environ, 'CC', os.environ['CC'])
+    if cc is None:
+      raise CompilerNotFoundException('Unable to find a suitable C compiler')
+
+    cxx = self.find_compiler(os.environ, 'CXX', os.environ['CXX'])
+    if cxx is None:
+      raise CompilerNotFoundException('Unable to find a suitable C++ compiler')
+
+    return self.create_cli(cc, cxx)
+
+  def create_cli(self, cc, cxx):
+    # Ensure that the two compilers have the same vendor.
+    if not cxx.vendor.equals(cc.vendor):
+      message = 'C and C++ compiler are different: CC={0}, CXX={1}'
+      message = message.format(cc.vendor, cxx.vendor)
+
+      util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
+      raise Exception(message)
+
+    if cxx.arch != cc.arch:
+      message = "C architecture {0} does not match C++ architecture {1}".format(cc.arch, cxx.arch)
+      util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
+      raise Exception(message)
+
+    return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, self.gen_options_)
+
+  def detect_msvc(self):
+    # If the caller has already configured the environment, we'll expect it to
+    # be always configured for us in the future.
+    _, has_cl = FindToolsInEnv(os.environ, ['cl.exe'])
+    if has_cl:
+      return self.find_default_compiler()
+
+    force_msvc = self.detect_options_.pop('force_msvc_version', None)
+
+    installs = msvc_utils.MSVCFinder().find_all()
+    for install in installs:
+      if force_msvc and install.version != force_msvc:
+        continue
+      if self.target_.arch not in install.vcvars:
+        continue
+
+      compiler = self.try_msvc_install(install)
+      if compiler is not None:
+        return compiler
+
+    raise CompilerNotFoundException('Unable to find a suitable C/C++ compiler')
+
+  def try_msvc_install(self, install):
+    bat_file = install.vcvars[self.target_.arch]
+    try:
+      env_cmds = msvc_utils.DeduceEnv(bat_file)
+      env = util.BuildEnv(env_cmds)
+    except:
+      util.con_err(util.ConsoleRed, "Could not run or analyze {}".format(bat_file), util.ConsoleNormal)
+      return None
+
+    necessary_tools = ['cl.exe', 'rc.exe', 'lib.exe']
+    tools, _ = FindToolsInEnv(env, necessary_tools)
+    for tool in necessary_tools:
+      if tool not in tools:
+        util.con_err(util.ConsoleRed, "Could not find {} for {}".format(tool, bat_file))
+        return None
+
+    cc, _ = self.run_compiler(env, 'CC', 'cl', 'msvc', abs_path = tools['cl.exe'])
+    if not cc:
+      return None
+    cxx, _ = self.run_compiler(env, 'CXX', 'cl', 'msvc', abs_path = tools['cl.exe'])
+    if not cxx:
+      return None
+
+    # We use tuples here so the data is hashable without going through Pickle.
+    tool_list = (
+      ('cl', tools['cl.exe']),
+      ('rc', tools['rc.exe']),
+      ('lib', tools['lib.exe']),
     )
+    env_data = (
+      ('env_cmds', env_cmds),
+      ('tools', tool_list),
+    )
+    return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, options = self.gen_options_,
+                                env_data = env_data)
+
+  def find_default_compiler(self):
+    candidates = []
+    if util.Platform() == 'windows':
+      candidates.append(kMsvcTuple)
+    candidates.extend([kClangTuple, kGccTuple, kIntelTuple])
+
+    for cc_cmd, cxx_cmd, cc_family in candidates:
+      cc = self.find_compiler(os.environ, 'CC', cc_cmd, cc_family)
+      if cc is None:
+        continue
+      cxx = self.find_compiler(os.environ, 'CXX', cxx_cmd, cc_family)
+      if cxx is not None:
+        return cc, cxx
+
+    raise CompilerNotFoundException('Unable to find a suitable C/C++ compiler')
+
+  def find_compiler(self, env, mode, cmd, cc_family = None):
+    families = []
+    if "EMSDK" in env and cmd[:2] == 'em':
+      families.append('emscripten')
+    if cc_family is not None:
+      families.append(cc_family)
+    else:
+      # On Windows, check for MSVC compatibility before checking GCC.
+      if util.Platform() == 'windows':
+        families.append('msvc')
+      families.append('gcc')
+
+    for family in families:
+      compiler, e = self.run_compiler(env, mode, cmd, family)
+      if compiler is not None:
+        return compiler
+      if isinstance(e, CompilerNotFoundException):
+        # No reason to keep trying the same command.
+        break
+
     return None
 
-def VerifyCompiler(env, mode, cmd, assumed_family):
-  base_argv = cmd.split()
+  def run_compiler(self, env, mode, cmd, assumed_family, abs_path = None):
+    try:
+      return VerifyCompiler(env, mode, cmd, assumed_family, abs_path), None
+    except Exception as e:
+      util.con_out(util.ConsoleHeader, 'Compiler {0} for {1} failed: '.format(cmd, mode),
+                   util.ConsoleRed, str(e), util.ConsoleNormal)
+      return None, e
+
+def VerifyCompiler(env, mode, cmd, assumed_family, abs_path):
+  base_argv = shlex.split(cmd)
+
   if 'CFLAGS' in env:
     base_argv.extend(env['CFLAGS'].split())
   if mode == 'CXX' and 'CXXFLAGS' in env:
     base_argv.extend(env['CXXFLAGS'].split())
 
   argv = base_argv[:]
+  if abs_path is not None:
+    argv[0] = abs_path
   if mode == 'CXX':
     filename = 'test.cpp'
   else:
@@ -186,9 +302,9 @@ int main()
     '{0}'.format(argv),
     util.ConsoleNormal
   )
-  p = util.CreateProcess(argv)
+  p = util.CreateProcess(argv, env = env)
   if p == None:
-    raise Exception('compiler not found')
+    raise CompilerNotFoundException('compiler not found')
   if util.WaitForProcess(p) != 0:
     raise Exception('compiler failed with return code {0}'.format(p.returncode))
 
@@ -203,7 +319,7 @@ int main()
   else:
     exe = util.MakePath('.', executable)
 
-  p = util.CreateProcess(executable_argv, executable = exe)
+  p = util.CreateProcess(executable_argv, executable = exe, env = env)
   if p == None:
     raise Exception('failed to create executable with {0}'.format(cmd))
   if util.WaitForProcess(p) != 0:

--- a/ambuild2/frontend/v2_1/cpp/msvc.py
+++ b/ambuild2/frontend/v2_1/cpp/msvc.py
@@ -62,7 +62,7 @@ class MSVC(Vendor):
     return ['/showIncludes', '/nologo', '/c', sourceFile, '/Fo' + objFile]
 
   def staticLinkArgv(self, files, outputFile):
-    return ['lib.exe', '/OUT:' + outputFile] + files
+    return ['lib', '/OUT:' + outputFile] + files
 
   def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
     argv = cmd_argv + files

--- a/ambuild2/frontend/v2_1/prep.py
+++ b/ambuild2/frontend/v2_1/prep.py
@@ -16,6 +16,7 @@
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, sys
 import platform
+import traceback
 from ambuild2 import util
 from optparse import OptionParser, Values, SUPPRESS_HELP
 from ambuild2.frontend.system import System
@@ -136,6 +137,10 @@ class Preparer(object):
       sys.exit(1)
 
     with util.FolderChanger(self.buildPath):
-      if not builder.generate():
-        sys.stderr.write('Configure failed.\n')
-        sys.exit(1)
+      try:
+        if not builder.generate():
+          sys.stderr.write('Configure failed.\n')
+          sys.exit(1)
+      except Exception as e:
+        traceback.print_exc()
+        util.con_err(util.ConsoleRed, 'Configure failed: {}'.format(e), util.ConsoleNormal)

--- a/ambuild2/frontend/v2_1/vs/gen.py
+++ b/ambuild2/frontend/v2_1/vs/gen.py
@@ -23,13 +23,14 @@ from ambuild2.frontend.v2_1.vs import cxx
 from ambuild2.frontend.v2_1.vs import nodes
 from ambuild2.frontend.v2_1.base import BaseGenerator
 
-SupportedVersions = ['10', '11', '12', '14', '15']
+SupportedVersions = ['10', '11', '12', '14', '15', '16']
 YearMap = {
   '2010': 10,
   '2012': 11,
   '2013': 12,
   '2015': 14,
   '2017': 15,
+  '2019': 16,
 }
 
 class Generator(BaseGenerator):
@@ -95,7 +96,7 @@ class Generator(BaseGenerator):
     pass
 
   # Overridden.
-  def detectCompilers(self):
+  def detectCompilers(self, options):
     if not self.compiler:
       version = cxx.Compiler.GetVersionFromVS(self.vs_version)
       vendor = cxx.VisualStudio(version)

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -134,10 +134,6 @@ class Entry(object):
 
     self.outgoing = None
 
-    # True if the node was not dirty when originally pulled from the DB, but is
-    # now actually dirty.
-    self.newlyDirty = False
-    
   def isCommand(self):
     return IsCommand(self.type)
 

--- a/ambuild2/run.py
+++ b/ambuild2/run.py
@@ -20,7 +20,7 @@ from optparse import OptionParser
 from ambuild2 import util
 from ambuild2.context import Context
 
-DEFAULT_API = '2.1'
+DEFAULT_API = '2.1.1'
 
 SampleScript = """# vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 builder.DetectCxx()
@@ -112,7 +112,7 @@ def PrepareBuild(sourcePath, buildPath=None):
 def PreparerForAPI(api):
   if api == '2.0':
     from ambuild2.frontend.v2_0.prep import Preparer
-  elif api == '2.1':
+  elif api == '2.1' or api.startswith('2.1.'):
     from ambuild2.frontend.v2_1 import Preparer
   else:
     raise Exception('API version {0} not found'.format(api))

--- a/tests/staticlib/configure.py
+++ b/tests/staticlib/configure.py
@@ -2,5 +2,5 @@
 import sys
 from ambuild2 import run
 
-builder = run.BuildParser(sourcePath = sys.path[0], api = '2.1')
+builder = run.BuildParser(sourcePath = sys.path[0], api = '2.0')
 builder.Configure()


### PR DESCRIPTION
This is a major refactoring of the C++ detection logic. The new behavior
is as follows:
 1. If 'CC' and 'CXX' are defined in the environment, those most result
    in a valid compiler, and no other detection is performed. On
    Windows, tools like "rc" and "lib" must be in the environment.
    Defining CC but not CXX (or vice-versa) is an error.
 2. If running on Windows, if 'cl.exe' is in PATH, then AMBuild assumes
    the environment has already been configured, and looks for, in this
    order: cl, clang, gcc, icc.
 3. If running on Windows, and 'cl.exe' is not in PATH, then AMBuild
    looks in the registry for Visual Studio 2015. It will also look for
    the 'vswhere' tool, and if present, will detect installations of
    Visual Studio 2017 and 2019. The highest working version is used. If
    no working version is found, the logic in step 2 is used as a
    last-ditch attempt.
 4. Otherwise, AMBuild tries to run clang, gcc, or icc (in that order).

This logic is heavily dependent on vcvars being functional. For example,
Visual Studio 2015 may not configure newer Windows Kits properly, and
AMBuild will not be able to automatically detect such an install.

Some important changes have been made underneath the hood. vcvars
configures a large number of extra environment variables. Normally we
would cache these values globally, and AMBuild would restore the
original environment on each build. The existing mechanism to do this is
too limited. Additionally, having a global environment means AMBuild can
only ever support one compiler per build. Windows has compiler binaries
for X64, ARM, ARM64, and X86 support, so universal builds would be
impossible if we kept this model.

We do not yet support universal builds in AMBuild. However, this patch
takes an important first step. Compiler objects can now have an
"environment" attached, which contains two critical pieces of
information:
 1. An environment command list. This is a sequence of edit operations
    to the environment, which we derive by comparing the environment
    before and after calling vcvars.
 2. A dictionary mapping tool names to their executable paths. This way,
    we can attach the exact paths for cl.exe, rc.exe, and lib.exe.
    Knowing the full path to a tool means we don't have to touch the
    global environment of each worker process. It also (slightly) makes
    the build process more hermetic, and significantly reduces the database
    size by not attaching full path information to thousands of C++ commands.

Environment data is stored in the database, and changes to an
environment will trigger a rebuild of any affected commands.

This is an important step forward because it will enable a number of
additional features to AMBuild. Most importantly, it enables future
support for multiple compilers/targets. It also opens the door for more
hermetic builds: we can re-build the environment from the database
during automatic reconfigures.