### PR TITLE
Restyle everything.

### DIFF
--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -1,0 +1,24 @@
+name: Style and Formatting Checks
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install yapf
+    - name: Style and Formatting Checks
+      run: |
+        yapf --diff --recursive .

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,6 @@
+[style]
+based_on_style = google
+column_limit = 100
+spaces_around_default_or_named_assign = True
+blank_line_before_nested_class_or_def = False
+blank_lines_around_top_level_definition = 1

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,2 @@
+ambuild/*
+ambuild2/database.py

--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ Build scripts for AMBuild are parsed once upon configuration, and are responsibl
 # AMBuild 1
 
 AMBuild 1 was intended as a replacement for build systems such as SCons or Make. Its syntax is easier than Make and handles C/C++ dependencies automatically. Like most build systems, it performs a full recursive search for outdated files, which can make it slower for dependency graphs with many edges. It has no multiprocess support. Also unlike AMBuild 2, the dependency graph is not saved in between builds, which greatly reduces its incremental build accuracy and speed.
-
+C
 AMBuild 1 is installed alongside AMBuild 2 for backward compatibility, however it resides in an older namespace and has a completely separate API.
+
+# Contributing
+
+AMBuild is written in Python. All changes must be Python 2.7 compatible, since it is used on some very old machines.
+
+Code is formatted using YAPF. If GitHub tells you there are style issues, you can use "yapf -r -i ." to fix them. You can get YAPF with pip ("pip install yapf").
+
+AlliedModders developers can often be found in IRC (irc.gamesurge.net, #smdevs) if you have questions.
+
+# References
 
 [1]: <http://gittup.org/tup/build_system_rules_and_algorithms.pdf> "Build System Rules and Algorithms by Mike Shal"

--- a/ambuild2/builder.py
+++ b/ambuild2/builder.py
@@ -10,330 +10,299 @@ from ambuild2.task import Task, TaskMaster
 # Given the partial command DAG, compute a task tree we can send to the task
 # thread.
 class TaskTreeBuilder(object):
-  def __init__(self, cx):
-    self.cx = cx
-    self.worklist = []
-    self.cache = {}
-    self.cmd_list = []
-    self.tree_leafs = []
-    self.max_parallel = 0
+    def __init__(self, cx):
+        self.cx = cx
+        self.worklist = []
+        self.cache = {}
+        self.cmd_list = []
+        self.tree_leafs = []
+        self.max_parallel = 0
 
-  def buildFromGraph(self, graph):
-    for node in graph.leafs:
-      leaf = self.enqueueCommand(node)
-      self.tree_leafs.append(leaf)
+    def buildFromGraph(self, graph):
+        for node in graph.leafs:
+            leaf = self.enqueueCommand(node)
+            self.tree_leafs.append(leaf)
 
-    self.max_parallel = len(self.worklist)
-    while len(self.worklist):
-      task, node = self.worklist.pop()
-
-      for outgoing in node.outgoing:
-        outgoing_task = self.findTask(outgoing)
-        task.addOutgoing(outgoing_task)
-
-      if len(self.worklist) > self.max_parallel:
         self.max_parallel = len(self.worklist)
+        while len(self.worklist):
+            task, node = self.worklist.pop()
 
-    return self.cmd_list, self.tree_leafs
+            for outgoing in node.outgoing:
+                outgoing_task = self.findTask(outgoing)
+                task.addOutgoing(outgoing_task)
 
-  def findTask(self, node):
-    if node in self.cache:
-      return self.cache[node]
-    return self.enqueueCommand(node)
+            if len(self.worklist) > self.max_parallel:
+                self.max_parallel = len(self.worklist)
 
-  def enqueueCommand(self, node):
-    assert node not in self.cache
-    assert node.isCommand()
-    output_list = []
-    for output in self.cx.db.query_outgoing(node.entry):
-      assert output.type == nodetypes.Output
-      output_list.append(output.path)
-    task = Task(len(self.cmd_list), node.entry, output_list)
-    self.cache[node] = task
-    self.cmd_list.append(node)
-    self.worklist.append((task, node))
-    return task
+        return self.cmd_list, self.tree_leafs
+
+    def findTask(self, node):
+        if node in self.cache:
+            return self.cache[node]
+        return self.enqueueCommand(node)
+
+    def enqueueCommand(self, node):
+        assert node not in self.cache
+        assert node.isCommand()
+        output_list = []
+        for output in self.cx.db.query_outgoing(node.entry):
+            assert output.type == nodetypes.Output
+            output_list.append(output.path)
+        task = Task(len(self.cmd_list), node.entry, output_list)
+        self.cache[node] = task
+        self.cmd_list.append(node)
+        self.worklist.append((task, node))
+        return task
 
 class Builder(object):
-  def __init__(self, cx, graph):
-    self.cx = cx
-    self.graph = graph
+    def __init__(self, cx, graph):
+        self.cx = cx
+        self.graph = graph
 
-    tb = TaskTreeBuilder(cx)
-    self.commands, self.leafs = tb.buildFromGraph(graph)
-    self.max_parallel = tb.max_parallel
-    self.num_completed_tasks = 0
+        tb = TaskTreeBuilder(cx)
+        self.commands, self.leafs = tb.buildFromGraph(graph)
+        self.max_parallel = tb.max_parallel
+        self.num_completed_tasks = 0
 
-    # Set of nodes we'll mark as clean in the database.
-    self.update_set = set()
+        # Set of nodes we'll mark as clean in the database.
+        self.update_set = set()
 
-  def printSteps(self):
-    if not len(self.graph.create) and not len(self.leafs):
-      print('Build is complete and no files changed; no steps needed.')
-      return
+    def printSteps(self):
+        if not len(self.graph.create) and not len(self.leafs):
+            print('Build is complete and no files changed; no steps needed.')
+            return
 
-    for entry in self.graph.create:
-      print(entry.format())
-    counter = 0
-    leafs = deque(self.leafs)
-    while len(leafs):
-      leaf = leafs.popleft()
-      print('task ' + str(format(counter)) + ': ' + leaf.format())
-      for output in leaf.outputs:
-        print('  -> ' + output)
+        for entry in self.graph.create:
+            print(entry.format())
+        counter = 0
+        leafs = deque(self.leafs)
+        while len(leafs):
+            leaf = leafs.popleft()
+            print('task ' + str(format(counter)) + ': ' + leaf.format())
+            for output in leaf.outputs:
+                print('  -> ' + output)
 
-      for child in leaf.outgoing:
-        child.incoming.remove(leaf)
-        if not len(child.incoming):
-          leafs.append(child)
+            for child in leaf.outgoing:
+                child.incoming.remove(leaf)
+                if not len(child.incoming):
+                    leafs.append(child)
 
-      counter += 1
+            counter += 1
 
-  def update(self):
-    for entry in self.graph.create:
-      if entry.type == nodetypes.Mkdir:
-        util.con_out(util.ConsoleBlue, '[create] ',
-                     util.ConsoleGreen, entry.format(),
-                     util.ConsoleNormal)
-        # The path might already exist because we mkdir -p and don't bother
-        # ordering.
-        if not os.path.exists(entry.path):
-          os.makedirs(entry.path)
-      else:
-        raise Exception('Unknown entry type: {0}'.format(entry.type))
-    if not len(self.leafs):
-      return TaskMaster.BUILD_NO_CHANGES
+    def update(self):
+        for entry in self.graph.create:
+            if entry.type == nodetypes.Mkdir:
+                util.con_out(util.ConsoleBlue, '[create] ', util.ConsoleGreen, entry.format(),
+                             util.ConsoleNormal)
+                # The path might already exist because we mkdir -p and don't bother
+                # ordering.
+                if not os.path.exists(entry.path):
+                    os.makedirs(entry.path)
+            else:
+                raise Exception('Unknown entry type: {0}'.format(entry.type))
+        if not len(self.leafs):
+            return TaskMaster.BUILD_NO_CHANGES
 
-    tm = TaskMaster(self.cx, self, self.leafs, self.max_parallel)
-    tm.run()
-    self.commit()
+        tm = TaskMaster(self.cx, self, self.leafs, self.max_parallel)
+        tm.run()
+        self.commit()
 
-    if tm.succeeded() and len(self.commands) != self.num_completed_tasks:
-      util.con_err(util.ConsoleRed,
-                  'Build marked as completed, but some commands were not executed?!\n',
-                  'Commands:', util.ConsoleNormal)
-      for task in self.commands:
-        if not task:
-          continue
-        util.con_err(util.ConsoleBlue, ' -> ',
-                     util.ConsoleRed, '{0}'.format(task.entry.format()),
-                     util.ConsoleNormal)
+        if tm.succeeded() and len(self.commands) != self.num_completed_tasks:
+            util.con_err(util.ConsoleRed,
+                         'Build marked as completed, but some commands were not executed?!\n',
+                         'Commands:', util.ConsoleNormal)
+            for task in self.commands:
+                if not task:
+                    continue
+                util.con_err(util.ConsoleBlue, ' -> ', util.ConsoleRed,
+                             '{0}'.format(task.entry.format()), util.ConsoleNormal)
 
-    return tm.status()
+        return tm.status()
 
-  def lazyUpdateEntry(self, entry):
-    if entry.type != nodetypes.Source:
-      return
-    if entry.dirty:
-      self.update_set.add(entry)
+    def lazyUpdateEntry(self, entry):
+        if entry.type != nodetypes.Source:
+            return
+        if entry.dirty:
+            self.update_set.add(entry)
 
-  def commit(self):
-    # Update any dirty source file timestamps. It's important that files are
-    # not modified in between being used as dependencies and the build
-    # finishing; otherwise, the DAG state will be incoherent.
-    for entry in self.update_set:
-      if entry.dirty != nodetypes.ALWAYS_DIRTY:
-        self.cx.db.unmark_dirty(entry)
-    self.cx.db.commit()
+    def commit(self):
+        # Update any dirty source file timestamps. It's important that files are
+        # not modified in between being used as dependencies and the build
+        # finishing; otherwise, the DAG state will be incoherent.
+        for entry in self.update_set:
+            if entry.dirty != nodetypes.ALWAYS_DIRTY:
+                self.cx.db.unmark_dirty(entry)
+        self.cx.db.commit()
 
-  def addDiscoveredSource(self, path):
-    if not os.path.isabs(path):
-      util.con_err(
-        util.ConsoleRed,
-        'Encountered an error while computing new dependencies: ',
-        'A new dependent file or path was discovered that has no corresponding build entry. ',
-        'This probably means a build script did not explicitly mark a generated file as an output. ',
-        'The build must abort since the ordering of these two steps is undefined. ',
-        util.ConsoleNormal
-      )
-      util.con_err(
-        util.ConsoleRed,
-        'Path: ',
-        util.ConsoleBlue,
-        path,
-        util.ConsoleNormal
-      )
-      return None
+    def addDiscoveredSource(self, path):
+        if not os.path.isabs(path):
+            util.con_err(
+                util.ConsoleRed, 'Encountered an error while computing new dependencies: ',
+                'A new dependent file or path was discovered that has no corresponding build entry. ',
+                'This probably means a build script did not explicitly mark a generated file as an output. ',
+                'The build must abort since the ordering of these two steps is undefined. ',
+                util.ConsoleNormal)
+            util.con_err(util.ConsoleRed, 'Path: ', util.ConsoleBlue, path, util.ConsoleNormal)
+            return None
 
-    rel_to_objdir = util.RelPathIfCommon(path, self.cx.buildPath)
-    if rel_to_objdir:
-      entry = self.cx.db.query_path(rel_to_objdir)
-      if not entry:
-        util.con_err(
-          util.ConsoleRed,
-          'Encountered an error while computing new dependencies: ',
-          'A new dependent file was discovered, but it exists in the output folder, and ',
-          'no corresponding command creates this file. One of the followeing might have ',
-          'occurred: \n',
-          ' (1) The file was created outside of AMBuild, which is not supported.\n',
-          ' (2) The file was created by a custom AMBuild command, but was not specified as an output.\n',
-          util.ConsoleNormal
-        )
-        util.con_err(
-          util.ConsoleRed,
-          'Path: ',
-          util.ConsoleBlue,
-          rel_to_objdir,
-          util.ConsoleNormal
-        )
-        return None
-      return entry
+        rel_to_objdir = util.RelPathIfCommon(path, self.cx.buildPath)
+        if rel_to_objdir:
+            entry = self.cx.db.query_path(rel_to_objdir)
+            if not entry:
+                util.con_err(
+                    util.ConsoleRed, 'Encountered an error while computing new dependencies: ',
+                    'A new dependent file was discovered, but it exists in the output folder, and ',
+                    'no corresponding command creates this file. One of the followeing might have ',
+                    'occurred: \n',
+                    ' (1) The file was created outside of AMBuild, which is not supported.\n',
+                    ' (2) The file was created by a custom AMBuild command, but was not specified as an output.\n',
+                    util.ConsoleNormal)
+                util.con_err(util.ConsoleRed, 'Path: ', util.ConsoleBlue, rel_to_objdir,
+                             util.ConsoleNormal)
+                return None
+            return entry
 
-    return self.cx.db.add_source(path)
+        return self.cx.db.add_source(path)
 
-  def discoverEntries(self, discovered_paths):
-    discovered_set = set()
-    for path in discovered_paths:
-      entry = self.cx.db.query_path(path)
-      if not entry:
-        entry = self.addDiscoveredSource(path)
-        if not entry:
-          return None
+    def discoverEntries(self, discovered_paths):
+        discovered_set = set()
+        for path in discovered_paths:
+            entry = self.cx.db.query_path(path)
+            if not entry:
+                entry = self.addDiscoveredSource(path)
+                if not entry:
+                    return None
 
-      if entry.type != nodetypes.Source and entry.type != nodetypes.Output:
-        util.con_err(
-          util.ConsoleRed,
-          'Fatal error in DAG construction! Dependency is not a file input.',
-          util.ConsoleNormal
-        )
-        util.con_err(util.ConsoleRed, 'Path: ', util.ConsoleBlue, path, util.ConsoleNormal)
-        return None
+            if entry.type != nodetypes.Source and entry.type != nodetypes.Output:
+                util.con_err(util.ConsoleRed,
+                             'Fatal error in DAG construction! Dependency is not a file input.',
+                             util.ConsoleNormal)
+                util.con_err(util.ConsoleRed, 'Path: ', util.ConsoleBlue, path, util.ConsoleNormal)
+                return None
 
-      discovered_set.add(entry)
+            discovered_set.add(entry)
 
-    return discovered_set
+        return discovered_set
 
-  def findPath(self, source, target):
-    # We search the graph from the target, since we assume there are fewer
-    # predecessor links than successor links that way.
-    assert source != target
+    def findPath(self, source, target):
+        # We search the graph from the target, since we assume there are fewer
+        # predecessor links than successor links that way.
+        assert source != target
 
-    queue = set([target])
-    seen = set()
-    while len(queue):
-      node = queue.pop()
+        queue = set([target])
+        seen = set()
+        while len(queue):
+            node = queue.pop()
 
-      # Once again, exclude dynamic inputs, it doesn't seem to make sense that
-      # they'd reliably participate in this algorithm.
-      strong_inputs = self.cx.db.query_strong_inputs(node)
-      if source in strong_inputs:
-        return True
-      weak_inputs = self.cx.db.query_weak_inputs(node)
-      if source in weak_inputs:
-        return True
+            # Once again, exclude dynamic inputs, it doesn't seem to make sense that
+            # they'd reliably participate in this algorithm.
+            strong_inputs = self.cx.db.query_strong_inputs(node)
+            if source in strong_inputs:
+                return True
+            weak_inputs = self.cx.db.query_weak_inputs(node)
+            if source in weak_inputs:
+                return True
 
-      new_nodes = (strong_inputs - seen) | (weak_inputs - seen)
-      seen |= new_nodes
-      queue |= new_nodes
+            new_nodes = (strong_inputs - seen) | (weak_inputs - seen)
+            seen |= new_nodes
+            queue |= new_nodes
 
-    return False
-
-  def ensureValidDependency(self, source, target):
-    # Build the set of nodes that are valid connectors for the dependency. For
-    # cxx and cpa commands, the exact dependencies are determined by AMB2, so
-    # we don't allow the user to attach arbitrary strong dependencies; they
-    # are always weak.
-    roots = set()
-
-    inputs = self.cx.db.query_weak_inputs(target)
-    if not nodetypes.HasAutoDependencies(target.type):
-      # Exclude dynamic inputs since they weren't specified in the build.
-      inputs |= self.cx.db.query_strong_inputs(target)
-
-    for input in inputs:
-      if input == source:
-        return True
-
-      if self.findPath(source, input):
-        return True
-
-    # There is no explicit ordering defined between these two nodes; we have
-    # abort the build.
-    util.con_err(
-      util.ConsoleRed,
-      'Encountered an error while computing new dependencies: ' ,
-      'A new dependency was discovered that exists as an output from another build step. ',
-      'However, there is no explicit dependency between that path and this command. ',
-      'The build must abort since the ordering of these two steps is undefined. ',
-      util.ConsoleNormal
-    )
-    util.con_err(
-      util.ConsoleRed,
-      'Dependency: ',
-      util.ConsoleBlue,
-      source.path,
-      util.ConsoleNormal
-    )
-    return False
-
-  def mergeDependencies(self, cmd_node, discovered_paths):
-    # Grab nodes for each dependency.
-    discovered_set = self.discoverEntries(discovered_paths)
-    if discovered_set is None:
-      return False
-
-    strong_inputs = self.cx.db.query_strong_inputs(cmd_node.entry)
-    dynamic_inputs = self.cx.db.query_dynamic_inputs(cmd_node.entry)
-
-    # Any inputs that were not inputs before, should be linked via the
-    # dynamic edge table now. If the new input is an output (i.e. a
-    # generated file), we have to ensure that there is a valid ordering
-    # between the two.
-    for added in (discovered_set - dynamic_inputs):
-      # Generally the set of dynamic inputs will be larger than the set of
-      # strong inputs, so perform the set difference against the larger set,
-      # and strong set membership manually here.
-      if added in strong_inputs:
-        continue
-
-      if added.type != nodetypes.Source:
-        assert added.type == nodetypes.Output
-        if not self.ensureValidDependency(added, cmd_node.entry):
-          return False
-
-      # Add the edge.
-      self.cx.db.add_dynamic_edge(added, cmd_node.entry)
-
-    # Remove any dynamic links that are no longer needed.
-    for removed in (dynamic_inputs - discovered_set):
-      self.cx.db.drop_dynamic_edge(removed, cmd_node.entry)
-
-    # Update the timestamps of the files we used.
-    for entry in discovered_set:
-      self.lazyUpdateEntry(entry)
-
-    return True
-
-  def updateGraph(self, task_id, updates, message):
-    if not self.commands[task_id]:
-      util.con_err(
-        util.ConsoleRed,
-        'Received update for task_id {0} that was already completed!\n'.format(task_id),
-        util.ConsoleBlue,
-        'Message details:\n',
-        util.ConsoleNormal,
-        '{0}'.format(message)
-      )
-      return False
-
-    node = self.commands[task_id]
-    self.commands[task_id] = None
-
-    if 'deps' in message:
-      if not self.mergeDependencies(node, message['deps']):
         return False
 
-    if node.entry.dirty != nodetypes.ALWAYS_DIRTY:
-      for incoming in self.cx.db.query_strong_inputs(node.entry):
-        self.lazyUpdateEntry(incoming)
-      for incoming in self.cx.db.query_dynamic_inputs(node.entry):
-        self.lazyUpdateEntry(incoming)
+    def ensureValidDependency(self, source, target):
+        # Build the set of nodes that are valid connectors for the dependency. For
+        # cxx and cpa commands, the exact dependencies are determined by AMB2, so
+        # we don't allow the user to attach arbitrary strong dependencies; they
+        # are always weak.
+        roots = set()
 
-      for path, stamp in updates:
-        entry = self.cx.db.query_path(path)
-        self.cx.db.unmark_dirty(entry, stamp)
-      self.cx.db.unmark_dirty(node.entry)
+        inputs = self.cx.db.query_weak_inputs(target)
+        if not nodetypes.HasAutoDependencies(target.type):
+            # Exclude dynamic inputs since they weren't specified in the build.
+            inputs |= self.cx.db.query_strong_inputs(target)
 
-    self.num_completed_tasks += 1
-    return True
+        for input in inputs:
+            if input == source:
+                return True
 
+            if self.findPath(source, input):
+                return True
+
+        # There is no explicit ordering defined between these two nodes; we have
+        # abort the build.
+        util.con_err(
+            util.ConsoleRed, 'Encountered an error while computing new dependencies: ',
+            'A new dependency was discovered that exists as an output from another build step. ',
+            'However, there is no explicit dependency between that path and this command. ',
+            'The build must abort since the ordering of these two steps is undefined. ',
+            util.ConsoleNormal)
+        util.con_err(util.ConsoleRed, 'Dependency: ', util.ConsoleBlue, source.path,
+                     util.ConsoleNormal)
+        return False
+
+    def mergeDependencies(self, cmd_node, discovered_paths):
+        # Grab nodes for each dependency.
+        discovered_set = self.discoverEntries(discovered_paths)
+        if discovered_set is None:
+            return False
+
+        strong_inputs = self.cx.db.query_strong_inputs(cmd_node.entry)
+        dynamic_inputs = self.cx.db.query_dynamic_inputs(cmd_node.entry)
+
+        # Any inputs that were not inputs before, should be linked via the
+        # dynamic edge table now. If the new input is an output (i.e. a
+        # generated file), we have to ensure that there is a valid ordering
+        # between the two.
+        for added in (discovered_set - dynamic_inputs):
+            # Generally the set of dynamic inputs will be larger than the set of
+            # strong inputs, so perform the set difference against the larger set,
+            # and strong set membership manually here.
+            if added in strong_inputs:
+                continue
+
+            if added.type != nodetypes.Source:
+                assert added.type == nodetypes.Output
+                if not self.ensureValidDependency(added, cmd_node.entry):
+                    return False
+
+            # Add the edge.
+            self.cx.db.add_dynamic_edge(added, cmd_node.entry)
+
+        # Remove any dynamic links that are no longer needed.
+        for removed in (dynamic_inputs - discovered_set):
+            self.cx.db.drop_dynamic_edge(removed, cmd_node.entry)
+
+        # Update the timestamps of the files we used.
+        for entry in discovered_set:
+            self.lazyUpdateEntry(entry)
+
+        return True
+
+    def updateGraph(self, task_id, updates, message):
+        if not self.commands[task_id]:
+            util.con_err(
+                util.ConsoleRed,
+                'Received update for task_id {0} that was already completed!\n'.format(task_id),
+                util.ConsoleBlue, 'Message details:\n', util.ConsoleNormal, '{0}'.format(message))
+            return False
+
+        node = self.commands[task_id]
+        self.commands[task_id] = None
+
+        if 'deps' in message:
+            if not self.mergeDependencies(node, message['deps']):
+                return False
+
+        if node.entry.dirty != nodetypes.ALWAYS_DIRTY:
+            for incoming in self.cx.db.query_strong_inputs(node.entry):
+                self.lazyUpdateEntry(incoming)
+            for incoming in self.cx.db.query_dynamic_inputs(node.entry):
+                self.lazyUpdateEntry(incoming)
+
+            for path, stamp in updates:
+                entry = self.cx.db.query_path(path)
+                self.cx.db.unmark_dirty(entry, stamp)
+            self.cx.db.unmark_dirty(node.entry)
+
+        self.num_completed_tasks += 1
+        return True

--- a/ambuild2/context.py
+++ b/ambuild2/context.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import time
@@ -24,153 +24,147 @@ from ambuild2.task import Task, TaskMaster
 from optparse import OptionParser
 
 class Context(object):
-  def __init__(self, buildPath, options, args):
-    self.buildPath = buildPath
-    self.options = options
-    self.args = args
-    self.cacheFolder = os.path.join(buildPath, '.ambuild2')
-    self.dbpath = os.path.join(self.cacheFolder, 'graph')
+    def __init__(self, buildPath, options, args):
+        self.buildPath = buildPath
+        self.options = options
+        self.args = args
+        self.cacheFolder = os.path.join(buildPath, '.ambuild2')
+        self.dbpath = os.path.join(self.cacheFolder, 'graph')
 
-    # This doesn't completely work yet because it's not communicated to child
-    # processes. We'll have to send a message down or up to fix this.
-    if self.options.no_color:
-      util.DisableConsoleColors()
+        # This doesn't completely work yet because it's not communicated to child
+        # processes. We'll have to send a message down or up to fix this.
+        if self.options.no_color:
+            util.DisableConsoleColors()
 
-    with open(os.path.join(self.cacheFolder, 'vars'), 'rb') as fp:
-      try:
-        self.vars = util.pickle.load(fp)
-      except ValueError as exn:
-        sys.stderr.write('Build was configured with Python 3; use python3 instead.\n')
-        sys.exit(1)
-      except Exception as exn:
-        if os.path.exists(os.path.join(self.cacheFolder, 'vars')):
-          sys.stderr.write('There does not appear to be a build configured here.\n')
-        else:
-          sys.stderr.write('The build configured here looks corrupt; you will have to delete your objdir.\n')
-        raise
-        sys.exit(1)
+        with open(os.path.join(self.cacheFolder, 'vars'), 'rb') as fp:
+            try:
+                self.vars = util.pickle.load(fp)
+            except ValueError as exn:
+                sys.stderr.write('Build was configured with Python 3; use python3 instead.\n')
+                sys.exit(1)
+            except Exception as exn:
+                if os.path.exists(os.path.join(self.cacheFolder, 'vars')):
+                    sys.stderr.write('There does not appear to be a build configured here.\n')
+                else:
+                    sys.stderr.write(
+                        'The build configured here looks corrupt; you will have to delete your objdir.\n'
+                    )
+                raise
+                sys.exit(1)
 
-    self.restore_environment()
+        self.restore_environment()
 
-    self.db = database.Database(self.dbpath)
-    self.procman = ProcessManager()
-    self.db.connect()
+        self.db = database.Database(self.dbpath)
+        self.procman = ProcessManager()
+        self.db.connect()
 
-  def __enter__(self):
-    return self
+    def __enter__(self):
+        return self
 
-  def __exit__(self, type, value, traceback):
-    self.procman.shutdown()
-    self.db.close()
+    def __exit__(self, type, value, traceback):
+        self.procman.shutdown()
+        self.db.close()
 
-  # Restore important environment properties that were present when this
-  # build was configured.
-  def restore_environment(self):
-    if 'env' not in self.vars:
-      return
+    # Restore important environment properties that were present when this
+    # build was configured.
+    def restore_environment(self):
+        if 'env' not in self.vars:
+            return
 
-    env = self.vars['env']
-    for key in env:
-      os.environ[key] = env[key]
+        env = self.vars['env']
+        for key in env:
+            os.environ[key] = env[key]
 
-  def reconfigure(self):
-    # See if we need to reconfigure.
-    files = []
-    reconfigure_needed = False
-    self.db.query_scripts(lambda row,path,stamp: files.append((path, stamp)))
-    for path, stamp in files:
-      if not os.path.exists(path) or os.path.getmtime(path) > stamp:
-        reconfigure_needed = True
-        break
+    def reconfigure(self):
+        # See if we need to reconfigure.
+        files = []
+        reconfigure_needed = False
+        self.db.query_scripts(lambda row, path, stamp: files.append((path, stamp)))
+        for path, stamp in files:
+            if not os.path.exists(path) or os.path.getmtime(path) > stamp:
+                reconfigure_needed = True
+                break
 
-    if not reconfigure_needed:
-      return True
+        if not reconfigure_needed:
+            return True
 
-    util.con_out(
-      util.ConsoleHeader,
-      'Reparsing build scripts.',
-      util.ConsoleNormal
-    )
+        util.con_out(util.ConsoleHeader, 'Reparsing build scripts.', util.ConsoleNormal)
 
-    # The database should be upgraded here, so we should always have an
-    # API version set.
-    api_version = self.db.query_var('api_version')
-    assert api_version is not None
+        # The database should be upgraded here, so we should always have an
+        # API version set.
+        api_version = self.db.query_var('api_version')
+        assert api_version is not None
 
-    if api_version == '2.0':
-      from ambuild2.frontend.v2_0.amb2.gen import Generator
-    elif api_version == '2.1':
-      from ambuild2.frontend.v2_1.amb2 import Generator
+        if api_version == '2.0':
+            from ambuild2.frontend.v2_0.amb2.gen import Generator
+        elif api_version == '2.1':
+            from ambuild2.frontend.v2_1.amb2 import Generator
 
-    gen = Generator.FromVars(self.vars, self.db, self.options.refactor)
-    try:
-      gen.generate()
-    except:
-      traceback.print_exc()
-      util.con_err(
-        util.ConsoleRed,
-        'Failed to reparse build scripts.',
-        util.ConsoleNormal
-      )
-      return False
+        gen = Generator.FromVars(self.vars, self.db, self.options.refactor)
+        try:
+            gen.generate()
+        except:
+            traceback.print_exc()
+            util.con_err(util.ConsoleRed, 'Failed to reparse build scripts.', util.ConsoleNormal)
+            return False
 
-    # We flush the node cache after this, since database.py expects to get
-    # never-before-seen items at the start. We could change this and make
-    # nodes individually import, which might be cleaner.
-    self.db.flush_caches()
+        # We flush the node cache after this, since database.py expects to get
+        # never-before-seen items at the start. We could change this and make
+        # nodes individually import, which might be cleaner.
+        self.db.flush_caches()
 
-    return True
+        return True
 
-  def Build(self):
-    if not self.reconfigure():
-      return False
+    def Build(self):
+        if not self.reconfigure():
+            return False
 
-    return self.build_internal()
+        return self.build_internal()
 
-  def build_internal(self):
-    if self.options.show_graph:
-      self.db.printGraph()
-      return True
+    def build_internal(self):
+        if self.options.show_graph:
+            self.db.printGraph()
+            return True
 
-    if self.options.show_changed:
-      dmg_list = damage.ComputeDamageGraph(self.db, only_changed=True)
-      for entry in dmg_list:
-        if not entry.isFile():
-          continue
-        print(entry.format())
-      return True
+        if self.options.show_changed:
+            dmg_list = damage.ComputeDamageGraph(self.db, only_changed = True)
+            for entry in dmg_list:
+                if not entry.isFile():
+                    continue
+                print(entry.format())
+            return True
 
-    dmg_graph = damage.ComputeDamageGraph(self.db)
-    if not dmg_graph:
-      return False
+        dmg_graph = damage.ComputeDamageGraph(self.db)
+        if not dmg_graph:
+            return False
 
-    # If we get here, we have to compute damage.
-    if self.options.show_damage:
-      dmg_graph.printGraph()
-      return True
+        # If we get here, we have to compute damage.
+        if self.options.show_damage:
+            dmg_graph.printGraph()
+            return True
 
-    dmg_graph.filter_commands()
+        dmg_graph.filter_commands()
 
-    if self.options.show_commands:
-      dmg_graph.printGraph()
-      return True
-    
-    builder = Builder(self, dmg_graph)
-    if self.options.show_steps:
-      builder.printSteps()
-      return True
+        if self.options.show_commands:
+            dmg_graph.printGraph()
+            return True
 
-    status = builder.update()
-    if status == TaskMaster.BUILD_FAILED:
-      util.con_err(util.ConsoleHeader, 'Build failed.', util.ConsoleNormal)
-      return False
-    if status == TaskMaster.BUILD_INTERRUPTED:
-      util.con_err(util.ConsoleHeader, 'Build cancelled.', util.ConsoleNormal)
-      return False
-    if status == TaskMaster.BUILD_NO_CHANGES:
-      util.con_out(util.ConsoleHeader, 'Build succeeded, no changes.', util.ConsoleNormal)
-      return True
+        builder = Builder(self, dmg_graph)
+        if self.options.show_steps:
+            builder.printSteps()
+            return True
 
-    assert status == TaskMaster.BUILD_SUCCEEDED
-    util.con_out(util.ConsoleHeader, 'Build succeeded.', util.ConsoleNormal)
-    return True
+        status = builder.update()
+        if status == TaskMaster.BUILD_FAILED:
+            util.con_err(util.ConsoleHeader, 'Build failed.', util.ConsoleNormal)
+            return False
+        if status == TaskMaster.BUILD_INTERRUPTED:
+            util.con_err(util.ConsoleHeader, 'Build cancelled.', util.ConsoleNormal)
+            return False
+        if status == TaskMaster.BUILD_NO_CHANGES:
+            util.con_out(util.ConsoleHeader, 'Build succeeded, no changes.', util.ConsoleNormal)
+            return True
+
+        assert status == TaskMaster.BUILD_SUCCEEDED
+        util.con_out(util.ConsoleHeader, 'Build succeeded.', util.ConsoleNormal)
+        return True

--- a/ambuild2/damage.py
+++ b/ambuild2/damage.py
@@ -1,17 +1,17 @@
 # vim: set sts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -20,85 +20,87 @@ from ambuild2 import nodetypes
 from ambuild2.graph import Graph
 
 def ComputeSourceDirty(node):
-  if not os.path.exists(node.path):
-    return True
+    if not os.path.exists(node.path):
+        return True
 
-  return os.path.getmtime(node.path) != node.stamp
+    return os.path.getmtime(node.path) != node.stamp
 
 def ComputeOutputDirty(node):
-  if not os.path.exists(node.path):
-    return True
+    if not os.path.exists(node.path):
+        return True
 
-  # If the timestamp on the object file has changed, then one of two things
-  # happened:
-  #  (1) The build command completed, but the build process crashed, and we
-  #      never got a chance to update the timestamp.
-  #  (2) The file was modified behind our back.
-  #
-  # In the first case, our preceding command node will not have been undirtied,
-  # so we should be able to find our incoming command in the graph. However,
-  # case #2 breaks that guarantee. To be safe, if the timestamp has changed,
-  # we mark the node as dirty.
-  stamp = os.path.getmtime(node.path)
-  return stamp != node.stamp
+    # If the timestamp on the object file has changed, then one of two things
+    # happened:
+    #  (1) The build command completed, but the build process crashed, and we
+    #      never got a chance to update the timestamp.
+    #  (2) The file was modified behind our back.
+    #
+    # In the first case, our preceding command node will not have been undirtied,
+    # so we should be able to find our incoming command in the graph. However,
+    # case #2 breaks that guarantee. To be safe, if the timestamp has changed,
+    # we mark the node as dirty.
+    stamp = os.path.getmtime(node.path)
+    return stamp != node.stamp
 
 def ComputeDirty(node):
-  if node.type == nodetypes.Source:
-    dirty = ComputeSourceDirty(node)
-  elif node.type == nodetypes.Output:
-    dirty = ComputeOutputDirty(node)
-  else:
-    raise Exception('cannot compute dirty bit for node type: ' + node.type)
-  return dirty
-
-def ComputeDamageGraph(database, only_changed = False):
-  graph = Graph(database)
-
-  def maybe_mkdir(node):
-    if not os.path.exists(node.path):
-      graph.create.append(node)
-  database.query_mkdir(maybe_mkdir)
-
-  dirty = []
-
-  def maybe_add_dirty(node):
-    if ComputeDirty(node):
-      database.mark_dirty(node)
-      dirty.append(node)
-
-  database.query_known_dirty(lambda node: dirty.append(node))
-  database.query_maybe_dirty(maybe_add_dirty)
-
-  if only_changed:
+    if node.type == nodetypes.Source:
+        dirty = ComputeSourceDirty(node)
+    elif node.type == nodetypes.Output:
+        dirty = ComputeOutputDirty(node)
+    else:
+        raise Exception('cannot compute dirty bit for node type: ' + node.type)
     return dirty
 
-  for entry in dirty:
-    if entry.type == nodetypes.Output:
-      # Ensure that our command has been marked as dirty.
-      incoming = database.query_strong_inputs(entry)
-      incoming |= database.query_dynamic_inputs(entry)
+def ComputeDamageGraph(database, only_changed = False):
+    graph = Graph(database)
 
-      # There should really only be one command to generate an output.
-      if len(incoming) != 1:
-        sys.stderr.write('Error in dependency graph: an output has multiple inputs.')
-        sys.stderr.write('Output: {0}'.format(entry.format()))
-        return None
+    def maybe_mkdir(node):
+        if not os.path.exists(node.path):
+            graph.create.append(node)
 
-      for cmd in incoming:
-        graph.addEntry(cmd)
-    else:
-      graph.addEntry(entry)
+    database.query_mkdir(maybe_mkdir)
 
-  graph.finish()
+    dirty = []
 
-  # Find all leaf commands in the graph and mark them as dirty. This ensures
-  # that we'll include them in the next damage graph. In theory, all leaf
-  # commands should *already* be dirty, so this is just in case.
-  def finish_mark_dirty(entry):
-    if entry.dirty == nodetypes.NOT_DIRTY:
-      # Mark this node as dirty in the DB so we don't have to check the
-      # filesystem next time.
-      database.mark_dirty(entry)
-  graph.for_each_leaf_command(finish_mark_dirty)
+    def maybe_add_dirty(node):
+        if ComputeDirty(node):
+            database.mark_dirty(node)
+            dirty.append(node)
 
-  return graph
+    database.query_known_dirty(lambda node: dirty.append(node))
+    database.query_maybe_dirty(maybe_add_dirty)
+
+    if only_changed:
+        return dirty
+
+    for entry in dirty:
+        if entry.type == nodetypes.Output:
+            # Ensure that our command has been marked as dirty.
+            incoming = database.query_strong_inputs(entry)
+            incoming |= database.query_dynamic_inputs(entry)
+
+            # There should really only be one command to generate an output.
+            if len(incoming) != 1:
+                sys.stderr.write('Error in dependency graph: an output has multiple inputs.')
+                sys.stderr.write('Output: {0}'.format(entry.format()))
+                return None
+
+            for cmd in incoming:
+                graph.addEntry(cmd)
+        else:
+            graph.addEntry(entry)
+
+    graph.finish()
+
+    # Find all leaf commands in the graph and mark them as dirty. This ensures
+    # that we'll include them in the next damage graph. In theory, all leaf
+    # commands should *already* be dirty, so this is just in case.
+    def finish_mark_dirty(entry):
+        if entry.dirty == nodetypes.NOT_DIRTY:
+            # Mark this node as dirty in the DB so we don't have to check the
+            # filesystem next time.
+            database.mark_dirty(entry)
+
+    graph.for_each_leaf_command(finish_mark_dirty)
+
+    return graph

--- a/ambuild2/frontend/msvc_utils.py
+++ b/ambuild2/frontend/msvc_utils.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import collections
@@ -46,6 +46,7 @@ class MSVCFinder(object):
 
         def sort_by_version(install):
             return install.version
+
         self.installs_.sort(key = sort_by_version, reverse = True)
 
         return self.installs_
@@ -66,9 +67,12 @@ class MSVCFinder(object):
             return
         argv = [
             vswhere,
-            '-format', 'json',
-            '-products', '*',
-            '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+            '-format',
+            'json',
+            '-products',
+            '*',
+            '-requires',
+            'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
         ]
         try:
             output = subprocess.check_output(argv)
@@ -144,7 +148,7 @@ def parse_env(text):
         if first_eq == -1:
             env[line.upper()] = ''
         else:
-            key = line[0 : first_eq]
+            key = line[0:first_eq]
             value = line[first_eq + 1:]
             env[key.upper()] = value
     return env

--- a/ambuild2/frontend/paths.py
+++ b/ambuild2/frontend/paths.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -22,46 +22,45 @@ from ambuild2 import util
 #
 # The parent folder and resolved folder are returned as a tuple.
 def ResolveFolder(parent, folder):
-  parent_path = ''
-  if parent:
-    parent_path = parent.path
-  path = os.path.normpath(os.path.join(parent_path, folder))
+    parent_path = ''
+    if parent:
+        parent_path = parent.path
+    path = os.path.normpath(os.path.join(parent_path, folder))
 
-  if path.startswith('..'):
-    util.con_err(
-      util.ConsoleRed, 'Output path ',
-      util.ConsoleBlue, path,
-      util.ConsoleRed, ' is outside the build folder!',
-      util.ConsoleNormal
-    )
-    raise Exception('Cannot generate folders outside the build folder')
+    if path.startswith('..'):
+        util.con_err(util.ConsoleRed, 'Output path ', util.ConsoleBlue, path, util.ConsoleRed,
+                     ' is outside the build folder!', util.ConsoleNormal)
+        raise Exception('Cannot generate folders outside the build folder')
 
-  return parent_path, path
+    return parent_path, path
 
 def Join(*nodes):
-  paths = []
-  for node in nodes:
-    if node is None:
-      continue
-    if util.IsString(node):
-      paths.append(node)
-    else:
-      paths.append(node.path)
-  return os.path.join(*paths)
+    paths = []
+    for node in nodes:
+        if node is None:
+            continue
+        if util.IsString(node):
+            paths.append(node)
+        else:
+            paths.append(node.path)
+    return os.path.join(*paths)
 
 def IsSubPath(other, folder, path_module = os.path):
-  other = path_module.abspath(other)
-  folder = path_module.abspath(folder)
+    other = path_module.abspath(other)
+    folder = path_module.abspath(folder)
 
-  drive1, _ = path_module.splitdrive(other)
-  drive2, _ = path_module.splitdrive(folder)
-  if drive1 != drive2:
-    return False
+    drive1, _ = path_module.splitdrive(other)
+    drive2, _ = path_module.splitdrive(folder)
+    if drive1 != drive2:
+        return False
 
-  relative = path_module.relpath(other, folder)
-  if relative.startswith(os.pardir): # Short-circuit on '..' -OR- '../', this is always pointing outside of "folder".
-    return False
-  elif relative.startswith(os.curdir): # Short-circuit on '.' -OR- './', this is always pointing to a child item.
-    return True
+    relative = path_module.relpath(other, folder)
+    if relative.startswith(
+            os.pardir
+    ):  # Short-circuit on '..' -OR- '../', this is always pointing outside of "folder".
+        return False
+    elif relative.startswith(
+            os.curdir):  # Short-circuit on '.' -OR- './', this is always pointing to a child item.
+        return True
 
-  return other.startswith(folder) # In most cases, we shouldn't ever arrive to this point.
+    return other.startswith(folder)  # In most cases, we shouldn't ever arrive to this point.

--- a/ambuild2/frontend/paths_test.py
+++ b/ambuild2/frontend/paths_test.py
@@ -1,4 +1,4 @@
-# vim: set sts=4 ts=8 sw=4 tw=99 et: 
+# vim: set sts=4 ts=8 sw=4 tw=99 et:
 import ntpath
 import unittest
 from ambuild2.frontend import paths

--- a/ambuild2/frontend/system.py
+++ b/ambuild2/frontend/system.py
@@ -1,33 +1,33 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from ambuild2 import util
 
 class System(object):
-  def __init__(self, platform, arch):
-    super(System, self).__init__()
-    self.platform_ = platform
-    self.arch_ = arch
+    def __init__(self, platform, arch):
+        super(System, self).__init__()
+        self.platform_ = platform
+        self.arch_ = arch
 
-  @property
-  def platform(self):
-    return self.platform_
+    @property
+    def platform(self):
+        return self.platform_
 
-  @property
-  def arch(self):
-    return self.arch_
+    @property
+    def arch(self):
+        return self.arch_
 
 System.Host = System(util.Platform(), util.Architecture)

--- a/ambuild2/frontend/v2_0/amb2/gen.py
+++ b/ambuild2/frontend/v2_0/amb2/gen.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -24,749 +24,724 @@ from ambuild2.frontend.v2_0.cpp import detect
 from ambuild2.frontend.v2_0.base import BaseGenerator
 
 class Generator(BaseGenerator):
-  def __init__(self, sourcePath, buildPath, originalCwd, options, args, db=None, refactoring=False):
-    super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
-    self.cacheFolder = os.path.join(self.buildPath, '.ambuild2')
-    self.old_scripts_ = set()
-    self.old_folders_ = set()
-    self.old_commands_ = set()
-    self.rm_list_ = []
-    self.bad_outputs_ = set()
-    self.db = db
-    self.is_bootstrap = not self.db
-    self.refactoring = refactoring
-    self.compiler = None
-    self.symlink_support = False
-    self.had_symlink_fallback = False
+    def __init__(self,
+                 sourcePath,
+                 buildPath,
+                 originalCwd,
+                 options,
+                 args,
+                 db = None,
+                 refactoring = False):
+        super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
+        self.cacheFolder = os.path.join(self.buildPath, '.ambuild2')
+        self.old_scripts_ = set()
+        self.old_folders_ = set()
+        self.old_commands_ = set()
+        self.rm_list_ = []
+        self.bad_outputs_ = set()
+        self.db = db
+        self.is_bootstrap = not self.db
+        self.refactoring = refactoring
+        self.compiler = None
+        self.symlink_support = False
+        self.had_symlink_fallback = False
 
-  @property
-  def backend(self):
-    return 'amb2'
+    @property
+    def backend(self):
+        return 'amb2'
 
-  @classmethod
-  def FromVars(cls, vars, db, refactoring):
-    # Backwards compatibility: for an automatic reconfigure on an older build,
-    # just assume the source path is the cwd. If the AMBuildScript suddenly
-    # has decided to depend on originalCwd, then the user may have to manually
-    # run configure.py again, until we remove configure.py entirely.
-    if 'originalCwd' in vars:
-      originalCwd = vars['originalCwd']
-    else:
-      originalCwd = vars['sourcePath']
+    @classmethod
+    def FromVars(cls, vars, db, refactoring):
+        # Backwards compatibility: for an automatic reconfigure on an older build,
+        # just assume the source path is the cwd. If the AMBuildScript suddenly
+        # has decided to depend on originalCwd, then the user may have to manually
+        # run configure.py again, until we remove configure.py entirely.
+        if 'originalCwd' in vars:
+            originalCwd = vars['originalCwd']
+        else:
+            originalCwd = vars['sourcePath']
 
-    gen = cls(
-      sourcePath = vars['sourcePath'],
-      buildPath = vars['buildPath'],
-      originalCwd = originalCwd,
-      options = vars['options'],
-      args = vars['args'],
-      db = db,
-      refactoring = refactoring
-    )
-    return gen
+        gen = cls(sourcePath = vars['sourcePath'],
+                  buildPath = vars['buildPath'],
+                  originalCwd = originalCwd,
+                  options = vars['options'],
+                  args = vars['args'],
+                  db = db,
+                  refactoring = refactoring)
+        return gen
 
-  def preGenerate(self):
-    if not os.path.isdir(self.cacheFolder):
-      os.mkdir(self.cacheFolder)
-    if not self.db:
-      db_path = os.path.join(self.cacheFolder, 'graph')
-      if not os.path.isfile(db_path):
-        self.db = database.CreateDatabase(db_path)
-      else:
-        self.db = database.Database(db_path)
-        self.db.connect()
+    def preGenerate(self):
+        if not os.path.isdir(self.cacheFolder):
+            os.mkdir(self.cacheFolder)
+        if not self.db:
+            db_path = os.path.join(self.cacheFolder, 'graph')
+            if not os.path.isfile(db_path):
+                self.db = database.CreateDatabase(db_path)
+            else:
+                self.db = database.Database(db_path)
+                self.db.connect()
 
-    self.symlink_support = util.DetectSymlinkSupport()
+        self.symlink_support = util.DetectSymlinkSupport()
 
-    self.db.query_scripts(lambda id,path,stamp: self.old_scripts_.add(path))
-    self.db.query_mkdir(lambda entry: self.old_folders_.add(entry))
-    self.db.query_commands(lambda entry: self.old_commands_.add(entry))
-    self.db.set_var('api_version', '2.0')
+        self.db.query_scripts(lambda id, path, stamp: self.old_scripts_.add(path))
+        self.db.query_mkdir(lambda entry: self.old_folders_.add(entry))
+        self.db.query_commands(lambda entry: self.old_commands_.add(entry))
+        self.db.set_var('api_version', '2.0')
 
-  def cleanup(self):
-    for path in self.rm_list_:
-      util.rm_path(path)
+    def cleanup(self):
+        for path in self.rm_list_:
+            util.rm_path(path)
 
-    for cmd_entry in self.old_commands_:
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'Command removed during refactoring: \n',
-                     util.ConsoleBlue, cmd_entry.format(),
+        for cmd_entry in self.old_commands_:
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'Command removed during refactoring: \n',
+                             util.ConsoleBlue, cmd_entry.format(), util.ConsoleNormal)
+                raise Exception('Refactoring error: command removed')
+            self.db.drop_command(cmd_entry)
+
+        for path in self.old_scripts_:
+            self.db.drop_script(path)
+
+        self.db.query_dead_sources(lambda e: self.db.drop_source(e))
+        self.db.query_dead_shared_outputs(lambda e: self.db.drop_output(e))
+
+        class Node:
+            def __init__(self):
+                self.incoming = set()
+                self.outgoing = set()
+
+        # Build a tree of dead folders.
+        tracker = {}
+        for entry in self.old_folders_:
+            if entry not in tracker:
+                tracker[entry] = Node()
+
+            if entry.folder is None:
+                continue
+
+            # If our parent is not a dead folder, don't create an edge. It should be
+            # impossible for a/b to be dead, a/b/c to be alive, and a/b/c/d to be
+            # dead, since a/b/c will implicitly keep a/b alive.
+            if entry.folder not in self.old_folders_:
+                continue
+
+            if entry.folder not in tracker:
+                tracker[entry.folder] = Node()
+
+            parent = tracker[entry.folder]
+            child = tracker[entry]
+            parent.incoming.add(entry)
+            child.outgoing.add(entry.folder)
+
+        # Find the leaves. Sets start out >= 1 items. Remove them as they they
+        # are empty.
+        dead_folders = [entry for entry in self.old_folders_ if len(tracker[entry].incoming) == 0]
+        while len(dead_folders):
+            child_entry = dead_folders.pop()
+            child_node = tracker[child_entry]
+
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'Folder removed during refactoring: \n',
+                             util.ConsoleBlue, child_entry.format(), util.ConsoleNormal)
+                raise Exception('Refactoring error: command removed')
+
+            self.db.drop_folder(child_entry)
+            for parent_entry in child_node.outgoing:
+                parent_node = tracker[parent_entry]
+                parent_node.incoming.remove(child_entry)
+                if not len(parent_node.incoming):
+                    dead_folders.append(parent_entry)
+
+    def postGenerate(self):
+        self.cleanup()
+        self.db.commit()
+        self.db.vacuum()
+        if self.is_bootstrap:
+            self.saveVars()
+            self.db.close()
+
+        if self.had_symlink_fallback:
+            util.con_out(
+                util.ConsoleHeader,
+                'Note: filesystem does not support symlinks. Files will be copied instead.',
+                util.ConsoleNormal)
+
+    def saveVars(self):
+        vars = {
+            'sourcePath': self.sourcePath,
+            'buildPath': self.buildPath,
+            'originalCwd': self.originalCwd,
+            'options': self.options,
+            'args': self.args
+        }
+
+        # Save any environment variables that are relevant to the build.
+        env = {}
+
+        if self.compiler is not None:
+            # Save env vars that will be needed to reconfigure.
+            for key in self.compiler.EnvVars:
+                if key in os.environ:
+                    env[key] = os.environ[key]
+
+            # Save any extra compiler info that must be communicated to the backend.
+            compilers = [
+                ('cc', self.compiler.cc),
+                ('cxx', self.compiler.cxx),
+            ]
+            for prefix, comp in compilers:
+                for prop_name in comp.extra_props:
+                    key = '{0}_{1}'.format(prefix, prop_name)
+                    vars[key] = comp.extra_props[prop_name]
+
+        vars['env'] = env
+
+        with open(os.path.join(self.cacheFolder, 'vars'), 'wb') as fp:
+            util.DiskPickle(vars, fp)
+
+    def detectCompilers(self):
+        if not self.compiler:
+            with util.FolderChanger(self.cacheFolder):
+                self.base_compiler = detect.DetectCxx(os.environ, self.options)
+                self.compiler = self.base_compiler.clone()
+
+        return self.compiler
+
+    def getLocalFolder(self, context):
+        if type(context.localFolder_) is nodetypes.Entry or context.localFolder_ is None:
+            return context.localFolder_
+
+        if len(context.buildFolder):
+            context.localFolder_ = self.generateFolder(None, context.buildFolder)
+        else:
+            context.localFolder_ = None
+        return context.localFolder_
+
+    def generateFolder(self, parent, folder):
+        parent_path, path = paths.ResolveFolder(parent, folder)
+
+        # Quick check. If this folder is not in our old folder list, and it's in
+        # the DB, then we already have an entry for it that has already negotiated
+        # its parent paths.
+        old_entry = self.db.query_path(path)
+        if old_entry and self.isValidFolderEntry(old_entry):
+            return old_entry
+
+        components = []
+        while folder:
+            folder, name = os.path.split(folder)
+            if not name:
+                break
+            components.append(name)
+
+        path = parent_path
+        while len(components):
+            name = components.pop()
+            path = os.path.join(path, name)
+            entry = self.db.query_path(path)
+            if not entry:
+                if self.refactoring:
+                    util.con_err(util.ConsoleRed, 'New folder introduced: ', util.ConsoleBlue, path,
+                                 util.ConsoleNormal)
+                    raise Exception('Refactoring error: new folder')
+                entry = self.db.add_folder(parent, path)
+            elif entry.type == nodetypes.Output or entry.type == nodetypes.SharedOutput:
+                if entry.type == nodetypes.Output:
+                    cmd_entries = [self.db.query_command_of(entry)]
+                elif entry.type == nodetypes.SharedOutput:
+                    cmd_entries = self.db.query_shared_commands_of(entry)
+
+                for cmd_entry in cmd_entries:
+                    if cmd_entry not in self.old_commands_:
+                        util.con_err(util.ConsoleRed,
+                                     'Folder has the same path as an output file generated by:\n',
+                                     util.ConsoleBlue, cmd_entry.format(), util.ConsoleNormal)
+                        raise Exception('Output has been duplicated: {0}'.format(entry.path))
+
+                if self.refactoring:
+                    util.con_err(util.ConsoleRed, 'Path "', util.ConsoleBlue, entry.path,
+                                 util.ConsoleRed, '" has changed from a file to a folder.',
+                                 util.ConsoleNormal)
+                    raise Exception('Refactoring error: path changed from file to folder')
+
+                self.rm_list_.append(entry.path)
+                self.db.change_to_folder(entry)
+            elif entry.type == nodetypes.Mkdir:
+                # We let the same folder be generated twice, so use discard, not remove.
+                self.old_folders_.discard(entry)
+            else:
+                util.con_err(util.ConsoleRed, 'Folder has the same node signature as: ',
+                             util.ConsoleBlue, entry.format(), util.ConsoleNormal)
+                raise Exception('Output has been duplicated: {0}'.format(entry.path))
+
+            parent = entry
+
+        return entry
+
+    def isValidFolderEntry(self, folder_entry):
+        # If it's a mkdir and it's created, we're done.
+        return folder_entry.type == nodetypes.Mkdir and folder_entry not in self.old_folders_
+
+    def validateOutputFolder(self, path):
+        # Empty path is the root folder, which is null.
+        if not len(path):
+            return None
+
+        # The folder must already exist.
+        folder_entry = self.db.query_path(path)
+        if not folder_entry:
+            util.con_err(util.ConsoleRed, 'Path "', util.ConsoleBlue, path, util.ConsoleRed,
+                         '" specifies a folder that does not exist.', util.ConsoleNormal)
+            raise Exception('path specifies a folder that does not exist')
+
+        if self.isValidFolderEntry(folder_entry):
+            return folder_entry
+
+        # If it's a folder or an output, we can give a better error message.
+        if folder_entry.type == nodetypes.Output or folder_entry.type == nodetypes.Mkdir:
+            util.con_err(util.ConsoleRed, 'Folder "', util.ConsoleBlue, folder_entry.path,
+                         util.ConsoleRed, '" was never created.', util.ConsoleNormal)
+            raise Exception('path {0} was never created', folder_entry.path)
+
+        util.con_err(util.ConsoleRed, 'Attempted to use node "', util.ConsoleBlue,
+                     folder_entry.format(), util.ConsoleRed, '" as a path component.',
                      util.ConsoleNormal)
-        raise Exception('Refactoring error: command removed')
-      self.db.drop_command(cmd_entry)
+        raise Exception('illegal path component')
 
-    for path in self.old_scripts_:
-      self.db.drop_script(path)
+    def parseOutput(self, cwd_entry, path, kind):
+        if path[-1] == os.sep or path[-1] == os.altsep or path == '.' or path == '':
+            util.con_err(util.ConsoleRed, 'Path "', util.ConsoleBlue, path, util.ConsoleRed,
+                         '" looks like a folder; a folder was not expected.', util.ConsoleNormal)
+            raise Exception('Expected folder, but path has a trailing slash')
 
-    self.db.query_dead_sources(lambda e: self.db.drop_source(e))
-    self.db.query_dead_shared_outputs(lambda e: self.db.drop_output(e))
+        path = os.path.normpath(path)
 
-    class Node:
-      def __init__(self):
-        self.incoming = set()
-        self.outgoing = set()
+        path, name = os.path.split(path)
+        path = nodetypes.combine(cwd_entry, path)
 
-    # Build a tree of dead folders.
-    tracker = {}
-    for entry in self.old_folders_:
-      if entry not in tracker:
-        tracker[entry] = Node()
+        # We should have caught a case like 'x/' earlier.
+        assert len(name)
 
-      if entry.folder is None:
-        continue
+        # If we resolved that there is no prefix path, then take this to mean the
+        # root folder.
+        if path:
+            folder_entry = self.validateOutputFolder(path)
+            output_path = os.path.join(path, name)
+        else:
+            folder_entry = None
+            output_path = name
 
-      # If our parent is not a dead folder, don't create an edge. It should be
-      # impossible for a/b to be dead, a/b/c to be alive, and a/b/c/d to be
-      # dead, since a/b/c will implicitly keep a/b alive.
-      if entry.folder not in self.old_folders_:
-        continue
+        entry = self.db.query_path(output_path)
+        if not entry:
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'New output file introduced: ', util.ConsoleBlue,
+                             output_path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
+            return self.db.add_output(folder_entry, output_path, kind)
 
-      if entry.folder not in tracker:
-        tracker[entry.folder] = Node()
+        if entry.type == kind:
+            return entry
 
-      parent = tracker[entry.folder]
-      child = tracker[entry]
-      parent.incoming.add(entry)
-      child.outgoing.add(entry.folder)
+        if entry.type == nodetypes.Mkdir:
+            if entry not in self.old_folders_:
+                util.con_err(util.ConsoleRed, 'A folder is being re-used as an output file: "',
+                             util.ConsoleBlue, entry.path, util.ConsoleRed, '"', util.ConsoleNormal)
+                raise Exception('Attempted to re-use a folder as generated file')
 
-    # Find the leaves. Sets start out >= 1 items. Remove them as they they
-    # are empty.
-    dead_folders = [entry for entry in self.old_folders_ if len(tracker[entry].incoming) == 0]
-    while len(dead_folders):
-      child_entry = dead_folders.pop()
-      child_node = tracker[child_entry]
+            if self.refactoring:
+                util.con_err(util.ConsoleRed,
+                             'A generated folder has changed to a generated file: ',
+                             util.ConsoleBlue, entry.path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
 
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'Folder removed during refactoring: \n',
-                     util.ConsoleBlue, child_entry.format(),
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error: command removed')
+            # We keep the node in old_folders_. This should be okay, since we've
+            # changed the type to Output now. This way we can stick to one folder
+            # deletion routine, since it's fairly complicated.
+        elif entry.type == nodetypes.Output:
+            # If we're asking for a shared output, make sure we can reuse this one.
+            input_cmd = self.db.query_command_of(entry)
+            if input_cmd and input_cmd not in self.old_commands_:
+                util.con_err(util.ConsoleRed, 'First defined with command: ', input_cmd.format(),
+                             util.ConsoleNormal)
+                raise Exception('Existing output cannot be a shared output: {0}'.format(entry.path))
 
-      self.db.drop_folder(child_entry)
-      for parent_entry in child_node.outgoing:
-        parent_node = tracker[parent_entry]
-        parent_node.incoming.remove(child_entry)
-        if not len(parent_node.incoming):
-          dead_folders.append(parent_entry)
-
-  def postGenerate(self):
-    self.cleanup()
-    self.db.commit()
-    self.db.vacuum()
-    if self.is_bootstrap:
-      self.saveVars()
-      self.db.close()
-
-    if self.had_symlink_fallback:
-      util.con_out(util.ConsoleHeader,
-                   'Note: filesystem does not support symlinks. Files will be copied instead.',
-                   util.ConsoleNormal)
-
-  def saveVars(self):
-    vars = {
-      'sourcePath': self.sourcePath,
-      'buildPath': self.buildPath,
-      'originalCwd': self.originalCwd,
-      'options': self.options,
-      'args': self.args
-    }
-
-    # Save any environment variables that are relevant to the build.
-    env = {}
-
-    if self.compiler is not None:
-      # Save env vars that will be needed to reconfigure.
-      for key in self.compiler.EnvVars:
-        if key in os.environ:
-          env[key] = os.environ[key]
-
-      # Save any extra compiler info that must be communicated to the backend.
-      compilers = [
-        ('cc', self.compiler.cc),
-        ('cxx', self.compiler.cxx),
-      ]
-      for prefix, comp in compilers:
-        for prop_name in comp.extra_props:
-          key = '{0}_{1}'.format(prefix, prop_name)
-          vars[key] = comp.extra_props[prop_name]
-
-    vars['env'] = env
-
-    with open(os.path.join(self.cacheFolder, 'vars'), 'wb') as fp:
-      util.DiskPickle(vars, fp)
-
-  def detectCompilers(self):
-    if not self.compiler:
-      with util.FolderChanger(self.cacheFolder):
-        self.base_compiler = detect.DetectCxx(os.environ, self.options)
-        self.compiler = self.base_compiler.clone()
-
-    return self.compiler
-
-  def getLocalFolder(self, context):
-    if type(context.localFolder_) is nodetypes.Entry or context.localFolder_ is None:
-      return context.localFolder_
-
-    if len(context.buildFolder):
-      context.localFolder_ = self.generateFolder(None, context.buildFolder)
-    else:
-      context.localFolder_ = None
-    return context.localFolder_
-
-  def generateFolder(self, parent, folder):
-    parent_path, path = paths.ResolveFolder(parent, folder)
-
-    # Quick check. If this folder is not in our old folder list, and it's in
-    # the DB, then we already have an entry for it that has already negotiated
-    # its parent paths.
-    old_entry = self.db.query_path(path)
-    if old_entry and self.isValidFolderEntry(old_entry):
-      return old_entry
-
-    components = []
-    while folder:
-      folder, name = os.path.split(folder)
-      if not name:
-        break
-      components.append(name)
-
-    path = parent_path
-    while len(components):
-      name = components.pop()
-      path = os.path.join(path, name)
-      entry = self.db.query_path(path)
-      if not entry:
-        if self.refactoring:
-          util.con_err(util.ConsoleRed, 'New folder introduced: ',
-                       util.ConsoleBlue, path,
-                       util.ConsoleNormal)
-          raise Exception('Refactoring error: new folder')
-        entry = self.db.add_folder(parent, path)
-      elif entry.type == nodetypes.Output or entry.type == nodetypes.SharedOutput:
-        if entry.type == nodetypes.Output:
-          cmd_entries = [self.db.query_command_of(entry)]
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'An output has changed to a shared output: ',
+                             util.ConsoleBlue, entry.path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
         elif entry.type == nodetypes.SharedOutput:
-          cmd_entries = self.db.query_shared_commands_of(entry)
+            input_cmds = self.db.query_shared_commands_of(entry)
+            for input_cmd in input_cmds:
+                if input_cmd not in self.old_commands_:
+                    util.con_err(util.ConsoleRed,
+                                 'A shared output cannot be specified as an normal output.',
+                                 util.ConsoleNormal)
+                    raise Exception('Existing shared output cannot be a normal output: {0}'.format(
+                        entry.path))
 
-        for cmd_entry in cmd_entries:
-          if cmd_entry not in self.old_commands_:
-            util.con_err(util.ConsoleRed, 'Folder has the same path as an output file generated by:\n',
-                         util.ConsoleBlue, cmd_entry.format(),
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'A shared output has changed to a normal output: ',
+                             util.ConsoleBlue, entry.path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
+        else:
+            util.con_err(util.ConsoleRed,
+                         'An existing node has been specified as an output file: "',
+                         util.ConsoleBlue, entry.format(), util.ConsoleRed, '"', util.ConsoleNormal)
+            raise Exception('Attempted to re-use an incompatible node as an output')
+
+        self.db.change_to_output(entry, kind)
+        return entry
+
+    def parseInput(self, context, source):
+        if util.IsString(source):
+            if not os.path.isabs(source):
+                source = os.path.join(context.currentSourcePath, source)
+            source = os.path.normpath(source)
+
+            entry = self.db.query_path(source)
+            if not entry:
+                return self.db.add_source(source)
+
+            # Otherwise, we have to valid the node.
+            source = entry
+
+        if source.type == nodetypes.Source or source.type == nodetypes.Output:
+            return source
+
+        if source.type == nodetypes.Mkdir:
+            if source not in self.bad_outputs_:
+                util.con_err(util.ConsoleRed, 'Tried to use folder path ', util.ConsoleBlue,
+                             source.path, util.ConsoleRed, ' as a file path.', util.ConsoleNormal)
+                raise Exception('Tried to use folder path as a file path')
+
+        util.con_err(util.ConsoleRed, 'Tried to use incompatible node "', util.ConsoleBlue,
+                     source.format(), util.ConsoleRed, '" as a file path.', util.ConsoleNormal)
+        raise Exception('Tried to use non-file node as a file path')
+
+    def addCommand(self,
+                   context,
+                   node_type,
+                   folder,
+                   data,
+                   inputs,
+                   outputs,
+                   weak_inputs = [],
+                   shared_outputs = []):
+        assert not folder or isinstance(folder, nodetypes.Entry)
+
+        # Build the set of weak links.
+        weak_links = set()
+        for weak_input in weak_inputs:
+            assert type(weak_input) is nodetypes.Entry
+            assert weak_input.type != nodetypes.Source
+            weak_links.add(weak_input)
+
+        # Build the set of strong links.
+        strong_links = set()
+        for strong_input in inputs:
+            strong_input = self.parseInput(context, strong_input)
+            strong_links.add(strong_input)
+
+        # Build the list of outputs.
+        cmd_entry = None
+        output_nodes = []
+        for output in outputs:
+            output_node = self.parseOutput(folder, output, nodetypes.Output)
+            output_nodes.append(output_node)
+
+            input_entry = self.db.query_command_of(output_node)
+            if not input_entry:
+                continue
+
+            # Make sure this output won't be duplicated.
+            if input_entry not in self.old_commands_:
+                util.con_err(util.ConsoleRed, 'Command: ', input_entry.format(), util.ConsoleNormal)
+                raise Exception('Output has been duplicated: {0}'.format(output_node.path))
+
+            if not cmd_entry:
+                cmd_entry = input_entry
+        # end for
+
+        # Build the list of shared outputs.
+        shared_output_nodes = []
+        for shared_output in shared_outputs:
+            shared_output_node = self.parseOutput(folder, shared_output, nodetypes.SharedOutput)
+            shared_output_nodes.append(shared_output_node)
+
+        output_links = set(output_nodes)
+        shared_links = set(shared_output_nodes)
+
+        # There should be no duplicates in either output list. These error messages
+        # could be better.
+        if len(output_nodes) > len(output_links):
+            util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
                          util.ConsoleNormal)
-            raise Exception('Output has been duplicated: {0}'.format(entry.path))
+            raise Exception('Shared output list contains duplicate files.')
+        if len(shared_output_nodes) > len(shared_links):
+            util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
+                         util.ConsoleNormal)
+            raise Exception('Shared output list contains duplicate files.')
 
-        if self.refactoring:
-          util.con_err(util.ConsoleRed, 'Path "',
-                       util.ConsoleBlue, entry.path,
-                       util.ConsoleRed, '" has changed from a file to a folder.',
-                       util.ConsoleNormal)
-          raise Exception('Refactoring error: path changed from file to folder')
+        # The intersection of output_links and shared_links should be the empty set.
+        duplicates = output_links.intersection(shared_links)
+        if len(duplicates):
+            bad_entry = duplicates.pop()
+            util.con_err(util.ConsoleRed, 'An output has been duplicated as a shared output: ',
+                         util.ConsoleBlue, bad_entry.path, util.ConsoleNormal)
+            raise Exception('An output has been duplicated as a shared output.')
 
-        self.rm_list_.append(entry.path)
-        self.db.change_to_folder(entry)
-      elif entry.type == nodetypes.Mkdir:
-        # We let the same folder be generated twice, so use discard, not remove.
-        self.old_folders_.discard(entry)
-      else:
-        util.con_err(util.ConsoleRed, 'Folder has the same node signature as: ',
-                     util.ConsoleBlue, entry.format(),
-                     util.ConsoleNormal)
-        raise Exception('Output has been duplicated: {0}'.format(entry.path))
+        dirty = nodetypes.DIRTY
 
-      parent = entry
+        if cmd_entry:
+            # Update the entry in the database.
+            self.db.update_command(cmd_entry, node_type, folder, data, dirty, self.refactoring,
+                                   None)
 
-    return entry
+            # Disconnect any outputs that are no longer connected to this output.
+            # It's okay to use output_links since there should never be duplicate
+            # outputs.
+            for outgoing in self.db.query_strong_outgoing(cmd_entry):
+                if outgoing not in output_links:
+                    self.db.drop_strong_edge(cmd_entry, outgoing)
+                    self.db.drop_output(outgoing)
+                else:
+                    output_links.remove(outgoing)
 
-  def isValidFolderEntry(self, folder_entry):
-    # If it's a mkdir and it's created, we're done.
-    return folder_entry.type == nodetypes.Mkdir and folder_entry not in self.old_folders_
+            # Do the same for shared outputs. Since there is a many:1 relationship,
+            # we can't drop shared outputs here. We save that for a cleanup step.
+            for outgoing in self.db.query_shared_outputs(cmd_entry):
+                if outgoing not in shared_links:
+                    self.db.drop_shared_output_edge(cmd_entry, outgoing)
+                else:
+                    shared_links.remove(outgoing)
 
-  def validateOutputFolder(self, path):
-    # Empty path is the root folder, which is null.
-    if not len(path):
-      return None
-
-    # The folder must already exist.
-    folder_entry = self.db.query_path(path)
-    if not folder_entry:
-      util.con_err(util.ConsoleRed, 'Path "',
-                   util.ConsoleBlue, path,
-                   util.ConsoleRed, '" specifies a folder that does not exist.',
-                   util.ConsoleNormal)
-      raise Exception('path specifies a folder that does not exist')
-
-    if self.isValidFolderEntry(folder_entry):
-      return folder_entry
-
-    # If it's a folder or an output, we can give a better error message.
-    if folder_entry.type == nodetypes.Output or folder_entry.type == nodetypes.Mkdir:
-      util.con_err(util.ConsoleRed, 'Folder "',
-                   util.ConsoleBlue, folder_entry.path,
-                   util.ConsoleRed, '" was never created.',
-                   util.ConsoleNormal)
-      raise Exception('path {0} was never created', folder_entry.path)
-
-    util.con_err(util.ConsoleRed, 'Attempted to use node "',
-                 util.ConsoleBlue, folder_entry.format(),
-                 util.ConsoleRed, '" as a path component.',
-                 util.ConsoleNormal)
-    raise Exception('illegal path component')
-
-  def parseOutput(self, cwd_entry, path, kind):
-    if path[-1] == os.sep or path[-1] == os.altsep or path == '.' or path == '':
-      util.con_err(util.ConsoleRed, 'Path "',
-                   util.ConsoleBlue, path,
-                   util.ConsoleRed, '" looks like a folder; a folder was not expected.',
-                   util.ConsoleNormal)
-      raise Exception('Expected folder, but path has a trailing slash')
-
-    path = os.path.normpath(path)
-
-    path, name = os.path.split(path)
-    path = nodetypes.combine(cwd_entry, path)
-
-    # We should have caught a case like 'x/' earlier.
-    assert len(name)
-
-    # If we resolved that there is no prefix path, then take this to mean the
-    # root folder.
-    if path:
-      folder_entry = self.validateOutputFolder(path)
-      output_path = os.path.join(path, name)
-    else:
-      folder_entry = None
-      output_path = name
-
-    entry = self.db.query_path(output_path)
-    if not entry:
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'New output file introduced: ',
-                     util.ConsoleBlue, output_path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-      return self.db.add_output(folder_entry, output_path, kind)
-
-    if entry.type == kind:
-      return entry
-
-    if entry.type == nodetypes.Mkdir:
-      if entry not in self.old_folders_:
-        util.con_err(util.ConsoleRed, 'A folder is being re-used as an output file: "',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleRed, '"',
-                     util.ConsoleNormal)
-        raise Exception('Attempted to re-use a folder as generated file')
-
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'A generated folder has changed to a generated file: ',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-
-      # We keep the node in old_folders_. This should be okay, since we've
-      # changed the type to Output now. This way we can stick to one folder
-      # deletion routine, since it's fairly complicated.
-    elif entry.type == nodetypes.Output:
-      # If we're asking for a shared output, make sure we can reuse this one.
-      input_cmd = self.db.query_command_of(entry)
-      if input_cmd and input_cmd not in self.old_commands_:
-        util.con_err(util.ConsoleRed, 'First defined with command: ', input_cmd.format(), util.ConsoleNormal)
-        raise Exception('Existing output cannot be a shared output: {0}'.format(entry.path))
-
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'An output has changed to a shared output: ',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-    elif entry.type == nodetypes.SharedOutput:
-      input_cmds = self.db.query_shared_commands_of(entry)
-      for input_cmd in input_cmds:
-        if input_cmd not in self.old_commands_:
-          util.con_err(util.ConsoleRed, 'A shared output cannot be specified as an normal output.',
-                       util.ConsoleNormal)
-          raise Exception('Existing shared output cannot be a normal output: {0}'.format(entry.path))
-
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'A shared output has changed to a normal output: ',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-    else:
-      util.con_err(util.ConsoleRed, 'An existing node has been specified as an output file: "',
-                   util.ConsoleBlue, entry.format(),
-                   util.ConsoleRed, '"',
-                   util.ConsoleNormal)
-      raise Exception('Attempted to re-use an incompatible node as an output')
-
-    self.db.change_to_output(entry, kind)
-    return entry
-
-  def parseInput(self, context, source):
-    if util.IsString(source):
-      if not os.path.isabs(source):
-        source = os.path.join(context.currentSourcePath, source)
-      source = os.path.normpath(source)
-
-      entry = self.db.query_path(source)
-      if not entry:
-        return self.db.add_source(source)
-
-      # Otherwise, we have to valid the node.
-      source = entry
-
-    if source.type == nodetypes.Source or source.type == nodetypes.Output:
-      return source
-
-    if source.type == nodetypes.Mkdir:
-      if source not in self.bad_outputs_:
-        util.con_err(util.ConsoleRed, 'Tried to use folder path ',
-                     util.ConsoleBlue, source.path,
-                     util.ConsoleRed, ' as a file path.',
-                     util.ConsoleNormal)
-        raise Exception('Tried to use folder path as a file path')
-
-    util.con_err(util.ConsoleRed, 'Tried to use incompatible node "',
-                 util.ConsoleBlue, source.format(),
-                 util.ConsoleRed, '" as a file path.',
-                 util.ConsoleNormal)
-    raise Exception('Tried to use non-file node as a file path')
-
-  def addCommand(self, context, node_type, folder, data, inputs, outputs,
-                 weak_inputs=[], shared_outputs=[]):
-    assert not folder or isinstance(folder, nodetypes.Entry)
-
-    # Build the set of weak links.
-    weak_links = set()
-    for weak_input in weak_inputs:
-      assert type(weak_input) is nodetypes.Entry
-      assert weak_input.type != nodetypes.Source
-      weak_links.add(weak_input)
-
-    # Build the set of strong links.
-    strong_links = set()
-    for strong_input in inputs:
-      strong_input = self.parseInput(context, strong_input)
-      strong_links.add(strong_input)
-
-    # Build the list of outputs.
-    cmd_entry = None
-    output_nodes = []
-    for output in outputs:
-      output_node = self.parseOutput(folder, output, nodetypes.Output)
-      output_nodes.append(output_node)
-
-      input_entry = self.db.query_command_of(output_node)
-      if not input_entry:
-        continue
-
-      # Make sure this output won't be duplicated.
-      if input_entry not in self.old_commands_:
-        util.con_err(util.ConsoleRed, 'Command: ', input_entry.format(), util.ConsoleNormal)
-        raise Exception('Output has been duplicated: {0}'.format(output_node.path))
-
-      if not cmd_entry:
-        cmd_entry = input_entry
-    # end for
-
-    # Build the list of shared outputs.
-    shared_output_nodes = []
-    for shared_output in shared_outputs:
-      shared_output_node = self.parseOutput(folder, shared_output, nodetypes.SharedOutput)
-      shared_output_nodes.append(shared_output_node)
-
-    output_links = set(output_nodes)
-    shared_links = set(shared_output_nodes)
-
-    # There should be no duplicates in either output list. These error messages
-    # could be better.
-    if len(output_nodes) > len(output_links):
-      util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
-                   util.ConsoleNormal)
-      raise Exception('Shared output list contains duplicate files.')
-    if len(shared_output_nodes) > len(shared_links):
-      util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
-                   util.ConsoleNormal)
-      raise Exception('Shared output list contains duplicate files.')
-
-    # The intersection of output_links and shared_links should be the empty set.
-    duplicates = output_links.intersection(shared_links)
-    if len(duplicates):
-      bad_entry = duplicates.pop()
-      util.con_err(util.ConsoleRed, 'An output has been duplicated as a shared output: ',
-                   util.ConsoleBlue, bad_entry.path,
-                   util.ConsoleNormal)
-      raise Exception('An output has been duplicated as a shared output.')
-
-    dirty = nodetypes.DIRTY
-
-    if cmd_entry:
-      # Update the entry in the database.
-      self.db.update_command(cmd_entry, node_type, folder, data, dirty, self.refactoring,
-                             None)
-
-      # Disconnect any outputs that are no longer connected to this output.
-      # It's okay to use output_links since there should never be duplicate
-      # outputs.
-      for outgoing in self.db.query_strong_outgoing(cmd_entry):
-        if outgoing not in output_links:
-          self.db.drop_strong_edge(cmd_entry, outgoing)
-          self.db.drop_output(outgoing)
+            # Remove us from the list of commands to delete.
+            self.old_commands_.remove(cmd_entry)
         else:
-          output_links.remove(outgoing)
+            # Note that if there are no outputs, we will always add a new command,
+            # and the old (identical) command will be deleted.
+            cmd_entry = self.db.add_command(node_type, folder, data, dirty, None)
 
-      # Do the same for shared outputs. Since there is a many:1 relationship,
-      # we can't drop shared outputs here. We save that for a cleanup step.
-      for outgoing in self.db.query_shared_outputs(cmd_entry):
-        if outgoing not in shared_links:
-          self.db.drop_shared_output_edge(cmd_entry, outgoing)
+        # Local helper function to warn about refactoring problems.
+        def refactoring_error(node):
+            util.con_err(util.ConsoleRed, 'New input introduced: ', util.ConsoleBlue,
+                         node.path + '\n', util.ConsoleRed, 'Command: ', util.ConsoleBlue,
+                         cmd_entry.format(), util.ConsoleNormal)
+            raise Exception('Refactoring error: new input introduced')
+
+        if len(output_links) and self.refactoring:
+            refactoring_error(output_links.pop())
+        if len(shared_links) and self.refactoring:
+            refactoring_error(shared_links.pop())
+
+        # Connect each output.
+        for output_node in output_links:
+            self.db.add_strong_edge(cmd_entry, output_node)
+        for shared_output_node in shared_links:
+            self.db.add_shared_output_edge(cmd_entry, shared_output_node)
+
+        # Connect/disconnect strong inputs.
+        strong_inputs = self.db.query_strong_inputs(cmd_entry)
+        strong_added = strong_links - strong_inputs
+        strong_removed = strong_inputs - strong_links
+
+        if len(strong_added) and self.refactoring:
+            refactoring_error(strong_added.pop())
+
+        for strong_input in strong_added:
+            self.db.add_strong_edge(strong_input, cmd_entry)
+        for strong_input in strong_removed:
+            self.db.drop_strong_edge(strong_input, cmd_entry)
+
+        # Connect/disconnect weak inputs.
+        weak_inputs = self.db.query_weak_inputs(cmd_entry)
+        weak_added = weak_links - weak_inputs
+        weak_removed = weak_inputs - weak_links
+
+        if len(weak_added) and self.refactoring:
+            refactoring_error(weak_added.pop())
+
+        for weak_input in weak_added:
+            self.db.add_weak_edge(weak_input, cmd_entry)
+        for weak_input in weak_removed:
+            self.db.drop_weak_edge(weak_input, cmd_entry)
+
+        # If we got new outputs or inputs, we need to re-run the command.
+        changed = len(output_links) + len(strong_added) + len(weak_added)
+        if changed and not cmd_entry.dirty:
+            self.db.mark_dirty(cmd_entry)
+
+        return cmd_entry, output_nodes
+
+    def parseCxxDeps(self, context, binary, inputs, items):
+        for val in items:
+            if util.IsString(val):
+                continue
+
+            if type(val) is nodetypes.Entry:
+                item = val
+            elif util.IsLambda(val.node):
+                item = val.node(context, binary)
+            elif val.node is None:
+                item = self.parseInput(context, val.text).path
+            else:
+                item = val.node
+
+            if type(item) is list:
+                inputs.extend(item)
+            else:
+                inputs.append(item)
+
+    def addCxxTasks(self, cx, binary):
+        folder_node = self.generateFolder(cx.localFolder, binary.localFolder)
+
+        # Find dependencies
+        inputs = []
+        self.parseCxxDeps(cx, binary, inputs, binary.compiler.linkflags)
+        self.parseCxxDeps(cx, binary, inputs, binary.compiler.postlink)
+
+        for objfile in binary.objects:
+            cxxData = {'argv': objfile.argv, 'type': binary.linker.behavior}
+            cxxCmd, (cxxNode,) = self.addCommand(context = cx,
+                                                 weak_inputs = binary.compiler.sourcedeps,
+                                                 inputs = [objfile.sourceFile],
+                                                 outputs = [objfile.outputFile],
+                                                 node_type = nodetypes.Cxx,
+                                                 folder = folder_node,
+                                                 data = cxxData,
+                                                 shared_outputs = objfile.sharedOutputs)
+            inputs.append(cxxNode)
+        for rcfile in binary.resources:
+            rcData = {
+                'cl_argv': rcfile.cl_argv,
+                'rc_argv': rcfile.rc_argv,
+            }
+            rcCmd, (preprocNode,
+                    rcNode) = self.addCommand(context = cx,
+                                              weak_inputs = binary.compiler.sourcedeps,
+                                              inputs = [rcfile.sourceFile],
+                                              outputs = [rcfile.preprocFile, rcfile.outputFile],
+                                              node_type = nodetypes.Rc,
+                                              folder = folder_node,
+                                              data = rcData)
+            inputs.append(rcNode)
+
+        output_file, debug_file = binary.link(context = cx, folder = folder_node, inputs = inputs)
+
+        return cpp.CppNodes(output_file, debug_file)
+
+    def addFileOp(self, cmd, context, source, output_path):
+        # Try to detect if our output_path is actually a folder, via trailing
+        # slash or '.'/'' indicating the context folder.
+        detected_folder = None
+        if util.IsString(output_path):
+            if output_path[-1] == os.sep or output_path[-1] == os.altsep:
+                detected_folder = os.path.join(context.buildFolder, os.path.normpath(output_path))
+            elif output_path == '.' or output_path == '':
+                detected_folder = context.buildFolder
+
+            # Since we're building something relative to the context folder, ensure
+            # that the context folder exists.
+            self.getLocalFolder(context)
         else:
-          shared_links.remove(outgoing)
+            assert output_path.type != nodetypes.Source
+            local_path = os.path.relpath(output_path.path, context.buildFolder)
+            detected_folder = os.path.join(context.buildFolder, local_path)
+            detected_folder = os.path.normpath(detected_folder)
 
-      # Remove us from the list of commands to delete.
-      self.old_commands_.remove(cmd_entry)
-    else:
-      # Note that if there are no outputs, we will always add a new command,
-      # and the old (identical) command will be deleted.
-      cmd_entry = self.db.add_command(node_type, folder, data, dirty, None)
+        source_entry = self.parseInput(context, source)
 
-    # Local helper function to warn about refactoring problems.
-    def refactoring_error(node):
-      util.con_err(util.ConsoleRed, 'New input introduced: ',
-                   util.ConsoleBlue, node.path + '\n',
-                   util.ConsoleRed, 'Command: ',
-                   util.ConsoleBlue, cmd_entry.format(),
-                   util.ConsoleNormal)
-      raise Exception('Refactoring error: new input introduced')
+        # This is similar to a "cp a b/", so we append to get "b/a" as the path.
+        if detected_folder is not None:
+            base, output_path = os.path.split(source_entry.path)
+            assert len(output_path)
 
-    if len(output_links) and self.refactoring:
-      refactoring_error(output_links.pop())
-    if len(shared_links) and self.refactoring:
-      refactoring_error(shared_links.pop())
+            output_folder = detected_folder
+        else:
+            output_folder = context.buildFolder
 
-    # Connect each output.
-    for output_node in output_links:
-      self.db.add_strong_edge(cmd_entry, output_node)
-    for shared_output_node in shared_links:
-      self.db.add_shared_output_edge(cmd_entry, shared_output_node)
+        output_path = nodetypes.combine(output_folder, output_path)
 
-    # Connect/disconnect strong inputs.
-    strong_inputs = self.db.query_strong_inputs(cmd_entry)
-    strong_added = strong_links - strong_inputs
-    strong_removed = strong_inputs - strong_links 
+        # For copy operations, it's okay to use the path from the current folder.
+        # However, when performing symlinks, we always want an absolute path.
+        if cmd == nodetypes.Symlink:
+            if source_entry.type == nodetypes.Source:
+                source_path = source_entry.path
+            else:
+                source_path = os.path.join(context.buildPath, source_entry.path)
+        else:
+            source_path = source_entry.path
 
-    if len(strong_added) and self.refactoring:
-      refactoring_error(strong_added.pop())
+        # For clarity of spew, we always execute file operations in the root of
+        # the build folder. This means that no matter what context we're in,
+        # we can use absolute-ish folders and get away with it.
+        return self.addCommand(context = context,
+                               node_type = cmd,
+                               folder = None,
+                               data = (source_path, output_path),
+                               inputs = [source_entry],
+                               outputs = [output_path])
 
-    for strong_input in strong_added:
-      self.db.add_strong_edge(strong_input, cmd_entry)
-    for strong_input in strong_removed:
-      self.db.drop_strong_edge(strong_input, cmd_entry)
+    def addSource(self, context, source_path):
+        return self.graph.addSource(source_path)
 
-    # Connect/disconnect weak inputs.
-    weak_inputs = self.db.query_weak_inputs(cmd_entry)
-    weak_added = weak_links - weak_inputs
-    weak_removed = weak_inputs - weak_links 
+    def addCopy(self, context, source, output_path):
+        return self.addFileOp(nodetypes.Copy, context, source, output_path)
 
-    if len(weak_added) and self.refactoring:
-      refactoring_error(weak_added.pop())
+    def addSymlink(self, context, source, output_path):
+        if util.IsWindows():
+            # Windows pre-Vista does not support symlinks. Windows Vista+ supports
+            # symlinks via mklink, but it's Administrator-only by default.
+            return self.addFileOp(nodetypes.Copy, context, source, output_path)
 
-    for weak_input in weak_added:
-      self.db.add_weak_edge(weak_input, cmd_entry)
-    for weak_input in weak_removed:
-      self.db.drop_weak_edge(weak_input, cmd_entry)
+        if not self.symlink_support:
+            self.had_symlink_fallback = True
+            return self.addFileOp(nodetypes.Copy, context, source, output_path)
 
-    # If we got new outputs or inputs, we need to re-run the command.
-    changed = len(output_links) + len(strong_added) + len(weak_added)
-    if changed and not cmd_entry.dirty:
-      self.db.mark_dirty(cmd_entry)
+        return self.addFileOp(nodetypes.Symlink, context, source, output_path)
 
-    return cmd_entry, output_nodes
+    def addFolder(self, context, folder):
+        return self.generateFolder(context.localFolder, folder)
 
-  def parseCxxDeps(self, context, binary, inputs, items):
-    for val in items:
-      if util.IsString(val):
-        continue
+    def addShellCommand(self,
+                        context,
+                        inputs,
+                        argv,
+                        outputs,
+                        folder = -1,
+                        dep_type = None,
+                        weak_inputs = [],
+                        shared_outputs = []):
+        if folder is -1:
+            folder = context.localFolder
 
-      if type(val) is nodetypes.Entry:
-        item = val
-      elif util.IsLambda(val.node):
-        item = val.node(context, binary)
-      elif val.node is None:
-        item = self.parseInput(context, val.text).path
-      else:
-        item = val.node
+        if dep_type is None:
+            node_type = nodetypes.Command
+            data = argv
+        else:
+            node_type = nodetypes.Cxx
+            if dep_type not in ['gcc', 'msvc', 'sun']:
+                util.con_err(util.ConsoleRed, 'Invalid dependency spew type: ', util.ConsoleBlue,
+                             dep_type, util.ConsoleNormal)
+                raise Exception('Invalid dependency spew type')
+            data = {
+                'type': dep_type,
+                'argv': argv,
+            }
 
-      if type(item) is list:
-        inputs.extend(item)
-      else:
-        inputs.append(item)
+        return self.addCommand(context = context,
+                               node_type = node_type,
+                               folder = folder,
+                               data = data,
+                               inputs = inputs,
+                               outputs = outputs,
+                               weak_inputs = weak_inputs,
+                               shared_outputs = shared_outputs)
 
-  def addCxxTasks(self, cx, binary):
-    folder_node = self.generateFolder(cx.localFolder, binary.localFolder)
+    def addConfigureFile(self, context, path):
+        if not os.path.isabs(path):
+            path = os.path.join(context.currentSourcePath, path)
+        path = os.path.normpath(path)
 
-    # Find dependencies
-    inputs = []
-    self.parseCxxDeps(cx, binary, inputs, binary.compiler.linkflags)
-    self.parseCxxDeps(cx, binary, inputs, binary.compiler.postlink)
-
-    for objfile in binary.objects:
-      cxxData = {
-        'argv': objfile.argv,
-        'type': binary.linker.behavior
-      }
-      cxxCmd, (cxxNode,) = self.addCommand(
-        context = cx,
-        weak_inputs = binary.compiler.sourcedeps,
-        inputs = [objfile.sourceFile],
-        outputs = [objfile.outputFile],
-        node_type = nodetypes.Cxx,
-        folder = folder_node,
-        data = cxxData,
-        shared_outputs = objfile.sharedOutputs
-      )
-      inputs.append(cxxNode)
-    for rcfile in binary.resources:
-      rcData = {
-        'cl_argv': rcfile.cl_argv,
-        'rc_argv': rcfile.rc_argv,
-      }
-      rcCmd, (preprocNode, rcNode) = self.addCommand(
-        context = cx,
-        weak_inputs = binary.compiler.sourcedeps,
-        inputs = [rcfile.sourceFile],
-        outputs = [rcfile.preprocFile, rcfile.outputFile],
-        node_type = nodetypes.Rc,
-        folder = folder_node,
-        data = rcData
-      )
-      inputs.append(rcNode)
-
-    output_file, debug_file = binary.link(
-      context = cx,
-      folder = folder_node,
-      inputs = inputs
-    )
-
-    return cpp.CppNodes(output_file, debug_file)
-
-  def addFileOp(self, cmd, context, source, output_path):
-    # Try to detect if our output_path is actually a folder, via trailing
-    # slash or '.'/'' indicating the context folder.
-    detected_folder = None
-    if util.IsString(output_path):
-      if output_path[-1] == os.sep or output_path[-1] == os.altsep:
-        detected_folder = os.path.join(context.buildFolder, os.path.normpath(output_path))
-      elif output_path == '.' or output_path == '':
-        detected_folder = context.buildFolder
-
-      # Since we're building something relative to the context folder, ensure
-      # that the context folder exists.
-      self.getLocalFolder(context)
-    else:
-      assert output_path.type != nodetypes.Source
-      local_path = os.path.relpath(output_path.path, context.buildFolder)
-      detected_folder = os.path.join(context.buildFolder, local_path)
-      detected_folder = os.path.normpath(detected_folder)
-
-    source_entry = self.parseInput(context, source)
-
-    # This is similar to a "cp a b/", so we append to get "b/a" as the path.
-    if detected_folder is not None:
-      base, output_path = os.path.split(source_entry.path)
-      assert len(output_path)
-
-      output_folder = detected_folder
-    else:
-      output_folder = context.buildFolder
-
-    output_path = nodetypes.combine(output_folder, output_path)
-
-    # For copy operations, it's okay to use the path from the current folder.
-    # However, when performing symlinks, we always want an absolute path.
-    if cmd == nodetypes.Symlink:
-      if source_entry.type == nodetypes.Source:
-        source_path = source_entry.path
-      else:
-        source_path = os.path.join(context.buildPath, source_entry.path)
-    else:
-      source_path = source_entry.path
-
-    # For clarity of spew, we always execute file operations in the root of
-    # the build folder. This means that no matter what context we're in,
-    # we can use absolute-ish folders and get away with it.
-    return self.addCommand(
-      context = context,
-      node_type = cmd,
-      folder = None,
-      data = (source_path, output_path),
-      inputs = [source_entry],
-      outputs = [output_path]
-    )
-
-  def addSource(self, context, source_path):
-    return self.graph.addSource(source_path)
-
-  def addCopy(self, context, source, output_path):
-    return self.addFileOp(nodetypes.Copy, context, source, output_path)
-
-  def addSymlink(self, context, source, output_path):
-    if util.IsWindows():
-      # Windows pre-Vista does not support symlinks. Windows Vista+ supports
-      # symlinks via mklink, but it's Administrator-only by default.
-      return self.addFileOp(nodetypes.Copy, context, source, output_path)
-
-    if not self.symlink_support:
-      self.had_symlink_fallback = True
-      return self.addFileOp(nodetypes.Copy, context, source, output_path)
-
-    return self.addFileOp(nodetypes.Symlink, context, source, output_path)
-
-  def addFolder(self, context, folder):
-    return self.generateFolder(context.localFolder, folder)
-
-  def addShellCommand(self,
-                      context,
-                      inputs,
-                      argv,
-                      outputs,
-                      folder=-1,
-                      dep_type=None,
-                      weak_inputs=[],
-                      shared_outputs=[]):
-    if folder is -1:
-      folder = context.localFolder
-
-    if dep_type is None:
-      node_type = nodetypes.Command
-      data = argv
-    else:
-      node_type = nodetypes.Cxx
-      if dep_type not in ['gcc', 'msvc', 'sun']:
-        util.con_err(util.ConsoleRed, 'Invalid dependency spew type: ',
-                     util.ConsoleBlue, dep_type,
-                     util.ConsoleNormal)
-        raise Exception('Invalid dependency spew type')
-      data = {
-        'type': dep_type,
-        'argv': argv,
-      }
-
-    return self.addCommand(
-      context = context,
-      node_type = node_type,
-      folder = folder,
-      data = data,
-      inputs = inputs,
-      outputs = outputs,
-      weak_inputs = weak_inputs,
-      shared_outputs = shared_outputs
-    )
-
-  def addConfigureFile(self, context, path):
-    if not os.path.isabs(path):
-      path = os.path.join(context.currentSourcePath, path)
-    path = os.path.normpath(path)
-
-    self.old_scripts_.discard(path)
-    self.db.add_or_update_script(path)
-
+        self.old_scripts_.discard(path)
+        self.db.add_or_update_script(path)

--- a/ambuild2/frontend/v2_0/base/gen.py
+++ b/ambuild2/frontend/v2_0/base/gen.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -29,231 +29,235 @@ from ambuild2 import util
 # scripts change.
 
 class ConfigureException(Exception):
-  def __init__(self, *args, **kwargs):
-    super(ConfigureException, self).__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super(ConfigureException, self).__init__(*args, **kwargs)
 
 class Context(object):
-  def __init__(self, generator, parent, script):
-    self.generator = generator
-    self.parent = parent
-    self.script = script
-    self.compiler = None
+    def __init__(self, generator, parent, script):
+        self.generator = generator
+        self.parent = parent
+        self.script = script
+        self.compiler = None
 
-    if parent:
-      self.compiler = parent.compiler.clone()
+        if parent:
+            self.compiler = parent.compiler.clone()
 
-    # By default, all generated files for a build script are placed in a path
-    # matching its layout in the source tree.
-    path, name = os.path.split(script)
-    if parent:
-      self.currentSourcePath = os.path.join(parent.currentSourcePath, path)
-      self.currentSourceFolder = os.path.join(parent.currentSourceFolder, path)
-      self.buildFolder = os.path.join(parent.buildFolder, path)
-    else:
-      self.currentSourcePath = generator.sourcePath
-      self.currentSourceFolder = ''
-      self.buildFolder = ''
-    self.buildScript = os.path.join(self.currentSourceFolder, name)
-    self.localFolder_ = self.buildFolder
+        # By default, all generated files for a build script are placed in a path
+        # matching its layout in the source tree.
+        path, name = os.path.split(script)
+        if parent:
+            self.currentSourcePath = os.path.join(parent.currentSourcePath, path)
+            self.currentSourceFolder = os.path.join(parent.currentSourceFolder, path)
+            self.buildFolder = os.path.join(parent.buildFolder, path)
+        else:
+            self.currentSourcePath = generator.sourcePath
+            self.currentSourceFolder = ''
+            self.buildFolder = ''
+        self.buildScript = os.path.join(self.currentSourceFolder, name)
+        self.localFolder_ = self.buildFolder
 
-  # Root source folder.
-  @property
-  def sourcePath(self):
-    return self.generator.sourcePath
+    # Root source folder.
+    @property
+    def sourcePath(self):
+        return self.generator.sourcePath
 
-  @property
-  def options(self):
-    return self.generator.options
+    @property
+    def options(self):
+        return self.generator.options
 
-  @property
-  def buildPath(self):
-    return self.generator.buildPath
+    @property
+    def buildPath(self):
+        return self.generator.buildPath
 
-  # In build systems with dependency graphs, this can return a node
-  # representing buildFolder. Otherwise, it returns buildFolder.
-  @property
-  def localFolder(self):
-    return self.generator.getLocalFolder(self)
+    # In build systems with dependency graphs, this can return a node
+    # representing buildFolder. Otherwise, it returns buildFolder.
+    @property
+    def localFolder(self):
+        return self.generator.getLocalFolder(self)
 
-  @property
-  def target_platform(self):
-    return self.generator.target_platform
+    @property
+    def target_platform(self):
+        return self.generator.target_platform
 
-  @property
-  def host_platform(self):
-    return self.generator.host_platform
+    @property
+    def host_platform(self):
+        return self.generator.host_platform
 
-  @property
-  def originalCwd(self):
-    return self.generator.originalCwd
+    @property
+    def originalCwd(self):
+        return self.generator.originalCwd
 
-  @property
-  def backend(self):
-    return self.generator.backend
+    @property
+    def backend(self):
+        return self.generator.backend
 
-  def SetBuildFolder(self, folder):
-    if folder == '/' or folder == '.' or folder == './':
-      self.buildFolder = ''
-    else:
-      self.buildFolder = os.path.normpath(folder)
-    self.localFolder_ = self.buildFolder
+    def SetBuildFolder(self, folder):
+        if folder == '/' or folder == '.' or folder == './':
+            self.buildFolder = ''
+        else:
+            self.buildFolder = os.path.normpath(folder)
+        self.localFolder_ = self.buildFolder
 
-  def DetectCompilers(self):
-    if not self.compiler:
-      self.compiler = self.generator.detectCompilers().clone()
-    return self.compiler
+    def DetectCompilers(self):
+        if not self.compiler:
+            self.compiler = self.generator.detectCompilers().clone()
+        return self.compiler
 
-  def ImportScript(self, file, vars={}):
-    return self.generator.importScript(self, file, vars)
+    def ImportScript(self, file, vars = {}):
+        return self.generator.importScript(self, file, vars)
 
-  def RunScript(self, file, vars={}):
-    return self.generator.evalScript(file, vars)
+    def RunScript(self, file, vars = {}):
+        return self.generator.evalScript(file, vars)
 
-  def RunBuildScripts(self, files, vars={}):
-    if util.IsString(files):
-      self.generator.evalScript(files, vars)
-    else:
-      for script in files:
-        self.generator.evalScript(script, vars)
+    def RunBuildScripts(self, files, vars = {}):
+        if util.IsString(files):
+            self.generator.evalScript(files, vars)
+        else:
+            for script in files:
+                self.generator.evalScript(script, vars)
 
-  def Add(self, taskbuilder):
-    taskbuilder.finish(self)
-    return taskbuilder.generate(self.generator, self)
+    def Add(self, taskbuilder):
+        taskbuilder.finish(self)
+        return taskbuilder.generate(self.generator, self)
 
-  def AddSource(self, source_path):
-    return self.generator.addSource(self, source_path)
+    def AddSource(self, source_path):
+        return self.generator.addSource(self, source_path)
 
-  def AddSymlink(self, source, output_path):
-    return self.generator.addSymlink(self, source, output_path)
+    def AddSymlink(self, source, output_path):
+        return self.generator.addSymlink(self, source, output_path)
 
-  def AddFolder(self, folder):
-    return self.generator.addFolder(self, folder)
+    def AddFolder(self, folder):
+        return self.generator.addFolder(self, folder)
 
-  def AddCopy(self, source, output_path):
-    return self.generator.addCopy(self, source, output_path)
+    def AddCopy(self, source, output_path):
+        return self.generator.addCopy(self, source, output_path)
 
-  def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=[],
-                 shared_outputs=[]):
-    return self.generator.addShellCommand(
-      self,
-      inputs,
-      argv,
-      outputs,
-      folder = folder,
-      dep_type = dep_type,
-      weak_inputs = weak_inputs,
-      shared_outputs = shared_outputs
-    )
+    def AddCommand(self,
+                   inputs,
+                   argv,
+                   outputs,
+                   folder = -1,
+                   dep_type = None,
+                   weak_inputs = [],
+                   shared_outputs = []):
+        return self.generator.addShellCommand(self,
+                                              inputs,
+                                              argv,
+                                              outputs,
+                                              folder = folder,
+                                              dep_type = dep_type,
+                                              weak_inputs = weak_inputs,
+                                              shared_outputs = shared_outputs)
 
-  def AddConfigureFile(self, path):
-    return self.generator.addConfigureFile(self, path)
+    def AddConfigureFile(self, path):
+        return self.generator.addConfigureFile(self, path)
 
-  def Context(self, name):
-    return self.generator.Context(name)
+    def Context(self, name):
+        return self.generator.Context(name)
 
 class AutoContext(Context):
-  def __init__(self, gen, parent, file):
-    super(AutoContext, self).__init__(gen, parent, file)
+    def __init__(self, gen, parent, file):
+        super(AutoContext, self).__init__(gen, parent, file)
 
-  def __enter__(self):
-    self.generator.pushContext(self)
-    return self
+    def __enter__(self):
+        self.generator.pushContext(self)
+        return self
 
-  def __exit__(self, type, value, traceback):
-    self.generator.popContext()
+    def __exit__(self, type, value, traceback):
+        self.generator.popContext()
 
 class BaseGenerator(object):
-  def __init__(self, sourcePath, buildPath, originalCwd, options, args):
-    super(BaseGenerator, self).__init__()
-    self.sourcePath = sourcePath
-    self.buildPath = os.path.normpath(buildPath)
-    self.originalCwd = originalCwd
-    self.options = options
-    self.args = args
-    self.contextStack_ = [None]
-    self.configure_failed = False
+    def __init__(self, sourcePath, buildPath, originalCwd, options, args):
+        super(BaseGenerator, self).__init__()
+        self.sourcePath = sourcePath
+        self.buildPath = os.path.normpath(buildPath)
+        self.originalCwd = originalCwd
+        self.options = options
+        self.args = args
+        self.contextStack_ = [None]
+        self.configure_failed = False
 
-    # This is a hack... if we ever do cross-compiling or something, we'll have
-    # to change this.
-    self.host_platform = util.Platform()
-    self.target_platform = util.Platform()
+        # This is a hack... if we ever do cross-compiling or something, we'll have
+        # to change this.
+        self.host_platform = util.Platform()
+        self.target_platform = util.Platform()
 
-  def parseBuildScripts(self):
-    root = os.path.join(self.sourcePath, 'AMBuildScript')
-    self.evalScript(root)
+    def parseBuildScripts(self):
+        root = os.path.join(self.sourcePath, 'AMBuildScript')
+        self.evalScript(root)
 
-  def pushContext(self, cx):
-    self.contextStack_.append(cx)
+    def pushContext(self, cx):
+        self.contextStack_.append(cx)
 
-  def popContext(self):
-    self.contextStack_.pop()
+    def popContext(self):
+        self.contextStack_.pop()
 
-  def enterContext(self, cx):
-    pass
+    def enterContext(self, cx):
+        pass
 
-  def leaveContext(self, cx):
-    pass
+    def leaveContext(self, cx):
+        pass
 
-  def compileScript(self, path):
-    with open(path) as fp:
-      chars = fp.read()
+    def compileScript(self, path):
+        with open(path) as fp:
+            chars = fp.read()
 
-      # Python 2.6 can't compile() with Windows line endings?!?!!?
-      chars = chars.replace('\r\n', '\n')
-      chars = chars.replace('\r', '\n')
+            # Python 2.6 can't compile() with Windows line endings?!?!!?
+            chars = chars.replace('\r\n', '\n')
+            chars = chars.replace('\r', '\n')
 
-      return compile(chars, path, 'exec')
+            return compile(chars, path, 'exec')
 
-  def importScript(self, context, file, vars={}):
-    path = os.path.normpath(os.path.join(context.sourcePath, file))
-    self.addConfigureFile(context, path)
+    def importScript(self, context, file, vars = {}):
+        path = os.path.normpath(os.path.join(context.sourcePath, file))
+        self.addConfigureFile(context, path)
 
-    new_vars = copy.copy(vars)
-    new_vars['builder'] = context
+        new_vars = copy.copy(vars)
+        new_vars['builder'] = context
 
-    code = self.compileScript(path)
-    exec(code, new_vars)
+        code = self.compileScript(path)
+        exec(code, new_vars)
 
-    obj = util.Expando()
-    for key in new_vars:
-      setattr(obj, key, new_vars[key])
-    return obj
+        obj = util.Expando()
+        for key in new_vars:
+            setattr(obj, key, new_vars[key])
+        return obj
 
-  def Context(self, name):
-    return AutoContext(self, self.contextStack_[-1], name)
+    def Context(self, name):
+        return AutoContext(self, self.contextStack_[-1], name)
 
-  def evalScript(self, file, vars={}):
-    file = os.path.normpath(file)
+    def evalScript(self, file, vars = {}):
+        file = os.path.normpath(file)
 
-    cx = Context(self, self.contextStack_[-1], file)
-    self.pushContext(cx)
+        cx = Context(self, self.contextStack_[-1], file)
+        self.pushContext(cx)
 
-    full_path = os.path.join(self.sourcePath, cx.buildScript)
+        full_path = os.path.join(self.sourcePath, cx.buildScript)
 
-    self.addConfigureFile(cx, full_path)
+        self.addConfigureFile(cx, full_path)
 
-    new_vars = copy.copy(vars)
-    new_vars['builder'] = cx
+        new_vars = copy.copy(vars)
+        new_vars['builder'] = cx
 
-    # Run it.
-    rvalue = None
-    code = self.compileScript(full_path)
+        # Run it.
+        rvalue = None
+        code = self.compileScript(full_path)
 
-    self.enterContext(cx)
-    exec(code, new_vars)
-    self.leaveContext(cx)
+        self.enterContext(cx)
+        exec(code, new_vars)
+        self.leaveContext(cx)
 
-    if 'rvalue' in new_vars:
-      rvalue = new_vars['rvalue']
-      del new_vars['rvalue']
+        if 'rvalue' in new_vars:
+            rvalue = new_vars['rvalue']
+            del new_vars['rvalue']
 
-    self.popContext()
-    return rvalue
+        self.popContext()
+        return rvalue
 
-  def generateBuildFiles(self):
-    build_py = os.path.join(self.buildPath, 'build.py')
-    with open(build_py, 'w') as fp:
-      fp.write("""
+    def generateBuildFiles(self):
+        build_py = os.path.join(self.buildPath, 'build.py')
+        with open(build_py, 'w') as fp:
+            fp.write("""
 #!{exe}
 # vim set: ts=8 sts=2 sw=2 tw=99 et:
 import sys
@@ -261,41 +265,48 @@ from ambuild2 import run
 
 if not run.CompatBuild(r"{build}"):
   sys.exit(1)
-""".format(exe=sys.executable, build=self.buildPath))
+""".format(exe = sys.executable, build = self.buildPath))
 
-    with open(os.path.join(self.buildPath, 'Makefile'), 'w') as fp:
-      fp.write("""
+        with open(os.path.join(self.buildPath, 'Makefile'), 'w') as fp:
+            fp.write("""
 all:
 	"{exe}" "{py}"
-""".format(exe=sys.executable, py=build_py))
+""".format(exe = sys.executable, py = build_py))
 
-  def generate(self):
-    self.preGenerate()
-    self.parseBuildScripts()
-    self.postGenerate()
-    if self.options.make_scripts:
-      self.generateBuildFiles()
-    return True
+    def generate(self):
+        self.preGenerate()
+        self.parseBuildScripts()
+        self.postGenerate()
+        if self.options.make_scripts:
+            self.generateBuildFiles()
+        return True
 
-  def getLocalFolder(self, context):
-    return context.localFolder_
+    def getLocalFolder(self, context):
+        return context.localFolder_
 
-  @property
-  def backend(self):
-    raise Exception('Must be implemented!')
+    @property
+    def backend(self):
+        raise Exception('Must be implemented!')
 
-  def addSymlink(self, context, source, output_path):
-    raise Exception('Must be implemented!')
+    def addSymlink(self, context, source, output_path):
+        raise Exception('Must be implemented!')
 
-  def addFolder(self, context, folder):
-    raise Exception('Must be implemented!')
+    def addFolder(self, context, folder):
+        raise Exception('Must be implemented!')
 
-  def addCopy(self, context, source, output_path):
-    raise Exception('Must be implemented!')
+    def addCopy(self, context, source, output_path):
+        raise Exception('Must be implemented!')
 
-  def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
-    raise Exception('Must be implemented!')
+    def addShellCommand(self,
+                        context,
+                        inputs,
+                        argv,
+                        outputs,
+                        folder = -1,
+                        dep_type = None,
+                        weak_inputs = [],
+                        shared_outputs = []):
+        raise Exception('Must be implemented!')
 
-  def addConfigureFile(self, context, path):
-    raise Exception('Must be implemented!')
+    def addConfigureFile(self, context, path):
+        raise Exception('Must be implemented!')

--- a/ambuild2/frontend/v2_0/cpp/__init__.py
+++ b/ambuild2/frontend/v2_0/cpp/__init__.py
@@ -2,7 +2,6 @@ from ambuild2.frontend.v2_0.cpp.compilers import Compiler
 from ambuild2.frontend.v2_0.cpp.builders import Dep
 
 class CppNodes(object):
-  def __init__(self, output, debug_outputs):
-    self.binary = output
-    self.debug = debug_outputs
-
+    def __init__(self, output, debug_outputs):
+        self.binary = output
+        self.debug = debug_outputs

--- a/ambuild2/frontend/v2_0/cpp/builders.py
+++ b/ambuild2/frontend/v2_0/cpp/builders.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import subprocess
@@ -23,383 +23,380 @@ from ambuild2 import util
 from ambuild2.frontend.v2_0.cpp.vendors import MSVC, CompatGCC, Emscripten
 
 class Dep(object):
-  def __init__(self, text, node):
-    self.text = text
-    self.node = node
+    def __init__(self, text, node):
+        self.text = text
+        self.node = node
 
-  @staticmethod
-  def resolve(cx, builder, item):
-    if type(item) is Dep:
-      # If the dep is a file dependency (no node attached), and has a relative
-      # path, make it absolute so the linker knows where to look.
-      if item.node is None and not os.path.isabs(item.text):
-        return os.path.join(cx.currentSourcePath, item.text)
-      return item.text
+    @staticmethod
+    def resolve(cx, builder, item):
+        if type(item) is Dep:
+            # If the dep is a file dependency (no node attached), and has a relative
+            # path, make it absolute so the linker knows where to look.
+            if item.node is None and not os.path.isabs(item.text):
+                return os.path.join(cx.currentSourcePath, item.text)
+            return item.text
 
-    if hasattr(item, 'path'):
-      if os.path.isabs(item.path):
-        return item.path
+        if hasattr(item, 'path'):
+            if os.path.isabs(item.path):
+                return item.path
 
-      local_path = os.path.join(cx.buildFolder, builder.localFolder)
-      return os.path.relpath(item.path, local_path)
+            local_path = os.path.join(cx.buildFolder, builder.localFolder)
+            return os.path.relpath(item.path, local_path)
 
-    return item
+        return item
 
 class BuilderProxy(object):
-  def __init__(self, builder, compiler, name):
-    self.constructor_ = builder.constructor_
-    self.sources = builder.sources[:]
-    self.compiler = compiler
-    self.name_ = name
+    def __init__(self, builder, compiler, name):
+        self.constructor_ = builder.constructor_
+        self.sources = builder.sources[:]
+        self.compiler = compiler
+        self.name_ = name
 
-  @property
-  def outputFile(self):
-    return self.constructor_.buildName(self.compiler, self.name_)
+    @property
+    def outputFile(self):
+        return self.constructor_.buildName(self.compiler, self.name_)
 
-  @property
-  def localFolder(self):
-    return self.name_
+    @property
+    def localFolder(self):
+        return self.name_
 
-  @property
-  def type(self):
-    return self.constructor_.type
+    @property
+    def type(self):
+        return self.constructor_.type
 
-  @staticmethod
-  def Dep(text, node=None): 
-    return Dep(text, node)
+    @staticmethod
+    def Dep(text, node = None):
+        return Dep(text, node)
 
 class Project(object):
-  def __init__(self, constructor, compiler, name):
-    super(Project, self).__init__()
-    self.constructor_ = constructor
-    self.compiler = compiler
-    self.name = name
-    self.sources = []
-    self.proxies_ = []
-    self.builders_ = []
+    def __init__(self, constructor, compiler, name):
+        super(Project, self).__init__()
+        self.constructor_ = constructor
+        self.compiler = compiler
+        self.name = name
+        self.sources = []
+        self.proxies_ = []
+        self.builders_ = []
 
-  def finish(self, cx):
-    for task in self.proxies_:
-      builder = task.constructor_(task.compiler, task.name_)
-      builder.sources = task.sources
-      builder.finish(cx)
-      self.builders_.append(builder)
+    def finish(self, cx):
+        for task in self.proxies_:
+            builder = task.constructor_(task.compiler, task.name_)
+            builder.sources = task.sources
+            builder.finish(cx)
+            self.builders_.append(builder)
 
-  def generate(self, generator, cx):
-    outputs = []
-    for builder in self.builders_:
-      outputs += [builder.generate(generator, cx)]
-    return outputs
+    def generate(self, generator, cx):
+        outputs = []
+        for builder in self.builders_:
+            outputs += [builder.generate(generator, cx)]
+        return outputs
 
-  def Configure(self, name, tag):
-    compiler = self.compiler.clone()
-    proxy = BuilderProxy(self, compiler, name)
-    self.proxies_.append(proxy)
-    return proxy
+    def Configure(self, name, tag):
+        compiler = self.compiler.clone()
+        proxy = BuilderProxy(self, compiler, name)
+        self.proxies_.append(proxy)
+        return proxy
 
 # Environment representing a C/C++ compiler invocation. Encapsulates most
 # arguments.
 class ArgBuilder(object):
-  def __init__(self, outputPath, config, compiler):
-    args = compiler.command.split(' ')
-    args += config.cflags
-    if config.debug_symbols:
-      args += compiler.debuginfo_argv
-    if compiler == config.cxx:
-      args += config.cxxflags
-    else:
-      args += config.c_only_flags
-    args += [compiler.definePrefix + define for define in config.defines]
-    if compiler == config.cxx:
-      args += [compiler.definePrefix + define for define in config.cxxdefines]
-    for include in config.includes:
-      args += compiler.formatInclude(outputPath, include)
-    if compiler == config.cxx:
-      for include in config.cxxincludes:
-        args += compiler.formatInclude(outputPath, include)
-    self.argv = args
-    self.compiler = compiler
+    def __init__(self, outputPath, config, compiler):
+        args = compiler.command.split(' ')
+        args += config.cflags
+        if config.debug_symbols:
+            args += compiler.debuginfo_argv
+        if compiler == config.cxx:
+            args += config.cxxflags
+        else:
+            args += config.c_only_flags
+        args += [compiler.definePrefix + define for define in config.defines]
+        if compiler == config.cxx:
+            args += [compiler.definePrefix + define for define in config.cxxdefines]
+        for include in config.includes:
+            args += compiler.formatInclude(outputPath, include)
+        if compiler == config.cxx:
+            for include in config.cxxincludes:
+                args += compiler.formatInclude(outputPath, include)
+        self.argv = args
+        self.compiler = compiler
 
 def NameForObjectFile(file):
-  return re.sub('[^a-zA-Z0-9_]+', '_', os.path.splitext(file)[0])
+    return re.sub('[^a-zA-Z0-9_]+', '_', os.path.splitext(file)[0])
 
 class ObjectFile(object):
-  def __init__(self, sourceFile, outputFile, argv, sharedOutputs):
-    self.sourceFile = sourceFile
-    self.outputFile = outputFile
-    self.argv = argv
-    self.sharedOutputs = sharedOutputs
+    def __init__(self, sourceFile, outputFile, argv, sharedOutputs):
+        self.sourceFile = sourceFile
+        self.outputFile = outputFile
+        self.argv = argv
+        self.sharedOutputs = sharedOutputs
 
 class RCFile(object):
-  def __init__(self, sourceFile, preprocFile, outputFile, cl_argv, rc_argv):
-    self.sourceFile = sourceFile
-    self.preprocFile = preprocFile
-    self.outputFile = outputFile
-    self.cl_argv = cl_argv 
-    self.rc_argv = rc_argv
+    def __init__(self, sourceFile, preprocFile, outputFile, cl_argv, rc_argv):
+        self.sourceFile = sourceFile
+        self.preprocFile = preprocFile
+        self.outputFile = outputFile
+        self.cl_argv = cl_argv
+        self.rc_argv = rc_argv
 
 class BinaryBuilder(object):
-  def __init__(self, compiler, name):
-    super(BinaryBuilder, self).__init__()
-    self.compiler = compiler
-    self.sources = []
-    self.name_ = name
-    self.used_cxx_ = False
-    self.linker_ = None
+    def __init__(self, compiler, name):
+        super(BinaryBuilder, self).__init__()
+        self.compiler = compiler
+        self.sources = []
+        self.name_ = name
+        self.used_cxx_ = False
+        self.linker_ = None
 
-  @property
-  def outputFile(self):
-    return self.buildName(self.compiler, self.name_)
+    @property
+    def outputFile(self):
+        return self.buildName(self.compiler, self.name_)
 
-  def generate(self, generator, cx):
-    return generator.addCxxTasks(cx, self)
+    def generate(self, generator, cx):
+        return generator.addCxxTasks(cx, self)
 
-  # Make an item that can be passed into linkflags/postlink but has an attached
-  # dependency.
-  def Dep(self, text, node=None): 
-    return Dep(text, node)
+    # Make an item that can be passed into linkflags/postlink but has an attached
+    # dependency.
+    def Dep(self, text, node = None):
+        return Dep(text, node)
 
-  # The folder we'll be in, relative to our build context.
-  @property
-  def localFolder(self):
-    return self.name_
+    # The folder we'll be in, relative to our build context.
+    @property
+    def localFolder(self):
+        return self.name_
 
-  # Exposed only for frontends.
-  @property
-  def linker(self):
-    return self.linker_
+    # Exposed only for frontends.
+    @property
+    def linker(self):
+        return self.linker_
 
-  # Compute the build folder.
-  def getBuildFolder(self, builder):
-    return os.path.join(builder.buildFolder, self.localFolder)
+    # Compute the build folder.
+    def getBuildFolder(self, builder):
+        return os.path.join(builder.buildFolder, self.localFolder)
 
-  def linkFlags(self, cx):
-    argv = [Dep.resolve(cx, self, item) for item in self.compiler.linkflags]
-    argv += [Dep.resolve(cx, self, item) for item in self.compiler.postlink]
-    return argv
+    def linkFlags(self, cx):
+        argv = [Dep.resolve(cx, self, item) for item in self.compiler.linkflags]
+        argv += [Dep.resolve(cx, self, item) for item in self.compiler.postlink]
+        return argv
 
-  def finish(self, cx):
-    # Because we want to compute relative include folders for MSVC (see its
-    # vendor object), we need to compute an absolute path to the build folder.
-    self.outputFolder = self.getBuildFolder(cx)
-    self.outputPath = os.path.join(cx.buildPath, self.outputFolder)
-    self.default_c_env = ArgBuilder(self.outputPath, self.compiler, self.compiler.cc)
-    self.default_cxx_env = ArgBuilder(self.outputPath, self.compiler, self.compiler.cxx)
+    def finish(self, cx):
+        # Because we want to compute relative include folders for MSVC (see its
+        # vendor object), we need to compute an absolute path to the build folder.
+        self.outputFolder = self.getBuildFolder(cx)
+        self.outputPath = os.path.join(cx.buildPath, self.outputFolder)
+        self.default_c_env = ArgBuilder(self.outputPath, self.compiler, self.compiler.cc)
+        self.default_cxx_env = ArgBuilder(self.outputPath, self.compiler, self.compiler.cxx)
 
-    shared_cc_outputs = []
-    if self.compiler.debug_symbols and self.compiler.cc.behavior == 'msvc':
-      cl_version = (int(int(self.compiler.cc.version) / 100) - 6) * 10
-      if cl_version >= 130:
-        cl_version += 10
-      shared_pdb = 'vc{0}.pdb'.format(cl_version)
-      shared_cc_outputs += [shared_pdb]
+        shared_cc_outputs = []
+        if self.compiler.debug_symbols and self.compiler.cc.behavior == 'msvc':
+            cl_version = (int(int(self.compiler.cc.version) / 100) - 6) * 10
+            if cl_version >= 130:
+                cl_version += 10
+            shared_pdb = 'vc{0}.pdb'.format(cl_version)
+            shared_cc_outputs += [shared_pdb]
 
-    self.objects = []
-    self.resources = []
-    for item in self.sources:
-      if os.path.isabs(item):
-        sourceFile = item
-      else:
-        sourceFile = os.path.join(cx.currentSourcePath, item)
-      sourceFile = os.path.normpath(sourceFile)
+        self.objects = []
+        self.resources = []
+        for item in self.sources:
+            if os.path.isabs(item):
+                sourceFile = item
+            else:
+                sourceFile = os.path.join(cx.currentSourcePath, item)
+            sourceFile = os.path.normpath(sourceFile)
 
-      filename, extension = os.path.splitext(item)
-      encname = NameForObjectFile(filename)
+            filename, extension = os.path.splitext(item)
+            encname = NameForObjectFile(filename)
 
-      if extension == '.rc':
-        cenv = self.default_c_env
-        objectFile = encname + '.res'
-      else:
-        if extension == '.c':
-          cenv = self.default_c_env
-        else:
-          cenv = self.default_cxx_env
-          self.used_cxx_ = True
-        objectFile = encname + cenv.compiler.objSuffix
+            if extension == '.rc':
+                cenv = self.default_c_env
+                objectFile = encname + '.res'
+            else:
+                if extension == '.c':
+                    cenv = self.default_c_env
+                else:
+                    cenv = self.default_cxx_env
+                    self.used_cxx_ = True
+                objectFile = encname + cenv.compiler.objSuffix
 
-      if extension == '.rc':
-        # This is only relevant on Windows.
-        vendor = cenv.compiler
-        defines = self.compiler.defines + self.compiler.cxxdefines + self.compiler.rcdefines
-        cl_argv = vendor.command.split(' ')
-        cl_argv += [vendor.definePrefix + define for define in defines]
-        for include in (self.compiler.includes + self.compiler.cxxincludes):
-          cl_argv += vendor.formatInclude(objectFile, include)
-        cl_argv += vendor.preprocessArgs(sourceFile, encname + '.i')
+            if extension == '.rc':
+                # This is only relevant on Windows.
+                vendor = cenv.compiler
+                defines = self.compiler.defines + self.compiler.cxxdefines + self.compiler.rcdefines
+                cl_argv = vendor.command.split(' ')
+                cl_argv += [vendor.definePrefix + define for define in defines]
+                for include in (self.compiler.includes + self.compiler.cxxincludes):
+                    cl_argv += vendor.formatInclude(objectFile, include)
+                cl_argv += vendor.preprocessArgs(sourceFile, encname + '.i')
 
-        rc_argv = ['rc', '/nologo']
-        for define in defines:
-          rc_argv.extend(['/d', define])
-        for include in (self.compiler.includes + self.compiler.cxxincludes):
-          rc_argv.extend(['/i', MSVC.IncludePath(objectFile, include)])
-        rc_argv.append('/fo' + objectFile)
-        rc_argv.append(sourceFile)
+                rc_argv = ['rc', '/nologo']
+                for define in defines:
+                    rc_argv.extend(['/d', define])
+                for include in (self.compiler.includes + self.compiler.cxxincludes):
+                    rc_argv.extend(['/i', MSVC.IncludePath(objectFile, include)])
+                rc_argv.append('/fo' + objectFile)
+                rc_argv.append(sourceFile)
 
-        self.resources.append(RCFile(sourceFile, encname + '.i', objectFile, cl_argv, rc_argv))
-      else:
-        argv = cenv.argv + cenv.compiler.objectArgs(sourceFile, objectFile)
-        obj = ObjectFile(sourceFile, objectFile, argv, shared_cc_outputs)
-        self.objects.append(obj)
+                self.resources.append(
+                    RCFile(sourceFile, encname + '.i', objectFile, cl_argv, rc_argv))
+            else:
+                argv = cenv.argv + cenv.compiler.objectArgs(sourceFile, objectFile)
+                obj = ObjectFile(sourceFile, objectFile, argv, shared_cc_outputs)
+                self.objects.append(obj)
 
-    if not self.linker_:
-      if self.used_cxx_:
-        self.linker_ = self.compiler.cxx
-      else:
-        self.linker_ = self.compiler.cc
+        if not self.linker_:
+            if self.used_cxx_:
+                self.linker_ = self.compiler.cxx
+            else:
+                self.linker_ = self.compiler.cc
 
-    files = [out.outputFile for out in self.objects + self.resources]
-    self.argv = self.generateBinary(cx, files)
-    self.linker_outputs = [self.outputFile]
-    self.debug_entry = None
+        files = [out.outputFile for out in self.objects + self.resources]
+        self.argv = self.generateBinary(cx, files)
+        self.linker_outputs = [self.outputFile]
+        self.debug_entry = None
 
-    if self.linker_.behavior == 'msvc':
-      if isinstance(self, Library):
-        # In theory, .dlls should have exports, so MSVC will generate these
-        # files. If this turns out not to be true, we may have to get fancier.
-        self.linker_outputs += [self.name_ + '.lib']
-        self.linker_outputs += [self.name_ + '.exp']
+        if self.linker_.behavior == 'msvc':
+            if isinstance(self, Library):
+                # In theory, .dlls should have exports, so MSVC will generate these
+                # files. If this turns out not to be true, we may have to get fancier.
+                self.linker_outputs += [self.name_ + '.lib']
+                self.linker_outputs += [self.name_ + '.exp']
 
-    if self.compiler.debug_symbols == 'separate':
-      self.perform_symbol_steps(cx)
+        if self.compiler.debug_symbols == 'separate':
+            self.perform_symbol_steps(cx)
 
-  def perform_symbol_steps(self, cx):
-    if isinstance(self.linker_, MSVC):
-      # Note, pdb is last since we read the pdb as outputs[-1].
-      self.linker_outputs += [self.name_ + '.pdb']
-    elif cx.target_platform == 'mac':
-      bundle_folder = os.path.join(self.localFolder, self.outputFile + '.dSYM')
-      bundle_entry = cx.AddFolder(bundle_folder)
-      bundle_layout = [
-        'Contents',
-        'Contents/Resources',
-        'Contents/Resources/DWARF',
-      ]
-      for folder in bundle_layout:
-        cx.AddFolder(os.path.join(bundle_folder, folder))
-      self.linker_outputs += [
-        self.outputFile + '.dSYM/Contents/Info.plist',
-        self.outputFile + '.dSYM/Contents/Resources/DWARF/' + self.outputFile
-      ]
-      self.debug_entry = bundle_entry
-      self.argv = ['ambuild_dsymutil_wrapper.sh', self.outputFile] + self.argv
-    elif cx.target_platform == 'linux':
-      self.linker_outputs += [
-        self.outputFile + '.dbg'
-      ]
-      self.argv = ['ambuild_objcopy_wrapper.sh', self.outputFile] + self.argv
+    def perform_symbol_steps(self, cx):
+        if isinstance(self.linker_, MSVC):
+            # Note, pdb is last since we read the pdb as outputs[-1].
+            self.linker_outputs += [self.name_ + '.pdb']
+        elif cx.target_platform == 'mac':
+            bundle_folder = os.path.join(self.localFolder, self.outputFile + '.dSYM')
+            bundle_entry = cx.AddFolder(bundle_folder)
+            bundle_layout = [
+                'Contents',
+                'Contents/Resources',
+                'Contents/Resources/DWARF',
+            ]
+            for folder in bundle_layout:
+                cx.AddFolder(os.path.join(bundle_folder, folder))
+            self.linker_outputs += [
+                self.outputFile + '.dSYM/Contents/Info.plist',
+                self.outputFile + '.dSYM/Contents/Resources/DWARF/' + self.outputFile
+            ]
+            self.debug_entry = bundle_entry
+            self.argv = ['ambuild_dsymutil_wrapper.sh', self.outputFile] + self.argv
+        elif cx.target_platform == 'linux':
+            self.linker_outputs += [self.outputFile + '.dbg']
+            self.argv = ['ambuild_objcopy_wrapper.sh', self.outputFile] + self.argv
 
-  def link(self, context, folder, inputs):
-    # The existence of .ilk files on Windows does not seem reliable, so we
-    # treat it as "shared" which does not participate in the DAG (yet).
-    shared_outputs = []
-    if self.linker_.behavior == 'msvc':
-      if not isinstance(self, StaticLibrary) and '/INCREMENTAL:NO' not in self.argv:
-        shared_outputs += [self.name_ + '.ilk']
+    def link(self, context, folder, inputs):
+        # The existence of .ilk files on Windows does not seem reliable, so we
+        # treat it as "shared" which does not participate in the DAG (yet).
+        shared_outputs = []
+        if self.linker_.behavior == 'msvc':
+            if not isinstance(self, StaticLibrary) and '/INCREMENTAL:NO' not in self.argv:
+                shared_outputs += [self.name_ + '.ilk']
 
-    ignore, outputs = context.AddCommand(
-      inputs = inputs,
-      argv = self.argv,
-      outputs = self.linker_outputs,
-      folder = folder,
-      shared_outputs = shared_outputs
-    )
-    if not self.debug_entry and self.compiler.debug_symbols:
-      if self.linker_.behavior != 'msvc' and self.compiler.debug_symbols == 'bundled':
-        self.debug_entry = outputs[0]
-      else:
-        self.debug_entry = outputs[-1]
-    return outputs[0], self.debug_entry
+        ignore, outputs = context.AddCommand(inputs = inputs,
+                                             argv = self.argv,
+                                             outputs = self.linker_outputs,
+                                             folder = folder,
+                                             shared_outputs = shared_outputs)
+        if not self.debug_entry and self.compiler.debug_symbols:
+            if self.linker_.behavior != 'msvc' and self.compiler.debug_symbols == 'bundled':
+                self.debug_entry = outputs[0]
+            else:
+                self.debug_entry = outputs[-1]
+        return outputs[0], self.debug_entry
 
 class Program(BinaryBuilder):
-  def __init__(self, compiler, name):
-    super(Program, self).__init__(compiler, name)
+    def __init__(self, compiler, name):
+        super(Program, self).__init__(compiler, name)
 
-  @staticmethod
-  def buildName(compiler, name):
-    return compiler.nameForExecutable(name)
+    @staticmethod
+    def buildName(compiler, name):
+        return compiler.nameForExecutable(name)
 
-  @property
-  def type(self):
-    return 'program'
+    @property
+    def type(self):
+        return 'program'
 
-  def generateBinary(self, cx, files):
-    argv = self.linker_.command.split(' ')
-    argv += files
+    def generateBinary(self, cx, files):
+        argv = self.linker_.command.split(' ')
+        argv += files
 
-    if isinstance(self.linker_, MSVC):
-      argv.append('/link')
-      argv.extend(self.linkFlags(cx))
-      argv.append('/nologo')
-      argv += [
-        '/OUT:' + self.outputFile,
-        '/nologo',
-      ]
-      if self.compiler.debug_symbols:
-        argv += ['/DEBUG', '/PDB:"' + self.name_ + '.pdb"']
-    else:
-      argv.extend(self.linkFlags(cx))
-      argv.extend(['-o', self.outputFile])
+        if isinstance(self.linker_, MSVC):
+            argv.append('/link')
+            argv.extend(self.linkFlags(cx))
+            argv.append('/nologo')
+            argv += [
+                '/OUT:' + self.outputFile,
+                '/nologo',
+            ]
+            if self.compiler.debug_symbols:
+                argv += ['/DEBUG', '/PDB:"' + self.name_ + '.pdb"']
+        else:
+            argv.extend(self.linkFlags(cx))
+            argv.extend(['-o', self.outputFile])
 
-    return argv
+        return argv
 
 class Library(BinaryBuilder):
-  def __init__(self, compiler, name):
-    super(Library, self).__init__(compiler, name)
+    def __init__(self, compiler, name):
+        super(Library, self).__init__(compiler, name)
 
-  @staticmethod
-  def buildName(compiler, name):
-    return compiler.nameForSharedLibrary(name)
+    @staticmethod
+    def buildName(compiler, name):
+        return compiler.nameForSharedLibrary(name)
 
-  @property
-  def type(self):
-    return 'library'
+    @property
+    def type(self):
+        return 'library'
 
-  def generateBinary(self, cx, files):
-    argv = self.linker_.command.split(' ')
-    argv += files
+    def generateBinary(self, cx, files):
+        argv = self.linker_.command.split(' ')
+        argv += files
 
-    if isinstance(self.linker_, MSVC):
-      argv.append('/link')
-      argv.extend(self.linkFlags(cx))
-      argv += [
-        '/OUT:' + self.outputFile,
-        '/DEBUG',
-        '/nologo',
-        '/DLL',
-      ]
-      if self.compiler.debug_symbols:
-        argv += ['/DEBUG', '/PDB:"' + self.name_ + '.pdb"']
-    elif isinstance(self.linker_, CompatGCC):
-      argv.extend(self.linkFlags(cx))
-      if util.IsMac():
-        argv.append('-dynamiclib')
-      else:
-        argv.append('-shared')
-      argv.extend(['-o', self.outputFile])
+        if isinstance(self.linker_, MSVC):
+            argv.append('/link')
+            argv.extend(self.linkFlags(cx))
+            argv += [
+                '/OUT:' + self.outputFile,
+                '/DEBUG',
+                '/nologo',
+                '/DLL',
+            ]
+            if self.compiler.debug_symbols:
+                argv += ['/DEBUG', '/PDB:"' + self.name_ + '.pdb"']
+        elif isinstance(self.linker_, CompatGCC):
+            argv.extend(self.linkFlags(cx))
+            if util.IsMac():
+                argv.append('-dynamiclib')
+            else:
+                argv.append('-shared')
+            argv.extend(['-o', self.outputFile])
 
-    return argv
+        return argv
 
 class StaticLibrary(BinaryBuilder):
-  def __init__(self, compiler, name):
-    super(StaticLibrary, self).__init__(compiler, name)
+    def __init__(self, compiler, name):
+        super(StaticLibrary, self).__init__(compiler, name)
 
-  @staticmethod
-  def buildName(compiler, name):
-    return compiler.nameForStaticLibrary(name)
+    @staticmethod
+    def buildName(compiler, name):
+        return compiler.nameForStaticLibrary(name)
 
-  @property
-  def type(self):
-    return 'static'
+    @property
+    def type(self):
+        return 'static'
 
-  def generateBinary(self, cx, files):
-    if isinstance(self.linker_, MSVC):
-      argv = ['lib.exe', '/OUT:' + self.outputFile]
-    elif isinstance(self.linker_, Emscripten):
-      argv = ['llvm-ar', 'rcs', self.outputFile]
-    else:
-      argv = ['ar', 'rcs', self.outputFile]
-    argv += files
-    return argv
+    def generateBinary(self, cx, files):
+        if isinstance(self.linker_, MSVC):
+            argv = ['lib.exe', '/OUT:' + self.outputFile]
+        elif isinstance(self.linker_, Emscripten):
+            argv = ['llvm-ar', 'rcs', self.outputFile]
+        else:
+            argv = ['ar', 'rcs', self.outputFile]
+        argv += files
+        return argv
 
-  def perform_symbol_steps(self, cx):
-    pass
+    def perform_symbol_steps(self, cx):
+        pass

--- a/ambuild2/frontend/v2_0/cpp/compilers.py
+++ b/ambuild2/frontend/v2_0/cpp/compilers.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import copy
@@ -20,166 +20,167 @@ from ambuild2.frontend.v2_0.cpp import builders
 
 # Base compiler object.
 class Compiler(object):
-  EnvVars = ['CFLAGS', 'CXXFLAGS', 'CC', 'CXX']
+    EnvVars = ['CFLAGS', 'CXXFLAGS', 'CC', 'CXX']
 
-  attrs = [
-    'includes',         # C and C++ include paths
-    'cxxincludes',      # C++-only include paths
-    'cflags',           # C and C++ compiler flags
-    'cxxflags',         # C++-only compiler flags
-    'defines',          # C and C++ #defines
-    'cxxdefines',       # C++-only #defines
+    attrs = [
+        'includes',  # C and C++ include paths
+        'cxxincludes',  # C++-only include paths
+        'cflags',  # C and C++ compiler flags
+        'cxxflags',  # C++-only compiler flags
+        'defines',  # C and C++ #defines
+        'cxxdefines',  # C++-only #defines
+        'c_only_flags',  # Flags for C but not C++.
+        'rcdefines',  # Resource Compiler (RC) defines
 
-    'c_only_flags',     # Flags for C but not C++.
+        # Link flags. If any members are not strings, they will be interpreted as
+        # Dep entries created from BinaryBuilder.
+        'linkflags',
 
-    'rcdefines',        # Resource Compiler (RC) defines
+        # An array of objects to link, after all link flags have been specified.
+        # Entries may either be strings containing a path, or Dep entries created
+        # from BinaryBuilder.
+        'postlink',
 
-    # Link flags. If any members are not strings, they will be interpreted as
-    # Dep entries created from BinaryBuilder.
-    'linkflags',
+        # An array of nodes which should be weak dependencies on each source
+        # compilation command.
+        'sourcedeps',
+    ]
 
-    # An array of objects to link, after all link flags have been specified.
-    # Entries may either be strings containing a path, or Dep entries created
-    # from BinaryBuilder.
-    'postlink',
+    def __init__(self, options = None):
+        if getattr(options, 'symbol_files', False):
+            self.debuginfo = 'separate'
+        else:
+            self.debuginfo = 'bundled'
+        for attr in self.attrs:
+            setattr(self, attr, [])
 
-    # An array of nodes which should be weak dependencies on each source
-    # compilation command.
-    'sourcedeps',
-  ]
+    def inherit(self, other):
+        self.debuginfo = other.debuginfo
+        for attr in self.attrs:
+            setattr(self, attr, copy.copy(getattr(other, attr)))
 
-  def __init__(self, options = None):
-    if getattr(options, 'symbol_files', False):
-      self.debuginfo = 'separate'
-    else:
-      self.debuginfo = 'bundled'
-    for attr in self.attrs:
-      setattr(self, attr, [])
+    def clone(self):
+        raise Exception('Must be implemented!')
 
-  def inherit(self, other):
-    self.debuginfo = other.debuginfo
-    for attr in self.attrs:
-      setattr(self, attr, copy.copy(getattr(other, attr)))
+    def like(self, name):
+        raise Exception('Must be implemented!')
 
-  def clone(self):
-    raise Exception('Must be implemented!')
+    @property
+    def vendor(self):
+        raise Exception('Must be implemented!')
 
-  def like(self, name):
-    raise Exception('Must be implemented!')
+    @property
+    def version(self):
+        raise Exception('Must be implemented!')
 
-  @property
-  def vendor(self):
-    raise Exception('Must be implemented!')
+    def Program(self, name):
+        raise Exception('Must be implemented!')
 
-  @property
-  def version(self):
-    raise Exception('Must be implemented!')
+    def Library(self, name):
+        raise Exception('Must be implemented!')
 
-  def Program(self, name):
-    raise Exception('Must be implemented!')
+    def StaticLibrary(self, name):
+        raise Exception('Must be implemented!')
 
-  def Library(self, name):
-    raise Exception('Must be implemented!')
-
-  def StaticLibrary(self, name):
-    raise Exception('Must be implemented!')
-
-  @staticmethod
-  def Dep(text, node=None):
-    return builders.Dep(text, node)
+    @staticmethod
+    def Dep(text, node = None):
+        return builders.Dep(text, node)
 
 class CxxCompiler(Compiler):
-  def __init__(self, cc, cxx, options = None):
-    super(CxxCompiler, self).__init__(options)
+    def __init__(self, cc, cxx, options = None):
+        super(CxxCompiler, self).__init__(options)
 
-    # Accesssing these attributes through the API is deprecated.
-    self.cc = cc
-    self.cxx = cxx
-    self.found_pkg_config_ = False
+        # Accesssing these attributes through the API is deprecated.
+        self.cc = cc
+        self.cxx = cxx
+        self.found_pkg_config_ = False
 
-  def clone(self):
-    cc = CxxCompiler(self.cc, self.cxx)
-    cc.inherit(self)
-    return cc
+    def clone(self):
+        cc = CxxCompiler(self.cc, self.cxx)
+        cc.inherit(self)
+        return cc
 
-  def Program(self, name):
-    return builders.Program(self.clone(), name)
+    def Program(self, name):
+        return builders.Program(self.clone(), name)
 
-  def Library(self, name):
-    return builders.Library(self.clone(), name)
+    def Library(self, name):
+        return builders.Library(self.clone(), name)
 
-  def StaticLibrary(self, name):
-    return builders.StaticLibrary(self.clone(), name)
+    def StaticLibrary(self, name):
+        return builders.StaticLibrary(self.clone(), name)
 
-  def ProgramProject(self, name):
-    return builders.Project(builders.Program, self.clone(), name)
+    def ProgramProject(self, name):
+        return builders.Project(builders.Program, self.clone(), name)
 
-  def LibraryProject(self, name):
-    return builders.Project(builders.Library, self.clone(), name)
+    def LibraryProject(self, name):
+        return builders.Project(builders.Library, self.clone(), name)
 
-  def StaticLibraryProject(self, name):
-    return builders.Project(builders.StaticLibrary, self.clone(), name)
+    def StaticLibraryProject(self, name):
+        return builders.Project(builders.StaticLibrary, self.clone(), name)
 
-  # These functions use |cxx|, because we expect the vendors to be the same
-  # across |cc| and |cxx|.
+    # These functions use |cxx|, because we expect the vendors to be the same
+    # across |cc| and |cxx|.
 
-  # Returns whether this compiler acts like another compiler. Available names
-  # are: msvc, gcc, icc, sun, clang
-  def like(self, name):
-    return self.cxx.like(name)
+    # Returns whether this compiler acts like another compiler. Available names
+    # are: msvc, gcc, icc, sun, clang
+    def like(self, name):
+        return self.cxx.like(name)
 
-  # Returns the vendor name (msvc, gcc, icc, sun, clang)
-  @property
-  def vendor(self):
-    return self.cxx.name
+    # Returns the vendor name (msvc, gcc, icc, sun, clang)
+    @property
+    def vendor(self):
+        return self.cxx.name
 
-  # Returns the version of the compiler. The return value is an object that
-  # can be compared against other versions, for example:
-  #
-  #  compiler.version >= '4.8.3'
-  #
-  @property
-  def version(self):
-    return self.cxx.versionObject
+    # Returns the version of the compiler. The return value is an object that
+    # can be compared against other versions, for example:
+    #
+    #  compiler.version >= '4.8.3'
+    #
+    @property
+    def version(self):
+        return self.cxx.versionObject
 
-  # Returns a list containing the program name and arguments used to invoke the compiler.
-  @property
-  def argv(self):
-    return self.cxx.command.split(' ')
+    # Returns a list containing the program name and arguments used to invoke the compiler.
+    @property
+    def argv(self):
+        return self.cxx.command.split(' ')
 
-  # Returns the debuginfo modulo what the underlying vendor's compiler supports.
-  @property
-  def debug_symbols(self):
-    return self.cxx.parse_debuginfo(self.debuginfo)
+    # Returns the debuginfo modulo what the underlying vendor's compiler supports.
+    @property
+    def debug_symbols(self):
+        return self.cxx.parse_debuginfo(self.debuginfo)
 
-  # Internal API.
-  def nameForStaticLibrary(self, name):
-    return self.cxx.nameForStaticLibrary(name)
-  def nameForSharedLibrary(self, name):
-    return self.cxx.nameForSharedLibrary(name)
-  def nameForExecutable(self, name):
-    return self.cxx.nameForExecutable(name)
-  def run_pkg_config(self, argv):
-    output = subprocess.check_output(args = ['pkg-config'] + argv)
-    return [item.strip() for item in output.strip().split(' ') if item.strip() != '']
+    # Internal API.
+    def nameForStaticLibrary(self, name):
+        return self.cxx.nameForStaticLibrary(name)
 
-  # Helper for running pkg-config.
-  def pkg_config(self, pkg, link = 'dynamic'):
-    if not self.found_pkg_config_:
-      try:
-        self.run_pkg_config(['--version'])
-        self.found_pkg_config = True
-      except:
-        raise Exception('failed to find pkg-config!')
+    def nameForSharedLibrary(self, name):
+        return self.cxx.nameForSharedLibrary(name)
 
-    for include in self.run_pkg_config(['--cflags-only-I', pkg]):
-      if include.startswith('-I'):
-        self.includes += [include[2:].strip()]
-      else:
-        self.cflags += [include]
-    self.cflags += self.run_pkg_config(['--cflags-only-other', pkg])
+    def nameForExecutable(self, name):
+        return self.cxx.nameForExecutable(name)
 
-    if link == 'dynamic':
-      self.linkflags += self.run_pkg_config(['--libs', pkg])
-    elif link == 'static':
-      self.linkflags += self.run_pkg_config(['--libs', '--static', pkg])
+    def run_pkg_config(self, argv):
+        output = subprocess.check_output(args = ['pkg-config'] + argv)
+        return [item.strip() for item in output.strip().split(' ') if item.strip() != '']
+
+    # Helper for running pkg-config.
+    def pkg_config(self, pkg, link = 'dynamic'):
+        if not self.found_pkg_config_:
+            try:
+                self.run_pkg_config(['--version'])
+                self.found_pkg_config = True
+            except:
+                raise Exception('failed to find pkg-config!')
+
+        for include in self.run_pkg_config(['--cflags-only-I', pkg]):
+            if include.startswith('-I'):
+                self.includes += [include[2:].strip()]
+            else:
+                self.cflags += [include]
+        self.cflags += self.run_pkg_config(['--cflags-only-other', pkg])
+
+        if link == 'dynamic':
+            self.linkflags += self.run_pkg_config(['--libs', pkg])
+        elif link == 'static':
+            self.linkflags += self.run_pkg_config(['--libs', '--static', pkg])

--- a/ambuild2/frontend/v2_0/cpp/detect.py
+++ b/ambuild2/frontend/v2_0/cpp/detect.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
@@ -22,133 +22,130 @@ from ambuild2 import util
 from ambuild2.frontend.v2_0.cpp import vendors, compilers
 
 def TryVerifyCompiler(env, mode, cmd):
-  if util.IsWindows():
-    cc = VerifyCompiler(env, mode, cmd, 'msvc')
-    if cc:
-      return cc
-  return VerifyCompiler(env, mode, cmd, 'gcc')
+    if util.IsWindows():
+        cc = VerifyCompiler(env, mode, cmd, 'msvc')
+        if cc:
+            return cc
+    return VerifyCompiler(env, mode, cmd, 'gcc')
 
 CompilerSearch = {
-  'CC': {
-    'mac': ['cc', 'clang', 'gcc', 'icc'],
-    'windows': ['cl'],
-    'default': ['cc', 'gcc', 'clang', 'icc']
-  },
-  'CXX': {
-    'mac': ['c++', 'clang++', 'g++', 'icc'],
-    'windows': ['cl'],
-    'default': ['c++', 'g++', 'clang++', 'icc']
-  }
+    'CC': {
+        'mac': ['cc', 'clang', 'gcc', 'icc'],
+        'windows': ['cl'],
+        'default': ['cc', 'gcc', 'clang', 'icc']
+    },
+    'CXX': {
+        'mac': ['c++', 'clang++', 'g++', 'icc'],
+        'windows': ['cl'],
+        'default': ['c++', 'g++', 'clang++', 'icc']
+    }
 }
 
 def DetectMicrosoftInclusionPattern(text):
-  for line in [raw.strip() for raw in text.split('\n')]:
-    m = re.match(r'(.*)\s+([A-Za-z]:\\.*stdio\.h)$', line)
-    if m is None:
-      continue
+    for line in [raw.strip() for raw in text.split('\n')]:
+        m = re.match(r'(.*)\s+([A-Za-z]:\\.*stdio\.h)$', line)
+        if m is None:
+            continue
 
-    phrase = m.group(1)
-    return re.escape(phrase) + r'\s+([A-Za-z]:\\.*)$'
+        phrase = m.group(1)
+        return re.escape(phrase) + r'\s+([A-Za-z]:\\.*)$'
 
-  raise Exception('Could not find compiler inclusion pattern')
+    raise Exception('Could not find compiler inclusion pattern')
 
 def DetectCxx(env, options):
-  cc = DetectCxxCompiler(env, 'CC')
-  cxx = DetectCxxCompiler(env, 'CXX')
+    cc = DetectCxxCompiler(env, 'CC')
+    cxx = DetectCxxCompiler(env, 'CXX')
 
-  # Ensure that the two compilers have the same vendor.
-  if type(cc) is not type(cxx):
-    message = 'C and C++ compiler vendors are not the same: CC={0}, CXX={1}'
-    message = message.format(cc.name, cxx.name)
+    # Ensure that the two compilers have the same vendor.
+    if type(cc) is not type(cxx):
+        message = 'C and C++ compiler vendors are not the same: CC={0}, CXX={1}'
+        message = message.format(cc.name, cxx.name)
 
-    util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
-    raise Exception(message)
+        util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
+        raise Exception(message)
 
-  # Ensure that the two compilers have the same version.
-  if cc.version != cxx.version:
-    message = 'C and C++ compilers have different versions: CC={0}-{1}, CXX={2}-{3}'
-    message = message.format(cc.name, cc.version, cxx.name, cxx.version)
+    # Ensure that the two compilers have the same version.
+    if cc.version != cxx.version:
+        message = 'C and C++ compilers have different versions: CC={0}-{1}, CXX={2}-{3}'
+        message = message.format(cc.name, cc.version, cxx.name, cxx.version)
 
-    util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
-    raise Exception(message)
+        util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
+        raise Exception(message)
 
-  return compilers.CxxCompiler(cc, cxx, options)
+    return compilers.CxxCompiler(cc, cxx, options)
 
 def DetectCxxCompiler(env, var):
-  if var in env:
-    trys = [env[var]]
-  else:
-    if util.Platform() in CompilerSearch[var]:
-      trys = CompilerSearch[var][util.Platform()]
+    if var in env:
+        trys = [env[var]]
     else:
-      trys = CompilerSearch[var]['default']
-  for i in trys:
-    cc = TryVerifyCompiler(env, var, i)
-    if cc:
-      return cc
+        if util.Platform() in CompilerSearch[var]:
+            trys = CompilerSearch[var][util.Platform()]
+        else:
+            trys = CompilerSearch[var]['default']
+    for i in trys:
+        cc = TryVerifyCompiler(env, var, i)
+        if cc:
+            return cc
 
-  # Try for Emscripten. This only works with an env override.
-  if 'emcc' in env.get(var, ''):
-    cc = DetectEmscripten(env, var)
-    if cc:
-      return cc
+    # Try for Emscripten. This only works with an env override.
+    if 'emcc' in env.get(var, ''):
+        cc = DetectEmscripten(env, var)
+        if cc:
+            return cc
 
-  # Fail.
-  raise Exception('Unable to find a suitable ' + var + ' compiler')
+    # Fail.
+    raise Exception('Unable to find a suitable ' + var + ' compiler')
 
 def DetectEmscripten(env, var):
-  cmd = env[var]
-  argv = cmd.split()
-  if 'CFLAGS' in env:
-    argv += env.get('CFLAGS', '').split()
-  if var == 'CC':
-    suffix = '.c'
-  elif var == 'CXX':
-    argv += env.get('CXXFLAGS', '').split()
-    suffix = '.cpp'
+    cmd = env[var]
+    argv = cmd.split()
+    if 'CFLAGS' in env:
+        argv += env.get('CFLAGS', '').split()
+    if var == 'CC':
+        suffix = '.c'
+    elif var == 'CXX':
+        argv += env.get('CXXFLAGS', '').split()
+        suffix = '.cpp'
 
-  # Run emcc -dM -E on a blank file to get preprocessor definitions.
-  with tempfile.NamedTemporaryFile(suffix = suffix, delete = True) as fp:
-    argv = cmd.split() + ['-dM', '-E', fp.name]
-    output = subprocess.check_output(args = argv, universal_newlines = True)
-  output = output.replace('\r', '')
-  lines = output.split('\n')
+    # Run emcc -dM -E on a blank file to get preprocessor definitions.
+    with tempfile.NamedTemporaryFile(suffix = suffix, delete = True) as fp:
+        argv = cmd.split() + ['-dM', '-E', fp.name]
+        output = subprocess.check_output(args = argv, universal_newlines = True)
+    output = output.replace('\r', '')
+    lines = output.split('\n')
 
-  # Map the definitions into a dictionary.
-  defs = {}
-  for line in lines:
-    m = re.match('#define\s+([A-Za-z_][A-Za-z0-9_]*)\s*(.*)', line)
-    if m is None:
-      continue
-    macro = m.group(1)
-    value = m.group(2)
-    defs[macro] = value
+    # Map the definitions into a dictionary.
+    defs = {}
+    for line in lines:
+        m = re.match('#define\s+([A-Za-z_][A-Za-z0-9_]*)\s*(.*)', line)
+        if m is None:
+            continue
+        macro = m.group(1)
+        value = m.group(2)
+        defs[macro] = value
 
-  if '__EMSCRIPTEN__' not in defs:
-    return None
+    if '__EMSCRIPTEN__' not in defs:
+        return None
 
-  version = '{0}.{1}'.format(defs['__EMSCRIPTEN_major__'], defs['__EMSCRIPTEN_minor__'])
-  v = vendors.Emscripten(cmd, version)
+    version = '{0}.{1}'.format(defs['__EMSCRIPTEN_major__'], defs['__EMSCRIPTEN_minor__'])
+    v = vendors.Emscripten(cmd, version)
 
-  util.con_out(
-    util.ConsoleHeader,
-    'found {0} version {1}'.format('Emscripten', version),
-    util.ConsoleNormal
-  )
-  return v
+    util.con_out(util.ConsoleHeader, 'found {0} version {1}'.format('Emscripten', version),
+                 util.ConsoleNormal)
+    return v
 
 def VerifyCompiler(env, mode, cmd, vendor):
-  args = cmd.split()
-  if 'CFLAGS' in env:
-    args.extend(env['CFLAGS'].split())
-  if mode == 'CXX' and 'CXXFLAGS' in env:
-    args.extend(env['CXXFLAGS'].split())
-  if mode == 'CXX':
-    filename = 'test.cpp'
-  else:
-    filename = 'test.c'
-  file = open(filename, 'w')
-  file.write("""
+    args = cmd.split()
+    if 'CFLAGS' in env:
+        args.extend(env['CFLAGS'].split())
+    if mode == 'CXX' and 'CXXFLAGS' in env:
+        args.extend(env['CXXFLAGS'].split())
+    if mode == 'CXX':
+        filename = 'test.cpp'
+    else:
+        filename = 'test.c'
+    file = open(filename, 'w')
+    file.write("""
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -187,83 +184,75 @@ int main()
   exit(0);
 }
 """)
-  file.close()
-  if mode == 'CC':
-    executable = 'test' + util.ExecutableSuffix
-  elif mode == 'CXX':
-    executable = 'testp' + util.ExecutableSuffix
+    file.close()
+    if mode == 'CC':
+        executable = 'test' + util.ExecutableSuffix
+    elif mode == 'CXX':
+        executable = 'testp' + util.ExecutableSuffix
 
-  # Make sure the exe is gone.
-  if os.path.exists(executable):
-    os.unlink(executable)
+    # Make sure the exe is gone.
+    if os.path.exists(executable):
+        os.unlink(executable)
 
-  # Until we can better detect vendors, don't do this.
-  # if vendor == 'gcc' and mode == 'CXX':
-  #   args.extend(['-fno-exceptions', '-fno-rtti'])
-  args.extend([filename, '-o', executable])
+    # Until we can better detect vendors, don't do this.
+    # if vendor == 'gcc' and mode == 'CXX':
+    #   args.extend(['-fno-exceptions', '-fno-rtti'])
+    args.extend([filename, '-o', executable])
 
-  # For MSVC, we need to detect the inclusion pattern for foreign-language
-  # systems.
-  if vendor == 'msvc':
-    args += ['-nologo', '-showIncludes']
+    # For MSVC, we need to detect the inclusion pattern for foreign-language
+    # systems.
+    if vendor == 'msvc':
+        args += ['-nologo', '-showIncludes']
 
-  util.con_out(
-    util.ConsoleHeader,
-    'Checking {0} compiler (vendor test {1})... '.format(mode, vendor),
-    util.ConsoleBlue,
-    '{0}'.format(args),
-    util.ConsoleNormal
-  )
-  p = util.CreateProcess(args)
-  if p == None:
-    print('not found')
-    return False
-  if util.WaitForProcess(p) != 0:
-    print('failed with return code {0}'.format(p.returncode))
-    return False
+    util.con_out(util.ConsoleHeader,
+                 'Checking {0} compiler (vendor test {1})... '.format(mode, vendor),
+                 util.ConsoleBlue, '{0}'.format(args), util.ConsoleNormal)
+    p = util.CreateProcess(args)
+    if p == None:
+        print('not found')
+        return False
+    if util.WaitForProcess(p) != 0:
+        print('failed with return code {0}'.format(p.returncode))
+        return False
 
-  inclusion_pattern = None
-  if vendor == 'msvc':
-    inclusion_pattern = DetectMicrosoftInclusionPattern(p.stdoutText)
+    inclusion_pattern = None
+    if vendor == 'msvc':
+        inclusion_pattern = DetectMicrosoftInclusionPattern(p.stdoutText)
 
-  exe = util.MakePath('.', executable)
-  p = util.CreateProcess([executable], executable = exe)
-  if p == None:
-    print('failed to create executable with {0}'.format(cmd))
-    return False
-  if util.WaitForProcess(p) != 0:
-    print('executable failed with return code {0}'.format(p.returncode))
-    return False
-  lines = p.stdoutText.splitlines()
-  if len(lines) != 2:
-    print('invalid executable output')
-    return False
-  if lines[1] != mode:
-    print('requested {0} compiler, found {1}'.format(mode, lines[1]))
-    return False
+    exe = util.MakePath('.', executable)
+    p = util.CreateProcess([executable], executable = exe)
+    if p == None:
+        print('failed to create executable with {0}'.format(cmd))
+        return False
+    if util.WaitForProcess(p) != 0:
+        print('executable failed with return code {0}'.format(p.returncode))
+        return False
+    lines = p.stdoutText.splitlines()
+    if len(lines) != 2:
+        print('invalid executable output')
+        return False
+    if lines[1] != mode:
+        print('requested {0} compiler, found {1}'.format(mode, lines[1]))
+        return False
 
-  vendor, version = lines[0].split(' ')
-  if vendor == 'gcc':
-    v = vendors.GCC(cmd, version)
-  elif vendor == 'apple-clang':
-    v = vendors.Clang('apple-clang', cmd, version)
-  elif vendor == 'clang':
-    v = vendors.Clang('clang', cmd, version)
-  elif vendor == 'msvc':
-    v = vendors.MSVC(cmd, version)
-  elif vendor == 'sun':
-    v = vendors.SunPro(cmd, version)
-  else:
-    print('Unknown vendor {0}'.format(vendor))
-    return False
+    vendor, version = lines[0].split(' ')
+    if vendor == 'gcc':
+        v = vendors.GCC(cmd, version)
+    elif vendor == 'apple-clang':
+        v = vendors.Clang('apple-clang', cmd, version)
+    elif vendor == 'clang':
+        v = vendors.Clang('clang', cmd, version)
+    elif vendor == 'msvc':
+        v = vendors.MSVC(cmd, version)
+    elif vendor == 'sun':
+        v = vendors.SunPro(cmd, version)
+    else:
+        print('Unknown vendor {0}'.format(vendor))
+        return False
 
-  if inclusion_pattern is not None:
-    v.extra_props['inclusion_pattern'] = inclusion_pattern
+    if inclusion_pattern is not None:
+        v.extra_props['inclusion_pattern'] = inclusion_pattern
 
-  util.con_out(
-    util.ConsoleHeader,
-    'found {0} version {1}'.format(vendor, version),
-    util.ConsoleNormal
-  )
-  return v
-
+    util.con_out(util.ConsoleHeader, 'found {0} version {1}'.format(vendor, version),
+                 util.ConsoleNormal)
+    return v

--- a/ambuild2/frontend/v2_0/cpp/vendors.py
+++ b/ambuild2/frontend/v2_0/cpp/vendors.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
@@ -20,123 +20,123 @@ from ambuild2 import util
 from ambuild2.frontend.version import Version
 
 class Vendor(object):
-  def __init__(self, name, version, behavior, command, objSuffix):
-    self.name = name
-    self.version = version
-    self.behavior = behavior
-    self.command = command
-    self.objSuffix = objSuffix
-    self.debuginfo_argv = []
-    self.extra_props = {}
-    self.versionObject = Version('{0}-{1}'.format(name, self.version))
+    def __init__(self, name, version, behavior, command, objSuffix):
+        self.name = name
+        self.version = version
+        self.behavior = behavior
+        self.command = command
+        self.objSuffix = objSuffix
+        self.debuginfo_argv = []
+        self.extra_props = {}
+        self.versionObject = Version('{0}-{1}'.format(name, self.version))
 
-  def nameForExecutable(self, name):
-    return name + util.ExecutableSuffix
+    def nameForExecutable(self, name):
+        return name + util.ExecutableSuffix
 
-  def nameForSharedLibrary(self, name):
-    return name + util.SharedLibSuffix
+    def nameForSharedLibrary(self, name):
+        return name + util.SharedLibSuffix
 
-  def nameForStaticLibrary(self, name):
-    return util.StaticLibPrefix + name + util.StaticLibSuffix
+    def nameForStaticLibrary(self, name):
+        return util.StaticLibPrefix + name + util.StaticLibSuffix
 
 class MSVC(Vendor):
-  def __init__(self, command, version):
-    super(MSVC, self).__init__('msvc', version, 'msvc', command, '.obj')
-    self.definePrefix = '/D'
-    self.debuginfo_argv = ['/Zi']
-    if int(self.version) >= 1800:
-      self.debuginfo_argv += ['/FS']
+    def __init__(self, command, version):
+        super(MSVC, self).__init__('msvc', version, 'msvc', command, '.obj')
+        self.definePrefix = '/D'
+        self.debuginfo_argv = ['/Zi']
+        if int(self.version) >= 1800:
+            self.debuginfo_argv += ['/FS']
 
-  def like(self, name):
-    return name == 'msvc'
+    def like(self, name):
+        return name == 'msvc'
 
-  def parse_debuginfo(self, debuginfo):
-    if debuginfo == 'bundled':
-      return 'separate'
-    return debuginfo
+    def parse_debuginfo(self, debuginfo):
+        if debuginfo == 'bundled':
+            return 'separate'
+        return debuginfo
 
-  @staticmethod
-  def IncludePath(outputPath, includePath):
-    # Hack - try and get a relative path because CL, with either 
-    # /Zi or /ZI, combined with subprocess, apparently tries and
-    # looks for paths like c:\bleh\"c:\bleh" <-- wtf
-    # .. this according to Process Monitor
-    outputPath = os.path.normcase(outputPath)
-    includePath = os.path.normcase(includePath)
-    outputDrive = os.path.splitdrive(outputPath)[0]
-    includeDrive = os.path.splitdrive(includePath)[0]
-    if outputDrive == includeDrive:
-      return os.path.relpath(includePath, outputPath)
-    return includePath
+    @staticmethod
+    def IncludePath(outputPath, includePath):
+        # Hack - try and get a relative path because CL, with either
+        # /Zi or /ZI, combined with subprocess, apparently tries and
+        # looks for paths like c:\bleh\"c:\bleh" <-- wtf
+        # .. this according to Process Monitor
+        outputPath = os.path.normcase(outputPath)
+        includePath = os.path.normcase(includePath)
+        outputDrive = os.path.splitdrive(outputPath)[0]
+        includeDrive = os.path.splitdrive(includePath)[0]
+        if outputDrive == includeDrive:
+            return os.path.relpath(includePath, outputPath)
+        return includePath
 
-  def formatInclude(self, outputPath, includePath):
-    return ['/I', self.IncludePath(outputPath, includePath)]
+    def formatInclude(self, outputPath, includePath):
+        return ['/I', self.IncludePath(outputPath, includePath)]
 
-  def preprocessArgs(self, sourceFile, outFile):
-    return ['/showIncludes', '/nologo', '/P', '/c', sourceFile, '/Fi' + outFile]
+    def preprocessArgs(self, sourceFile, outFile):
+        return ['/showIncludes', '/nologo', '/P', '/c', sourceFile, '/Fi' + outFile]
 
-  def objectArgs(self, sourceFile, objFile):
-    return ['/showIncludes', '/nologo', '/c', sourceFile, '/Fo' + objFile]
+    def objectArgs(self, sourceFile, objFile):
+        return ['/showIncludes', '/nologo', '/c', sourceFile, '/Fo' + objFile]
 
 class CompatGCC(Vendor):
-  def __init__(self, name, command, version):
-    super(CompatGCC, self).__init__(name, version, 'gcc', command, '.o')
-    parts = version.split('.')
-    self.majorVersion = int(parts[0])
-    self.minorVersion = int(parts[1])
-    self.definePrefix = '-D'
+    def __init__(self, name, command, version):
+        super(CompatGCC, self).__init__(name, version, 'gcc', command, '.o')
+        parts = version.split('.')
+        self.majorVersion = int(parts[0])
+        self.minorVersion = int(parts[1])
+        self.definePrefix = '-D'
 
-  def formatInclude(self, outputPath, includePath):
-    return ['-I', os.path.normpath(includePath)]
+    def formatInclude(self, outputPath, includePath):
+        return ['-I', os.path.normpath(includePath)]
 
-  def objectArgs(self, sourceFile, objFile):
-    return ['-H', '-c', sourceFile, '-o', objFile]
+    def objectArgs(self, sourceFile, objFile):
+        return ['-H', '-c', sourceFile, '-o', objFile]
 
-  def parse_debuginfo(self, debuginfo):
-    return debuginfo
+    def parse_debuginfo(self, debuginfo):
+        return debuginfo
 
 class GCC(CompatGCC):
-  def __init__(self, command, version):
-    super(GCC, self).__init__('gcc', command, version)
-    self.debuginfo_argv = ['-g3', '-ggdb3']
+    def __init__(self, command, version):
+        super(GCC, self).__init__('gcc', command, version)
+        self.debuginfo_argv = ['-g3', '-ggdb3']
 
-  def like(self, name):
-    return name == 'gcc'
+    def like(self, name):
+        return name == 'gcc'
 
 class Clang(CompatGCC):
-  def __init__(self, vendor_name, command, version):
-    super(Clang, self).__init__(vendor_name, command, version)
-    self.name = 'clang' # Rewrite name to just 'clang' to make things easier.
-    self.vendor_name = vendor_name
-    self.debuginfo_argv = ['-g3']
+    def __init__(self, vendor_name, command, version):
+        super(Clang, self).__init__(vendor_name, command, version)
+        self.name = 'clang'  # Rewrite name to just 'clang' to make things easier.
+        self.vendor_name = vendor_name
+        self.debuginfo_argv = ['-g3']
 
-  def like(self, name):
-    return name == 'gcc' or name == 'clang' or name == self.vendor_name
+    def like(self, name):
+        return name == 'gcc' or name == 'clang' or name == self.vendor_name
 
 class Emscripten(Clang):
-  def __init__(self, command, version):
-    super(Emscripten, self).__init__('emscripten', command, version)
-    self.name = 'emscripten'
+    def __init__(self, command, version):
+        super(Emscripten, self).__init__('emscripten', command, version)
+        self.name = 'emscripten'
 
-  def like(self, name):
-    if name == 'emscripten':
-      return True
-    return super(Emscripten, self).like(name)
+    def like(self, name):
+        if name == 'emscripten':
+            return True
+        return super(Emscripten, self).like(name)
 
-  def nameForExecutable(self, name):
-    return name + '.js'
+    def nameForExecutable(self, name):
+        return name + '.js'
 
 class SunPro(Vendor):
-  def __init__(self, command, version):
-    super(SunPro, self).__init__('sun', version, 'sun', command, '.o')
-    self.definePrefix = '-D'
-    self.debuginfo_argv = ['-g3']
+    def __init__(self, command, version):
+        super(SunPro, self).__init__('sun', version, 'sun', command, '.o')
+        self.definePrefix = '-D'
+        self.debuginfo_argv = ['-g3']
 
-  def formatInclude(self, outputPath, includePath):
-    return ['-I', os.path.normpath(includePath)]
+    def formatInclude(self, outputPath, includePath):
+        return ['-I', os.path.normpath(includePath)]
 
-  def objectArgs(self, sourceFile, objFile):
-    return ['-H', '-c', sourceFile, '-o', objFile]
+    def objectArgs(self, sourceFile, objFile):
+        return ['-H', '-c', sourceFile, '-o', objFile]
 
-  def like(self, name):
-    return name == 'sun'
+    def like(self, name):
+        return name == 'sun'

--- a/ambuild2/frontend/v2_0/prep.py
+++ b/ambuild2/frontend/v2_0/prep.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can Headeristribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, sys
@@ -20,104 +20,126 @@ from ambuild2 import util
 from optparse import OptionParser, Values, SUPPRESS_HELP
 
 class Preparer(object):
-  def __init__(self, sourcePath, buildPath):
-    self.sourcePath = sourcePath
-    self.buildPath = buildPath
-    self.host_platform = util.Platform()
-    self.target_platform = util.Platform()
+    def __init__(self, sourcePath, buildPath):
+        self.sourcePath = sourcePath
+        self.buildPath = buildPath
+        self.host_platform = util.Platform()
+        self.target_platform = util.Platform()
 
-    self.options = OptionParser("usage: %prog [options]")
-    self.options.add_option("-g", "--gen", type="string", dest="generator", default="ambuild2",
-                            help="Build system generator to use. See --list-gen")
-    self.options.add_option("--list-gen", action="store_true", dest="list_gen", default=False,
-                            help="List available build system generators, then exit.")
-    self.options.add_option("--make-scripts", action="store_true", dest="make_scripts", default=False,
-                            help="Generate extra command-line files for building (build.py, Makefile).")
-    self.options.add_option("--no-color", action="store_true", dest="no_color", default=False,
-                            help="Disable color output in the terminal.")
-    self.options.add_option("--symbol-files", action="store_true", dest="symbol_files", default=False,
-                            help="Split debugging symbols from binaries into separate symbol files.")
+        self.options = OptionParser("usage: %prog [options]")
+        self.options.add_option("-g",
+                                "--gen",
+                                type = "string",
+                                dest = "generator",
+                                default = "ambuild2",
+                                help = "Build system generator to use. See --list-gen")
+        self.options.add_option("--list-gen",
+                                action = "store_true",
+                                dest = "list_gen",
+                                default = False,
+                                help = "List available build system generators, then exit.")
+        self.options.add_option(
+            "--make-scripts",
+            action = "store_true",
+            dest = "make_scripts",
+            default = False,
+            help = "Generate extra command-line files for building (build.py, Makefile).")
+        self.options.add_option("--no-color",
+                                action = "store_true",
+                                dest = "no_color",
+                                default = False,
+                                help = "Disable color output in the terminal.")
+        self.options.add_option(
+            "--symbol-files",
+            action = "store_true",
+            dest = "symbol_files",
+            default = False,
+            help = "Split debugging symbols from binaries into separate symbol files.")
 
-    # Generator specific options.
-    self.options.add_option("--vs-version", type="string", dest="vs_version", default="12",
-                            help=SUPPRESS_HELP)
-    self.options.add_option("--vs-split", action='store_true', dest="vs_split", default=False,
-                            help=SUPPRESS_HELP)
+        # Generator specific options.
+        self.options.add_option("--vs-version",
+                                type = "string",
+                                dest = "vs_version",
+                                default = "12",
+                                help = SUPPRESS_HELP)
+        self.options.add_option("--vs-split",
+                                action = 'store_true',
+                                dest = "vs_split",
+                                default = False,
+                                help = SUPPRESS_HELP)
 
-  @staticmethod
-  def default_build_folder(prep):
-    return 'obj-' + util.Platform() + '-' + platform.machine()
+    @staticmethod
+    def default_build_folder(prep):
+        return 'obj-' + util.Platform() + '-' + platform.machine()
 
-  def Configure(self): 
-    v_options, args = self.options.parse_args()
+    def Configure(self):
+        v_options, args = self.options.parse_args()
 
-    # In order to support pickling, we need to rewrite |options| to not use
-    # optparse.Values, since its implementation changes across Python versions.
-    options = util.Expando()
-    ignore_attrs = set(dir(Values))
-    for attr in dir(v_options):
-      if attr in ignore_attrs:
-        continue
-      setattr(options, attr, getattr(v_options, attr))
+        # In order to support pickling, we need to rewrite |options| to not use
+        # optparse.Values, since its implementation changes across Python versions.
+        options = util.Expando()
+        ignore_attrs = set(dir(Values))
+        for attr in dir(v_options):
+            if attr in ignore_attrs:
+                continue
+            setattr(options, attr, getattr(v_options, attr))
 
-    if options.list_gen:
-      print('Available build system generators:')
-      print('  {0:24} - AMBuild 2 (default)'.format('ambuild2'))
-      print('  {0:24} - Visual Studio'.format('vs'))
-      print('')
-      print('Extra options:')
-      print('  --vs-version=N        Visual Studio: IDE version (2010 or 10 default)')
-      print('  --vs-split            Visual Studio: generate one project file per configuration')
-      sys.exit(0)
+        if options.list_gen:
+            print('Available build system generators:')
+            print('  {0:24} - AMBuild 2 (default)'.format('ambuild2'))
+            print('  {0:24} - Visual Studio'.format('vs'))
+            print('')
+            print('Extra options:')
+            print('  --vs-version=N        Visual Studio: IDE version (2010 or 10 default)')
+            print(
+                '  --vs-split            Visual Studio: generate one project file per configuration'
+            )
+            sys.exit(0)
 
-    if options.no_color:
-      util.DisableConsoleColors()
+        if options.no_color:
+            util.DisableConsoleColors()
 
-    source_abspath = os.path.normpath(os.path.abspath(self.sourcePath))
-    build_abspath = os.path.normpath(os.path.abspath(self.buildPath))
-    if source_abspath == build_abspath:
-      if util.IsString(self.default_build_folder):
-        objfolder = self.default_build_folder
-      else:
-        objfolder = self.default_build_folder(self)
-      new_buildpath = os.path.join(self.buildPath, objfolder)
+        source_abspath = os.path.normpath(os.path.abspath(self.sourcePath))
+        build_abspath = os.path.normpath(os.path.abspath(self.buildPath))
+        if source_abspath == build_abspath:
+            if util.IsString(self.default_build_folder):
+                objfolder = self.default_build_folder
+            else:
+                objfolder = self.default_build_folder(self)
+            new_buildpath = os.path.join(self.buildPath, objfolder)
 
-      util.con_err(
-        util.ConsoleHeader,
-        'Warning: build is being configured in the source tree.',
-        util.ConsoleNormal
-      )
-      if os.path.exists(os.path.join(new_buildpath)):
-        has_amb2 = os.path.exists(os.path.join(new_buildpath, '.ambuild2'))
-        if not has_amb2 and len(os.listdir(new_buildpath)) and options.generator == 'ambuild2':
-          util.con_err(util.ConsoleRed, 'Tried to use ',
-                       util.ConsoleBlue, objfolder,
-                       util.ConsoleRed, ' as a build folder, but it is not empty!',
-                       util.ConsoleNormal)
-          raise Exception('build folder has unrecognized files')
+            util.con_err(util.ConsoleHeader,
+                         'Warning: build is being configured in the source tree.',
+                         util.ConsoleNormal)
+            if os.path.exists(os.path.join(new_buildpath)):
+                has_amb2 = os.path.exists(os.path.join(new_buildpath, '.ambuild2'))
+                if not has_amb2 and len(
+                        os.listdir(new_buildpath)) and options.generator == 'ambuild2':
+                    util.con_err(util.ConsoleRed, 'Tried to use ', util.ConsoleBlue, objfolder,
+                                 util.ConsoleRed, ' as a build folder, but it is not empty!',
+                                 util.ConsoleNormal)
+                    raise Exception('build folder has unrecognized files')
 
-        util.con_err(util.ConsoleHeader, 'Re-using build folder: ',
-                     util.ConsoleBlue, '{0}'.format(objfolder),
-                     util.ConsoleNormal)
-      else:
-        util.con_err(util.ConsoleHeader, 'Creating "',
-                     util.ConsoleBlue, '{0}'.format(objfolder),
-                     util.ConsoleHeader, '" as a build folder.',
-                     util.ConsoleNormal)
-        os.mkdir(new_buildpath)
-      self.buildPath = new_buildpath
+                util.con_err(util.ConsoleHeader, 'Re-using build folder: ', util.ConsoleBlue,
+                             '{0}'.format(objfolder), util.ConsoleNormal)
+            else:
+                util.con_err(util.ConsoleHeader, 'Creating "', util.ConsoleBlue,
+                             '{0}'.format(objfolder), util.ConsoleHeader, '" as a build folder.',
+                             util.ConsoleNormal)
+                os.mkdir(new_buildpath)
+            self.buildPath = new_buildpath
 
-    if options.generator == 'ambuild2':
-      from ambuild2.frontend.v2_0.amb2 import gen
-      builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
-    elif options.generator == 'vs':
-      from ambuild2.frontend.v2_0.vs import gen
-      builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
-    else:
-      sys.stderr.write('Unrecognized build generator: ' + options.generator + '\n')
-      sys.exit(1)
+        if options.generator == 'ambuild2':
+            from ambuild2.frontend.v2_0.amb2 import gen
+            builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
+        elif options.generator == 'vs':
+            from ambuild2.frontend.v2_0.vs import gen
+            builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
+        else:
+            sys.stderr.write('Unrecognized build generator: ' + options.generator + '\n')
+            sys.exit(1)
 
-    with util.FolderChanger(self.buildPath):
-      if not builder.generate():
-        sys.stderr.write('Configure failed.\n')
-        sys.exit(1)
+        with util.FolderChanger(self.buildPath):
+            if not builder.generate():
+                sys.stderr.write('Configure failed.\n')
+                sys.exit(1)

--- a/ambuild2/frontend/v2_0/vs/cxx.py
+++ b/ambuild2/frontend/v2_0/vs/cxx.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, types
@@ -24,201 +24,201 @@ from ambuild2.frontend.v2_0.cpp import compilers
 from ambuild2.frontend.v2_0.cpp import Dep, CppNodes
 
 class CompilerShell(object):
-  def __init__(self, version):
-    self.version = version
-    self.behavior = 'msvc'
-    self.name = 'msvc'
+    def __init__(self, version):
+        self.version = version
+        self.behavior = 'msvc'
+        self.name = 'msvc'
 
-  def like(self, name):
-    return name == self.name
+    def like(self, name):
+        return name == self.name
 
 class Project(object):
-  def __init__(self, ctor, compiler, name):
-    self.ctor_ = ctor
-    self.name_ = name
-    self.compiler = compiler
-    self.sources = []
-    self.builders_ = []
+    def __init__(self, ctor, compiler, name):
+        self.ctor_ = ctor
+        self.name_ = name
+        self.compiler = compiler
+        self.sources = []
+        self.builders_ = []
 
-  def Configure(self, name, tag):
-    compiler = self.compiler.clone()
-    builder = self.ctor_(self, compiler, name, tag)
-    builder.sources = self.sources[:]
-    self.builders_ += [builder]
-    return builder
+    def Configure(self, name, tag):
+        compiler = self.compiler.clone()
+        builder = self.ctor_(self, compiler, name, tag)
+        builder.sources = self.sources[:]
+        self.builders_ += [builder]
+        return builder
 
-  def default(self):
-    # Attach finish/generate methods to this builder, so it generates a
-    # projeet file. This is a wrapper around the older API which does not
-    # wrap binaries in projects.
-    builder = self.Configure(self.name_, 'Default')
-    builder.finish = self.finish
-    builder.generate = lambda generator, cx: self.generate(generator, cx)[0]
-    return builder
+    def default(self):
+        # Attach finish/generate methods to this builder, so it generates a
+        # projeet file. This is a wrapper around the older API which does not
+        # wrap binaries in projects.
+        builder = self.Configure(self.name_, 'Default')
+        builder.finish = self.finish
+        builder.generate = lambda generator, cx: self.generate(generator, cx)[0]
+        return builder
 
-  def finish(self, cx):
-    pass
+    def finish(self, cx):
+        pass
 
-  def generate(self, generator, cx):
-    if generator.options.vs_split:
-      return self.generate_split(generator, cx)
-    return self.generate_combined(generator, cx)
+    def generate(self, generator, cx):
+        if generator.options.vs_split:
+            return self.generate_split(generator, cx)
+        return self.generate_combined(generator, cx)
 
-  def generate_split(self, generator, cx):
-    outputs = []
-    for builder in self.builders_:
-      project = Project(self.ctor_, self.compiler, builder.name_)
-      project.sources = self.sources[:]
-      project.builders_ = [builder]
-      outputs += project.generate_combined(generator, cx)
-    return outputs
+    def generate_split(self, generator, cx):
+        outputs = []
+        for builder in self.builders_:
+            project = Project(self.ctor_, self.compiler, builder.name_)
+            project.sources = self.sources[:]
+            project.builders_ = [builder]
+            outputs += project.generate_combined(generator, cx)
+        return outputs
 
-  def generate_combined(self, generator, cx):
-    outputs = []
-    proj_path = paths.Join(cx.localFolder, self.name_ + self.compiler.projectFileSuffix)
-    node = nodes.ProjectNode(cx, proj_path, self)
-    for builder in self.builders_:
-      tag_folder = generator.addFolder(cx, builder.localFolder)
-      objFile = paths.Join(tag_folder, builder.outputFile)
-      pdbFile = paths.Join(tag_folder, builder.name_ + '.pdb')
-      objNode = generator.addOutput(cx, objFile, node)
-      pdbNode = generator.addOutput(cx, pdbFile, node)
-      outputs.append(CppNodes(objNode, pdbNode))
-    generator.addProjectNode(cx, node)
-    return outputs
+    def generate_combined(self, generator, cx):
+        outputs = []
+        proj_path = paths.Join(cx.localFolder, self.name_ + self.compiler.projectFileSuffix)
+        node = nodes.ProjectNode(cx, proj_path, self)
+        for builder in self.builders_:
+            tag_folder = generator.addFolder(cx, builder.localFolder)
+            objFile = paths.Join(tag_folder, builder.outputFile)
+            pdbFile = paths.Join(tag_folder, builder.name_ + '.pdb')
+            objNode = generator.addOutput(cx, objFile, node)
+            pdbNode = generator.addOutput(cx, pdbFile, node)
+            outputs.append(CppNodes(objNode, pdbNode))
+        generator.addProjectNode(cx, node)
+        return outputs
 
-  def export(self, node):
-    export_vcxproj.export(node)
+    def export(self, node):
+        export_vcxproj.export(node)
 
 class Compiler(compilers.Compiler):
-  def __init__(self, version):
-    super(Compiler, self).__init__()
-    self.version_ = version
+    def __init__(self, version):
+        super(Compiler, self).__init__()
+        self.version_ = version
 
-    # For compatibility with older build scripts.
-    self.cc = CompilerShell(version)
-    self.cxx = CompilerShell(version)
+        # For compatibility with older build scripts.
+        self.cc = CompilerShell(version)
+        self.cxx = CompilerShell(version)
 
-  def clone(self):
-    cc = Compiler(self.version)
-    cc.inherit(self)
-    return cc
+    def clone(self):
+        cc = Compiler(self.version)
+        cc.inherit(self)
+        return cc
 
-  @property
-  def projectFileSuffix(self):
-    # Assume the compiler version is related to the IDE version.
-    if self.version >= 1600:
-      return '.vcxproj'
-    if self.version >= 1300:
-      return '.vcproj'
-    # lol whatevs
-    return '.dsp'
+    @property
+    def projectFileSuffix(self):
+        # Assume the compiler version is related to the IDE version.
+        if self.version >= 1600:
+            return '.vcxproj'
+        if self.version >= 1300:
+            return '.vcproj'
+        # lol whatevs
+        return '.dsp'
 
-  @property
-  def version(self):
-    return self.version_
+    @property
+    def version(self):
+        return self.version_
 
-  @staticmethod
-  def GetVersionFromVS(vs_version):
-    if vs_version >= 14:
-      return Version((vs_version * 100) + 500)
-    return Version((vs_version * 100) + 600)
+    @staticmethod
+    def GetVersionFromVS(vs_version):
+        if vs_version >= 14:
+            return Version((vs_version * 100) + 500)
+        return Version((vs_version * 100) + 600)
 
-  def ProgramProject(self, name):
-    return Project(Program, self, name)
+    def ProgramProject(self, name):
+        return Project(Program, self, name)
 
-  def LibraryProject(self, name):
-    return Project(Library, self, name)
+    def LibraryProject(self, name):
+        return Project(Library, self, name)
 
-  def StaticLibraryProject(self, name):
-    return Project(StaticLibrary, self, name)
+    def StaticLibraryProject(self, name):
+        return Project(StaticLibrary, self, name)
 
-  def Program(self, name):
-    return Project(Program, self, name).default()
+    def Program(self, name):
+        return Project(Program, self, name).default()
 
-  def Library(self, name):
-    return Project(Library, self, name).default()
+    def Library(self, name):
+        return Project(Library, self, name).default()
 
-  def StaticLibrary(self, name):
-    return Project(StaticLibrary, self, name).default()
+    def StaticLibrary(self, name):
+        return Project(StaticLibrary, self, name).default()
 
-  def like(self, name):
-    return name == 'msvc'
+    def like(self, name):
+        return name == 'msvc'
 
-  @property
-  def vendor(self):
-    return 'msvc'
+    @property
+    def vendor(self):
+        return 'msvc'
 
 class BinaryBuilder(object):
-  def __init__(self, project, compiler, name, tag):
-    super(BinaryBuilder, self).__init__()
-    self.project_ = project
-    self.compiler = compiler
-    self.sources = []
-    self.name_ = name
-    self.tag_ = tag
+    def __init__(self, project, compiler, name, tag):
+        super(BinaryBuilder, self).__init__()
+        self.project_ = project
+        self.compiler = compiler
+        self.sources = []
+        self.name_ = name
+        self.tag_ = tag
 
-  def Dep(self, text, node=None): 
-    return Dep(text, node)
+    def Dep(self, text, node = None):
+        return Dep(text, node)
 
-  @property
-  def localFolder(self):
-    # If this is a one-off binary, we need to make sure its folder name won't
-    # create conflicts.
-    if hasattr(self, 'generate'):
-      return '{0} - {1}'.format(self.name_, self.tag_)
+    @property
+    def localFolder(self):
+        # If this is a one-off binary, we need to make sure its folder name won't
+        # create conflicts.
+        if hasattr(self, 'generate'):
+            return '{0} - {1}'.format(self.name_, self.tag_)
 
-    # Otherwise - we basically expect one project per context.
-    return self.tag_
+        # Otherwise - we basically expect one project per context.
+        return self.tag_
 
-  @property
-  def outputFile(self):
-    return self.buildOutputName(self.name_)
+    @property
+    def outputFile(self):
+        return self.buildOutputName(self.name_)
 
 class Program(BinaryBuilder):
-  def __init__(self, project, compiler, name, tag):
-    super(Program, self).__init__(project, compiler, name, tag)
+    def __init__(self, project, compiler, name, tag):
+        super(Program, self).__init__(project, compiler, name, tag)
 
-  @staticmethod
-  def buildOutputName(name):
-    return '{0}.exe'.format(name)
+    @staticmethod
+    def buildOutputName(name):
+        return '{0}.exe'.format(name)
 
-  @property
-  def type(self):
-    return 'program'
+    @property
+    def type(self):
+        return 'program'
 
-  @property
-  def configurationType(self):
-    return 'Application'
+    @property
+    def configurationType(self):
+        return 'Application'
 
 class Library(BinaryBuilder):
-  def __init__(self, project, compiler, name, tag):
-    super(Library, self).__init__(project, compiler, name, tag)
+    def __init__(self, project, compiler, name, tag):
+        super(Library, self).__init__(project, compiler, name, tag)
 
-  @staticmethod
-  def buildOutputName(name):
-    return '{0}.dll'.format(name)
+    @staticmethod
+    def buildOutputName(name):
+        return '{0}.dll'.format(name)
 
-  @property
-  def type(self):
-    return 'library'
+    @property
+    def type(self):
+        return 'library'
 
-  @property
-  def configurationType(self):
-    return 'DynamicLibrary'
+    @property
+    def configurationType(self):
+        return 'DynamicLibrary'
 
 class StaticLibrary(BinaryBuilder):
-  def __init__(self, project, compiler, name, tag):
-    super(StaticLibrary, self).__init__(project, compiler, name, tag)
+    def __init__(self, project, compiler, name, tag):
+        super(StaticLibrary, self).__init__(project, compiler, name, tag)
 
-  @staticmethod
-  def buildOutputName(name):
-    return '{0}.lib'.format(name)
+    @staticmethod
+    def buildOutputName(name):
+        return '{0}.lib'.format(name)
 
-  @property
-  def type(self):
-    return 'static'
+    @property
+    def type(self):
+        return 'static'
 
-  @property
-  def configurationType(self):
-    return 'StaticLibrary'
+    @property
+    def configurationType(self):
+        return 'StaticLibrary'

--- a/ambuild2/frontend/v2_0/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_0/vs/export_vcxproj.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, re
@@ -21,298 +21,295 @@ from ambuild2.frontend.v2_0.cpp import Dep
 from ambuild2.frontend.v2_0.vs.xmlbuilder import XmlBuilder
 
 def export(node):
-  with open(node.path, 'w') as fp:
-    export_fp(node, fp)
+    with open(node.path, 'w') as fp:
+        export_fp(node, fp)
 
 def export_fp(node, fp):
-  xml = XmlBuilder(fp)
+    xml = XmlBuilder(fp)
 
-  version = node.project.compiler.version 
-  if version >= 1900:
-    toolsVersion = '14.0'
-  elif version >= 1800:
-    toolsVersion = '12.0'
-  elif version >= 1600 and version < 1800:
-    toolsVersion = '4.0'
+    version = node.project.compiler.version
+    if version >= 1900:
+        toolsVersion = '14.0'
+    elif version >= 1800:
+        toolsVersion = '12.0'
+    elif version >= 1600 and version < 1800:
+        toolsVersion = '4.0'
 
-  scope = xml.block('Project',
-    DefaultTargets = 'Build',
-    ToolsVersion = toolsVersion,
-    xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003'
-  )
-  with scope:
-    export_body(node, xml)
+    scope = xml.block('Project',
+                      DefaultTargets = 'Build',
+                      ToolsVersion = toolsVersion,
+                      xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003')
+    with scope:
+        export_body(node, xml)
 
 def export_body(node, xml):
-  with xml.block('ItemGroup', Label = 'ProjectConfigurations'):
-    export_configuration_headers(node, xml)
+    with xml.block('ItemGroup', Label = 'ProjectConfigurations'):
+        export_configuration_headers(node, xml)
 
-  with xml.block('PropertyGroup', Label = 'Globals'):
-    xml.tag('ProjectGuid', '{{{0}}}'.format(node.uuid))
-    xml.tag('RootNamespace', node.project.name_)
-    xml.tag('Keyword', 'Win32Proj')
+    with xml.block('PropertyGroup', Label = 'Globals'):
+        xml.tag('ProjectGuid', '{{{0}}}'.format(node.uuid))
+        xml.tag('RootNamespace', node.project.name_)
+        xml.tag('Keyword', 'Win32Proj')
 
-  xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.Default.props')
-  export_configuration_properties(node, xml)
+    xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+    export_configuration_properties(node, xml)
 
-  xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.props')
-  with xml.block('ImportGroup', Label = 'ExtensionSettings'):
-    pass
-  export_configuration_user_props(node, xml)
+    xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.props')
+    with xml.block('ImportGroup', Label = 'ExtensionSettings'):
+        pass
+    export_configuration_user_props(node, xml)
 
-  with xml.block('PropertyGroup', Label = "UserMacros"):
-    pass
+    with xml.block('PropertyGroup', Label = "UserMacros"):
+        pass
 
-  with xml.block('PropertyGroup'):
-    export_configuration_paths(node, xml)
+    with xml.block('PropertyGroup'):
+        export_configuration_paths(node, xml)
 
-  for builder in node.project.builders_:
-    with xml.block('ItemDefinitionGroup', Condition = condition_for(builder)):
-      export_configuration_options(node, xml, builder)
+    for builder in node.project.builders_:
+        with xml.block('ItemDefinitionGroup', Condition = condition_for(builder)):
+            export_configuration_options(node, xml, builder)
 
-  export_source_files(node, xml)
+    export_source_files(node, xml)
 
-  xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.cpp.targets')
-  with xml.block('ImportGroup', Label = 'ExtensionTargets'):
-    pass
+    xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.cpp.targets')
+    with xml.block('ImportGroup', Label = 'ExtensionTargets'):
+        pass
 
 def condition_for(builder):
-  full_tag = '{0}|Win32'.format(builder.tag_)
-  return "'$(Configuration)|$(Platform)'=='{0}'".format(full_tag)
+    full_tag = '{0}|Win32'.format(builder.tag_)
+    return "'$(Configuration)|$(Platform)'=='{0}'".format(full_tag)
 
 def export_configuration_headers(node, xml):
-  for builder in node.project.builders_:
-    full_tag = '{0}|Win32'.format(builder.tag_)
-    with xml.block('ProjectConfiguration', Include = full_tag):
-      xml.tag('Configuration', builder.tag_)
-      xml.tag('Platform', 'Win32')
+    for builder in node.project.builders_:
+        full_tag = '{0}|Win32'.format(builder.tag_)
+        with xml.block('ProjectConfiguration', Include = full_tag):
+            xml.tag('Configuration', builder.tag_)
+            xml.tag('Platform', 'Win32')
 
 def export_configuration_properties(node, xml):
-  for builder in node.project.builders_:
-    condition = condition_for(builder)
-    with xml.block('PropertyGroup', Condition = condition, Label = 'Configuration'):
-      xml.tag('ConfigurationType', builder.configurationType)
-      xml.tag('CharacterSet', 'MultiByte')
-      if '/GL' in builder.compiler.cxxflags:
-        xml.tag('WholeProgramOptimization', 'true')
-      
-      version = builder.compiler.version
-      if version >= 1900:
-        xml.tag('PlatformToolset', 'v140')
-      elif version >= 1800:
-        xml.tag('PlatformToolset', 'v120')
-      elif version >= 1700:
-        xml.tag('PlatformToolset', 'v110')
+    for builder in node.project.builders_:
+        condition = condition_for(builder)
+        with xml.block('PropertyGroup', Condition = condition, Label = 'Configuration'):
+            xml.tag('ConfigurationType', builder.configurationType)
+            xml.tag('CharacterSet', 'MultiByte')
+            if '/GL' in builder.compiler.cxxflags:
+                xml.tag('WholeProgramOptimization', 'true')
+
+            version = builder.compiler.version
+            if version >= 1900:
+                xml.tag('PlatformToolset', 'v140')
+            elif version >= 1800:
+                xml.tag('PlatformToolset', 'v120')
+            elif version >= 1700:
+                xml.tag('PlatformToolset', 'v110')
 
 def export_configuration_user_props(node, xml):
-  for builder in node.project.builders_:
-    condition = condition_for(builder)
-    with xml.block('ImportGroup', Condition = condition, Label = 'PropertySheets'):
-      xml.tag('Import',
-        Project = "$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props",
-        Condition = "exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')",
-        Label = "LocalAppDataPlatform"
-      )
-      
+    for builder in node.project.builders_:
+        condition = condition_for(builder)
+        with xml.block('ImportGroup', Condition = condition, Label = 'PropertySheets'):
+            xml.tag('Import',
+                    Project = "$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props",
+                    Condition = "exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')",
+                    Label = "LocalAppDataPlatform")
+
 def export_configuration_paths(node, xml):
-  for builder in node.project.builders_:
-    condition = condition_for(builder)
-    xml.tag('OutDir', "$(Configuration)\\", Condition = condition)
-    xml.tag('IntDir', "$(Configuration)\\", Condition = condition)
-    if '/INCREMENTAL:NO' not in builder.compiler.linkflags and '/INCREMENTAL:NO' not in builder.compiler.postlink:
-      xml.tag('LinkIncremental', 'true', Condition = condition)
-    xml.tag('TargetName', builder.name_, Condition = condition)
+    for builder in node.project.builders_:
+        condition = condition_for(builder)
+        xml.tag('OutDir', "$(Configuration)\\", Condition = condition)
+        xml.tag('IntDir', "$(Configuration)\\", Condition = condition)
+        if '/INCREMENTAL:NO' not in builder.compiler.linkflags and '/INCREMENTAL:NO' not in builder.compiler.postlink:
+            xml.tag('LinkIncremental', 'true', Condition = condition)
+        xml.tag('TargetName', builder.name_, Condition = condition)
 
 def sanitize_val_defines(defines):
-  new_defines = []
-  for option in defines:
-    index = option.find('=')
-    if index == -1:
-      new_defines.append(option)
-      continue
+    new_defines = []
+    for option in defines:
+        index = option.find('=')
+        if index == -1:
+            new_defines.append(option)
+            continue
 
-    key = option[0:index]
-    val = option[index + 1:]
-    if val[0] == '"' and val[-1] == '"':
-      val = '\\"{0}\\"'.format(val)
-    new_defines.append('{0}={1}'.format(key, val))
-  return new_defines
+        key = option[0:index]
+        val = option[index + 1:]
+        if val[0] == '"' and val[-1] == '"':
+            val = '\\"{0}\\"'.format(val)
+        new_defines.append('{0}={1}'.format(key, val))
+    return new_defines
 
 def export_configuration_options(node, xml, builder):
-  compiler = builder.compiler
+    compiler = builder.compiler
 
-  includes = ['%(AdditionalIncludeDirectories)'] + compiler.includes + compiler.cxxincludes
-  all_defines = compiler.defines + compiler.cxxdefines
-  simple_defines = ['%(PreprocessorDefinitions)'] + [option for option in all_defines if '=' not in option]
-  val_defines = ['/D{0}'.format(option) for option in all_defines if '=' in option]
+    includes = ['%(AdditionalIncludeDirectories)'] + compiler.includes + compiler.cxxincludes
+    all_defines = compiler.defines + compiler.cxxdefines
+    simple_defines = ['%(PreprocessorDefinitions)'
+                     ] + [option for option in all_defines if '=' not in option]
+    val_defines = ['/D{0}'.format(option) for option in all_defines if '=' in option]
 
-  with xml.block('ClCompile'):
-    flags = compiler.cflags + compiler.cxxflags
+    with xml.block('ClCompile'):
+        flags = compiler.cflags + compiler.cxxflags
 
-    # Filter out options we handle specially.
-    other_flags = val_defines + flags
-    other_flags = [flag for flag in other_flags if not flag.startswith('/O')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/RTC')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/EH')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/MT')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/MD')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/W')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/GR')]
+        # Filter out options we handle specially.
+        other_flags = val_defines + flags
+        other_flags = [flag for flag in other_flags if not flag.startswith('/O')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/RTC')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/EH')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/MT')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/MD')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/W')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/GR')]
 
-    if len(other_flags):
-      xml.tag('AdditionalOptions', ' '.join(other_flags))
+        if len(other_flags):
+            xml.tag('AdditionalOptions', ' '.join(other_flags))
 
-    xml.tag('AdditionalIncludeDirectories', ';'.join(includes))
-    xml.tag('PreprocessorDefinitions', ';'.join(simple_defines))
+        xml.tag('AdditionalIncludeDirectories', ';'.join(includes))
+        xml.tag('PreprocessorDefinitions', ';'.join(simple_defines))
 
-    if '/Ox' in flags:
-      xml.tag('Optimization', 'Full')
-    elif '/O2' in flags:
-      xml.tag('Optimization', 'MaxSpeed')
-    elif '/O1' in flags:
-      xml.tag('Optimization', 'MinSpace')
-    else:
-      xml.tag('Optimization', 'Disabled')
+        if '/Ox' in flags:
+            xml.tag('Optimization', 'Full')
+        elif '/O2' in flags:
+            xml.tag('Optimization', 'MaxSpeed')
+        elif '/O1' in flags:
+            xml.tag('Optimization', 'MinSpace')
+        else:
+            xml.tag('Optimization', 'Disabled')
 
-    if '/Os' in flags:
-      xml.tag('FavorSizeOrSpeed', 'Size')
-    elif '/Ot' in flags:
-      xml.tag('FavorSizeOrSpeed', 'Speed')
+        if '/Os' in flags:
+            xml.tag('FavorSizeOrSpeed', 'Size')
+        elif '/Ot' in flags:
+            xml.tag('FavorSizeOrSpeed', 'Speed')
 
-    xml.tag('MinimalRebuild', 'true')
+        xml.tag('MinimalRebuild', 'true')
 
-    if '/RTC1' in flags or '/RTCsu' in flags:
-      xml.tag('BasicRuntimeChecks', 'EnableFastChecks')
-    elif '/RTCs' in flags:
-      xml.tag('BasicRuntimeChecks', 'StackFrame')
-    elif '/RTCu' in flags:
-      xml.tag('BasicRuntimeChecks', 'UninitVariables')
+        if '/RTC1' in flags or '/RTCsu' in flags:
+            xml.tag('BasicRuntimeChecks', 'EnableFastChecks')
+        elif '/RTCs' in flags:
+            xml.tag('BasicRuntimeChecks', 'StackFrame')
+        elif '/RTCu' in flags:
+            xml.tag('BasicRuntimeChecks', 'UninitVariables')
 
-    if '/Oy-' in flags:
-      xml.tag('OmitFramePointer', 'true')
-    if '/EHsc' in flags:
-      xml.tag('ExceptionHandling', 'Sync')
+        if '/Oy-' in flags:
+            xml.tag('OmitFramePointer', 'true')
+        if '/EHsc' in flags:
+            xml.tag('ExceptionHandling', 'Sync')
 
-    if '/MT' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreaded')
-    elif '/MTd' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreadedDebug')
-    elif '/MD' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreadedDLL')
-    elif '/MDd' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreadedDebugDLL')
+        if '/MT' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreaded')
+        elif '/MTd' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreadedDebug')
+        elif '/MD' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreadedDLL')
+        elif '/MDd' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreadedDebugDLL')
 
-    if '/W0' in flags:
-      xml.tag('WarningLevel', 'Level0')
-    elif '/W1' in flags:
-      xml.tag('WarningLevel', 'Level1')
-    elif '/W2' in flags:
-      xml.tag('WarningLevel', 'Level2')
-    elif '/W3' in flags:
-      xml.tag('WarningLevel', 'Level3')
-    elif '/W4' in flags:
-      xml.tag('WarningLevel', 'Level4')
+        if '/W0' in flags:
+            xml.tag('WarningLevel', 'Level0')
+        elif '/W1' in flags:
+            xml.tag('WarningLevel', 'Level1')
+        elif '/W2' in flags:
+            xml.tag('WarningLevel', 'Level2')
+        elif '/W3' in flags:
+            xml.tag('WarningLevel', 'Level3')
+        elif '/W4' in flags:
+            xml.tag('WarningLevel', 'Level4')
 
-    if '/Od' in flags:
-      xml.tag('DebugInformationFormat', 'EditAndContinue')
-    else:
-      xml.tag('DebugInformationFormat', 'ProgramDatabase')
+        if '/Od' in flags:
+            xml.tag('DebugInformationFormat', 'EditAndContinue')
+        else:
+            xml.tag('DebugInformationFormat', 'ProgramDatabase')
 
-    if '/GR-' in flags:
-      xml.tag('RuntimeTypeInfo', 'false')
-    elif '/GR' in flags:
-      xml.tag('RuntimeTypeInfo', 'true')
+        if '/GR-' in flags:
+            xml.tag('RuntimeTypeInfo', 'false')
+        elif '/GR' in flags:
+            xml.tag('RuntimeTypeInfo', 'true')
 
-    with xml.block('PrecompiledHeader'):
-      pass
-    xml.tag('MultiProcessorCompilation', 'true')
+        with xml.block('PrecompiledHeader'):
+            pass
+        xml.tag('MultiProcessorCompilation', 'true')
 
-  with xml.block('ResourceCompile'):
-    defines = ['%(PreprocessorDefinitions)'] + compiler.defines + compiler.cxxdefines + compiler.rcdefines
-    defines = sanitize_val_defines(defines)
-    xml.tag('PreprocessorDefinitions', ';'.join(defines))
-    xml.tag('AdditionalIncludeDirectories', ';'.join(includes[1:] + includes[0:1]))
+    with xml.block('ResourceCompile'):
+        defines = ['%(PreprocessorDefinitions)'
+                  ] + compiler.defines + compiler.cxxdefines + compiler.rcdefines
+        defines = sanitize_val_defines(defines)
+        xml.tag('PreprocessorDefinitions', ';'.join(defines))
+        xml.tag('AdditionalIncludeDirectories', ';'.join(includes[1:] + includes[0:1]))
 
-  with xml.block('Link'):
-    link_flags = compiler.linkflags + compiler.postlink
+    with xml.block('Link'):
+        link_flags = compiler.linkflags + compiler.postlink
 
-    # Parse link flags.
-    libs = ['%(AdditionalDependencies)']
-    ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
-    machine = 'X86'
-    subsystem = 'Windows'
-    for flag in link_flags:
-      if util.IsString(flag):
-        if flag == '/SUBSYSTEM:CONSOLE':
-          subsystem = 'Console'
-          continue
+        # Parse link flags.
+        libs = ['%(AdditionalDependencies)']
+        ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
+        machine = 'X86'
+        subsystem = 'Windows'
+        for flag in link_flags:
+            if util.IsString(flag):
+                if flag == '/SUBSYSTEM:CONSOLE':
+                    subsystem = 'Console'
+                    continue
 
-        if '.lib' in flag:
-          libs.append(flag)
-          continue
+                if '.lib' in flag:
+                    libs.append(flag)
+                    continue
 
-        m = re.match('/NODEFAULTLIB:(.+)', flag)
-        if m is not None:
-          ignore_libs.append(m.group(1))
-          continue
+                m = re.match('/NODEFAULTLIB:(.+)', flag)
+                if m is not None:
+                    ignore_libs.append(m.group(1))
+                    continue
 
-        m = re.match('/MACHINE:(.+)', flag)
-        if m is not None:
-          machine = m.group(1)
-      else:
-        libs.append(Dep.resolve(node.context, builder, flag))
+                m = re.match('/MACHINE:(.+)', flag)
+                if m is not None:
+                    machine = m.group(1)
+            else:
+                libs.append(Dep.resolve(node.context, builder, flag))
 
-    xml.tag('AdditionalDependencies', ';'.join(libs))
-    xml.tag('OutputFile', '$(OutDir)$(TargetFileName)')
-    xml.tag('IgnoreSpecificDefaultLibraries', ';'.join(ignore_libs))
-    if compiler.debuginfo is None:
-      xml.tag('GenerateDebugInformation', 'false')
-    else:
-      xml.tag('GenerateDebugInformation', 'true')
-    if '/OPT:REF' in link_flags:
-      xml.tag('OptimizeReferences', 'true')
-    elif '/OPT:NOREF' in link_flags:
-      xml.tag('OptimizeReferences', 'false')
-    if '/OPT:ICF' in link_flags:
-      xml.tag('EnableCOMDATFolding', 'true')
-    elif '/OPT:NOICF' in link_flags:
-      xml.tag('EnableCOMDATFolding', 'true')
-    xml.tag('TargetMachine', 'Machine{0}'.format(machine))
+        xml.tag('AdditionalDependencies', ';'.join(libs))
+        xml.tag('OutputFile', '$(OutDir)$(TargetFileName)')
+        xml.tag('IgnoreSpecificDefaultLibraries', ';'.join(ignore_libs))
+        if compiler.debuginfo is None:
+            xml.tag('GenerateDebugInformation', 'false')
+        else:
+            xml.tag('GenerateDebugInformation', 'true')
+        if '/OPT:REF' in link_flags:
+            xml.tag('OptimizeReferences', 'true')
+        elif '/OPT:NOREF' in link_flags:
+            xml.tag('OptimizeReferences', 'false')
+        if '/OPT:ICF' in link_flags:
+            xml.tag('EnableCOMDATFolding', 'true')
+        elif '/OPT:NOICF' in link_flags:
+            xml.tag('EnableCOMDATFolding', 'true')
+        xml.tag('TargetMachine', 'Machine{0}'.format(machine))
 
 def export_source_files(node, xml):
-  files = {}
-  all_builders = set()
-  for builder in node.project.builders_:
-    for source in builder.sources:
-      file = os.path.relpath(
-        paths.Join(node.context.currentSourcePath, source),
-        node.context.buildFolder
-      )
-      builders = files.setdefault(file, set())
-      builders.add(builder)
-    all_builders.add(builder)
+    files = {}
+    all_builders = set()
+    for builder in node.project.builders_:
+        for source in builder.sources:
+            file = os.path.relpath(paths.Join(node.context.currentSourcePath, source),
+                                   node.context.buildFolder)
+            builders = files.setdefault(file, set())
+            builders.add(builder)
+        all_builders.add(builder)
 
-  def emit(file, kind):
-    builders = files[file]
-    excluded = all_builders - builders
+    def emit(file, kind):
+        builders = files[file]
+        excluded = all_builders - builders
 
-    if len(excluded) == 0:
-      xml.tag(kind, Include = file)
-      return
+        if len(excluded) == 0:
+            xml.tag(kind, Include = file)
+            return
 
-    with xml.block(kind, Include = file):
-      for builder in excluded:
-        xml.tag('ExcludedFromBuild', 'true', Condition = condition_for(builder))
+        with xml.block(kind, Include = file):
+            for builder in excluded:
+                xml.tag('ExcludedFromBuild', 'true', Condition = condition_for(builder))
 
+    with xml.block('ItemGroup'):
+        for file in files:
+            _, ext = os.path.splitext(file)
+            if ext != '.rc':
+                emit(file, 'ClCompile')
 
-  with xml.block('ItemGroup'):
-    for file in files:
-      _, ext = os.path.splitext(file)
-      if ext != '.rc':
-        emit(file, 'ClCompile')
-
-  with xml.block('ItemGroup'):
-    for file in files:
-      _, ext = os.path.splitext(file)
-      if ext == '.rc':
-        emit(file, 'ResourceCompile')
+    with xml.block('ItemGroup'):
+        for file in files:
+            _, ext = os.path.splitext(file)
+            if ext == '.rc':
+                emit(file, 'ResourceCompile')

--- a/ambuild2/frontend/v2_0/vs/gen.py
+++ b/ambuild2/frontend/v2_0/vs/gen.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, errno
@@ -25,146 +25,152 @@ from ambuild2.frontend.v2_0.base import BaseGenerator
 
 SupportedVersions = ['10', '11', '12', '14']
 YearMap = {
-  '2010': 10,
-  '2012': 11,
-  '2013': 12,
-  '2015': 14,
+    '2010': 10,
+    '2012': 11,
+    '2013': 12,
+    '2015': 14,
 }
 
 class Generator(BaseGenerator):
-  def __init__(self, sourcePath, buildPath, originalCwd, options, args):
-    super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
-    self.compiler = None
-    self.vs_version = None
-    self.files_ = {}
-    self.projects_ = set()
+    def __init__(self, sourcePath, buildPath, originalCwd, options, args):
+        super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
+        self.compiler = None
+        self.vs_version = None
+        self.files_ = {}
+        self.projects_ = set()
 
-    if self.options.vs_version in SupportedVersions:
-      self.vs_version = int(self.options.vs_version)
-    else:
-      if self.options.vs_version not in YearMap:
-        util.con_err(
-          util.ConsoleRed,
-          'Unsupported Visual Studio version: {0}'.format(self.options.vs_version),
-          util.ConsoleNormal
-        )
-        raise Exception('Unsupported Visual Studio version: {0}'.format(self.options.vs_version)) 
-      self.vs_version = YearMap[self.options.vs_version]
+        if self.options.vs_version in SupportedVersions:
+            self.vs_version = int(self.options.vs_version)
+        else:
+            if self.options.vs_version not in YearMap:
+                util.con_err(
+                    util.ConsoleRed,
+                    'Unsupported Visual Studio version: {0}'.format(self.options.vs_version),
+                    util.ConsoleNormal)
+                raise Exception('Unsupported Visual Studio version: {0}'.format(
+                    self.options.vs_version))
+            self.vs_version = YearMap[self.options.vs_version]
 
-    self.cacheFile = os.path.join(self.buildPath, '.cache')
-    try:
-      with open(self.cacheFile, 'rb') as fp:
-        self.vars_ = util.pickle.load(fp)
-    except:
-      self.vars_ = {}
+        self.cacheFile = os.path.join(self.buildPath, '.cache')
+        try:
+            with open(self.cacheFile, 'rb') as fp:
+                self.vars_ = util.pickle.load(fp)
+        except:
+            self.vars_ = {}
 
-    if 'uuids' not in self.vars_:
-      self.vars_['uuids'] = {}
+        if 'uuids' not in self.vars_:
+            self.vars_['uuids'] = {}
 
-    self.target_platform = 'windows'
+        self.target_platform = 'windows'
 
-  # Overridden.
-  @property
-  def backend(self):
-    return 'vs'
+    # Overridden.
+    @property
+    def backend(self):
+        return 'vs'
 
-  # Overridden.
-  def preGenerate(self):
-    pass
+    # Overridden.
+    def preGenerate(self):
+        pass
 
-  # Overriden.
-  def postGenerate(self):
-    self.generateProjects()
-    with open(self.cacheFile, 'wb') as fp:
-      util.DiskPickle(self.vars_, fp)
+    # Overriden.
+    def postGenerate(self):
+        self.generateProjects()
+        with open(self.cacheFile, 'wb') as fp:
+            util.DiskPickle(self.vars_, fp)
 
-  def generateProjects(self):
-    for node in self.projects_:
-      # We cache uuids across runs to keep them consistent.
-      node.uuid = self.vars_['uuids'].get(node.path)
-      if node.uuid is None:
-        node.uuid = str(uuids.uuid1()).upper()
-        self.vars_['uuids'][node.path] = node.uuid
-      node.project.export(node)
+    def generateProjects(self):
+        for node in self.projects_:
+            # We cache uuids across runs to keep them consistent.
+            node.uuid = self.vars_['uuids'].get(node.path)
+            if node.uuid is None:
+                node.uuid = str(uuids.uuid1()).upper()
+                self.vars_['uuids'][node.path] = node.uuid
+            node.project.export(node)
 
-  # Overridden.
-  #
-  # We don't support reconfiguring in this frontend.
-  def addConfigureFile(self, cx, path):
-    pass
+    # Overridden.
+    #
+    # We don't support reconfiguring in this frontend.
+    def addConfigureFile(self, cx, path):
+        pass
 
-  # Overridden.
-  def detectCompilers(self):
-    if not self.compiler:
-      self.base_compiler = cxx.Compiler(cxx.Compiler.GetVersionFromVS(self.vs_version))
-      self.compiler = self.base_compiler.clone()
-    return self.compiler
+    # Overridden.
+    def detectCompilers(self):
+        if not self.compiler:
+            self.base_compiler = cxx.Compiler(cxx.Compiler.GetVersionFromVS(self.vs_version))
+            self.compiler = self.base_compiler.clone()
+        return self.compiler
 
-  # Overridden.
-  def enterContext(self, cx):
-    cx.vs_nodes = []
+    # Overridden.
+    def enterContext(self, cx):
+        cx.vs_nodes = []
 
-  # Overridden.
-  def leaveContext(self, cx):
-    pass
+    # Overridden.
+    def leaveContext(self, cx):
+        pass
 
-  def ensureUnique(self, path):
-    if path in self.files_:
-      entry = self.files_[path]
-      util.con_err(
-        util.ConsoleRed, 'Path {0} already exists as: {1}'.format(path, entry.kind),
-        util.ConsoleNormal
-      )
-      raise Exception('Path {0} already exists as: {1}'.format(path, entry.kind))
+    def ensureUnique(self, path):
+        if path in self.files_:
+            entry = self.files_[path]
+            util.con_err(util.ConsoleRed,
+                         'Path {0} already exists as: {1}'.format(path,
+                                                                  entry.kind), util.ConsoleNormal)
+            raise Exception('Path {0} already exists as: {1}'.format(path, entry.kind))
 
-  # Overridden.
-  def getLocalFolder(self, context):
-    if type(context.localFolder_) is nodes.FolderNode or context.localFolder_ is None:
-      return context.localFolder_
+    # Overridden.
+    def getLocalFolder(self, context):
+        if type(context.localFolder_) is nodes.FolderNode or context.localFolder_ is None:
+            return context.localFolder_
 
-    if not len(context.buildFolder):
-      context.localFolder_ = None
-    else:
-      context.localFolder_ = self.addFolder(context.parent, context.buildFolder)
+        if not len(context.buildFolder):
+            context.localFolder_ = None
+        else:
+            context.localFolder_ = self.addFolder(context.parent, context.buildFolder)
 
-    return context.localFolder_
+        return context.localFolder_
 
-  # Overridden.
-  def addFolder(self, cx, folder):
-    parentFolderNode = None
-    if cx is not None:
-      parentFolderNode = cx.localFolder
+    # Overridden.
+    def addFolder(self, cx, folder):
+        parentFolderNode = None
+        if cx is not None:
+            parentFolderNode = cx.localFolder
 
-    _, path = paths.ResolveFolder(parentFolderNode, folder)
-    if path in self.files_:
-      entry = self.files_[path]
-      if type(entry) is not nodes.FolderNode:
-        self.ensureUnique(path) # Will always throw.
-      return entry
+        _, path = paths.ResolveFolder(parentFolderNode, folder)
+        if path in self.files_:
+            entry = self.files_[path]
+            if type(entry) is not nodes.FolderNode:
+                self.ensureUnique(path)  # Will always throw.
+            return entry
 
-    try:
-      os.makedirs(path)
-    except OSError as exn:
-      if not (exn.errno == errno.EEXIST and os.path.isdir(path)):
-        raise
+        try:
+            os.makedirs(path)
+        except OSError as exn:
+            if not (exn.errno == errno.EEXIST and os.path.isdir(path)):
+                raise
 
-    obj = nodes.FolderNode(path)
-    self.files_[path] = obj
-    return obj
+        obj = nodes.FolderNode(path)
+        self.files_[path] = obj
+        return obj
 
-  # Overridden.
-  def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
-    print(inputs, argv, outputs, folder, dep_type, weak_inputs, shared_outputs)
+    # Overridden.
+    def addShellCommand(self,
+                        context,
+                        inputs,
+                        argv,
+                        outputs,
+                        folder = -1,
+                        dep_type = None,
+                        weak_inputs = [],
+                        shared_outputs = []):
+        print(inputs, argv, outputs, folder, dep_type, weak_inputs, shared_outputs)
 
-  def addOutput(self, context, path, parent):
-    self.ensureUnique(path)
+    def addOutput(self, context, path, parent):
+        self.ensureUnique(path)
 
-    node = nodes.OutputNode(context, path, parent)
-    self.files_[path] = node
-    return node
+        node = nodes.OutputNode(context, path, parent)
+        self.files_[path] = node
+        return node
 
-  def addProjectNode(self, context, project):
-    self.ensureUnique(project.path)
-    self.projects_.add(project)
-    self.files_[project.path] = project
+    def addProjectNode(self, context, project):
+        self.ensureUnique(project.path)
+        self.projects_.add(project)
+        self.files_[project.path] = project

--- a/ambuild2/frontend/v2_0/vs/graph.py
+++ b/ambuild2/frontend/v2_0/vs/graph.py
@@ -1,17 +1,16 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
-

--- a/ambuild2/frontend/v2_0/vs/nodes.py
+++ b/ambuild2/frontend/v2_0/vs/nodes.py
@@ -1,63 +1,63 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
 class Node(object):
-  def __init__(self, context, path):
-    super(Node, self).__init__()
-    self.context = context
-    self.path = path
-    self.children = set()
-    self.parents = set()
+    def __init__(self, context, path):
+        super(Node, self).__init__()
+        self.context = context
+        self.path = path
+        self.children = set()
+        self.parents = set()
 
-  def addParent(self, parent):
-    self.parents.add(parent)
-    parent.children.add(self)
+    def addParent(self, parent):
+        self.parents.add(parent)
+        parent.children.add(self)
 
 class FolderNode(Node):
-  def __init__(self, path):
-    super(FolderNode, self).__init__(None, path)
+    def __init__(self, path):
+        super(FolderNode, self).__init__(None, path)
 
-  @property
-  def kind(self):
-    return 'folder'
+    @property
+    def kind(self):
+        return 'folder'
 
 class ContainerNode(Node):
-  def __init__(self, cx):
-    super(ContainerNode, self).__init__(cx, None)
+    def __init__(self, cx):
+        super(ContainerNode, self).__init__(cx, None)
 
-  @property
-  def kind(self):
-    return 'container'
+    @property
+    def kind(self):
+        return 'container'
 
 class OutputNode(Node):
-  def __init__(self, context, path, parent):
-    super(OutputNode, self).__init__(context, path)
-    self.addParent(parent)
+    def __init__(self, context, path, parent):
+        super(OutputNode, self).__init__(context, path)
+        self.addParent(parent)
 
-  @property
-  def kind(self):
-    return 'output'
+    @property
+    def kind(self):
+        return 'output'
 
 class ProjectNode(Node):
-  def __init__(self, context, path, project):
-    super(ProjectNode, self).__init__(context, path)
-    self.project = project
-    self.uuid = None
+    def __init__(self, context, path, project):
+        super(ProjectNode, self).__init__(context, path)
+        self.project = project
+        self.uuid = None
 
-  @property
-  def kind(self):
-    return 'project'
+    @property
+    def kind(self):
+        return 'project'

--- a/ambuild2/frontend/v2_0/vs/xmlbuilder.py
+++ b/ambuild2/frontend/v2_0/vs/xmlbuilder.py
@@ -1,70 +1,70 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
 class XmlScope(object):
-  def __init__(self, builder, tag, **kwargs):
-    self.builder_ = builder
-    self.tag_ = tag
-    self.kwargs_ = kwargs
+    def __init__(self, builder, tag, **kwargs):
+        self.builder_ = builder
+        self.tag_ = tag
+        self.kwargs_ = kwargs
 
-  def __enter__(self):
-    self.builder_.enter(self.tag_, **self.kwargs_)
+    def __enter__(self):
+        self.builder_.enter(self.tag_, **self.kwargs_)
 
-  def __exit__(self, type, value, traceback):
-    self.builder_.leave(self.tag_)
+    def __exit__(self, type, value, traceback):
+        self.builder_.leave(self.tag_)
 
 class XmlBuilder(object):
-  def __init__(self, fp, version="1.0", encoding="utf-8"):
-    super(XmlBuilder, self).__init__()
-    self.fp_ = fp
-    self.indent_ = 0
-    self.write('<?xml version="{0}" encoding="{1}"?>'.format(version, encoding))
+    def __init__(self, fp, version = "1.0", encoding = "utf-8"):
+        super(XmlBuilder, self).__init__()
+        self.fp_ = fp
+        self.indent_ = 0
+        self.write('<?xml version="{0}" encoding="{1}"?>'.format(version, encoding))
 
-  def block(self, tag, **kwargs):
-    return XmlScope(self, tag, **kwargs)
+    def block(self, tag, **kwargs):
+        return XmlScope(self, tag, **kwargs)
 
-  def tag(self, tag, contents = None, **kwargs):
-    open = self.build_element(tag, **kwargs)
-    if contents is None:
-      self.write('<{0} />'.format(open))
-    else:
-      self.write('<{0}>{1}</{2}>'.format(open, contents, tag))
+    def tag(self, tag, contents = None, **kwargs):
+        open = self.build_element(tag, **kwargs)
+        if contents is None:
+            self.write('<{0} />'.format(open))
+        else:
+            self.write('<{0}>{1}</{2}>'.format(open, contents, tag))
 
-  # Internal.
-  def enter(self, tag, **kwargs):
-    elt = self.build_element(tag, **kwargs)
-    self.write('<{0}>'.format(elt))
-    self.indent_ += 1
+    # Internal.
+    def enter(self, tag, **kwargs):
+        elt = self.build_element(tag, **kwargs)
+        self.write('<{0}>'.format(elt))
+        self.indent_ += 1
 
-  def leave(self, tag):
-    self.indent_ -= 1
-    self.write('</{0}>'.format(tag))
+    def leave(self, tag):
+        self.indent_ -= 1
+        self.write('</{0}>'.format(tag))
 
-  def build_element(self, tag, **kwargs):
-    if len(kwargs) == 0:
-      return '{0}'.format(tag)
+    def build_element(self, tag, **kwargs):
+        if len(kwargs) == 0:
+            return '{0}'.format(tag)
 
-    props = []
-    for key in kwargs:
-      props.append('{0}="{1}"'.format(key, kwargs[key]))
-    attrs = ' '.join(props)
-    return '{0} {1}'.format(tag, attrs)
+        props = []
+        for key in kwargs:
+            props.append('{0}="{1}"'.format(key, kwargs[key]))
+        attrs = ' '.join(props)
+        return '{0} {1}'.format(tag, attrs)
 
-  def write(self, line):
-    self.fp_.write('  ' * self.indent_)
-    self.fp_.write(line)
-    self.fp_.write('\n')
+    def write(self, line):
+        self.fp_.write('  ' * self.indent_)
+        self.fp_.write(line)
+        self.fp_.write('\n')

--- a/ambuild2/frontend/v2_1/amb2/gen.py
+++ b/ambuild2/frontend/v2_1/amb2/gen.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -24,768 +24,746 @@ from ambuild2.frontend.v2_1.cpp import detect
 from ambuild2.frontend.v2_1.base import BaseGenerator
 
 class Generator(BaseGenerator):
-  def __init__(self, sourcePath, buildPath, originalCwd, options, args, db=None, refactoring=False):
-    super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
-    self.cacheFolder = os.path.join(self.buildPath, '.ambuild2')
-    self.old_scripts_ = set()
-    self.old_folders_ = set()
-    self.old_commands_ = set()
-    self.rm_list_ = []
-    self.bad_outputs_ = set()
-    self.db = db
-    self.is_bootstrap = not self.db
-    self.refactoring = refactoring
-    self.compiler = None
-    self.symlink_support = False
-    self.had_symlink_fallback = False
+    def __init__(self,
+                 sourcePath,
+                 buildPath,
+                 originalCwd,
+                 options,
+                 args,
+                 db = None,
+                 refactoring = False):
+        super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
+        self.cacheFolder = os.path.join(self.buildPath, '.ambuild2')
+        self.old_scripts_ = set()
+        self.old_folders_ = set()
+        self.old_commands_ = set()
+        self.rm_list_ = []
+        self.bad_outputs_ = set()
+        self.db = db
+        self.is_bootstrap = not self.db
+        self.refactoring = refactoring
+        self.compiler = None
+        self.symlink_support = False
+        self.had_symlink_fallback = False
 
-  @property
-  def backend(self):
-    return 'amb2'
+    @property
+    def backend(self):
+        return 'amb2'
 
-  @classmethod
-  def FromVars(cls, vars, db, refactoring):
-    # Backwards compatibility: for an automatic reconfigure on an older build,
-    # just assume the source path is the cwd. If the AMBuildScript suddenly
-    # has decided to depend on originalCwd, then the user may have to manually
-    # run configure.py again, until we remove configure.py entirely.
-    if 'originalCwd' in vars:
-      originalCwd = vars['originalCwd']
-    else:
-      originalCwd = vars['sourcePath']
+    @classmethod
+    def FromVars(cls, vars, db, refactoring):
+        # Backwards compatibility: for an automatic reconfigure on an older build,
+        # just assume the source path is the cwd. If the AMBuildScript suddenly
+        # has decided to depend on originalCwd, then the user may have to manually
+        # run configure.py again, until we remove configure.py entirely.
+        if 'originalCwd' in vars:
+            originalCwd = vars['originalCwd']
+        else:
+            originalCwd = vars['sourcePath']
 
-    gen = cls(
-      sourcePath = vars['sourcePath'],
-      buildPath = vars['buildPath'],
-      originalCwd = originalCwd,
-      options = vars['options'],
-      args = vars['args'],
-      db = db,
-      refactoring = refactoring
-    )
-    return gen
+        gen = cls(sourcePath = vars['sourcePath'],
+                  buildPath = vars['buildPath'],
+                  originalCwd = originalCwd,
+                  options = vars['options'],
+                  args = vars['args'],
+                  db = db,
+                  refactoring = refactoring)
+        return gen
 
-  def preGenerate(self):
-    if not os.path.isdir(self.cacheFolder):
-      os.mkdir(self.cacheFolder)
-    if not self.db:
-      db_path = os.path.join(self.cacheFolder, 'graph')
-      if not os.path.isfile(db_path):
-        self.db = database.CreateDatabase(db_path)
-      else:
-        self.db = database.Database(db_path)
-        self.db.connect()
+    def preGenerate(self):
+        if not os.path.isdir(self.cacheFolder):
+            os.mkdir(self.cacheFolder)
+        if not self.db:
+            db_path = os.path.join(self.cacheFolder, 'graph')
+            if not os.path.isfile(db_path):
+                self.db = database.CreateDatabase(db_path)
+            else:
+                self.db = database.Database(db_path)
+                self.db.connect()
 
-    self.symlink_support = util.DetectSymlinkSupport()
+        self.symlink_support = util.DetectSymlinkSupport()
 
-    self.db.load_environments()
-    self.db.query_scripts(lambda id,path,stamp: self.old_scripts_.add(path))
-    self.db.query_mkdir(lambda entry: self.old_folders_.add(entry))
-    self.db.query_commands(lambda entry: self.old_commands_.add(entry))
-    self.db.set_var('api_version', '2.1')
+        self.db.load_environments()
+        self.db.query_scripts(lambda id, path, stamp: self.old_scripts_.add(path))
+        self.db.query_mkdir(lambda entry: self.old_folders_.add(entry))
+        self.db.query_commands(lambda entry: self.old_commands_.add(entry))
+        self.db.set_var('api_version', '2.1')
 
-  def cleanup(self):
-    for path in self.rm_list_:
-      util.rm_path(path)
+    def cleanup(self):
+        for path in self.rm_list_:
+            util.rm_path(path)
 
-    for cmd_entry in self.old_commands_:
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'Command removed during refactoring: \n',
-                     util.ConsoleBlue, cmd_entry.format(),
+        for cmd_entry in self.old_commands_:
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'Command removed during refactoring: \n',
+                             util.ConsoleBlue, cmd_entry.format(), util.ConsoleNormal)
+                raise Exception('Refactoring error: command removed')
+            self.db.drop_command(cmd_entry)
+
+        for path in self.old_scripts_:
+            self.db.drop_script(path)
+
+        self.db.query_dead_sources(lambda e: self.db.drop_source(e))
+        self.db.query_dead_shared_outputs(lambda e: self.db.drop_output(e))
+        self.db.drop_unused_environments()
+
+        class Node:
+            def __init__(self):
+                self.incoming = set()
+                self.outgoing = set()
+
+        # Build a tree of dead folders.
+        tracker = {}
+        for entry in self.old_folders_:
+            if entry not in tracker:
+                tracker[entry] = Node()
+
+            if entry.folder is None:
+                continue
+
+            # If our parent is not a dead folder, don't create an edge. It should be
+            # impossible for a/b to be dead, a/b/c to be alive, and a/b/c/d to be
+            # dead, since a/b/c will implicitly keep a/b alive.
+            if entry.folder not in self.old_folders_:
+                continue
+
+            if entry.folder not in tracker:
+                tracker[entry.folder] = Node()
+
+            parent = tracker[entry.folder]
+            child = tracker[entry]
+            parent.incoming.add(entry)
+            child.outgoing.add(entry.folder)
+
+        # Find the leaves. Sets start out >= 1 items. Remove them as they they
+        # are empty.
+        dead_folders = [entry for entry in self.old_folders_ if len(tracker[entry].incoming) == 0]
+        while len(dead_folders):
+            child_entry = dead_folders.pop()
+            child_node = tracker[child_entry]
+
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'Folder removed during refactoring: \n',
+                             util.ConsoleBlue, child_entry.format(), util.ConsoleNormal)
+                raise Exception('Refactoring error: command removed')
+
+            self.db.drop_folder(child_entry)
+            for parent_entry in child_node.outgoing:
+                parent_node = tracker[parent_entry]
+                parent_node.incoming.remove(child_entry)
+                if not len(parent_node.incoming):
+                    dead_folders.append(parent_entry)
+
+    def postGenerate(self):
+        self.cleanup()
+        self.db.commit()
+        self.db.vacuum()
+        if self.is_bootstrap:
+            self.saveVars()
+            self.db.close()
+
+        if self.had_symlink_fallback:
+            util.con_out(
+                util.ConsoleHeader,
+                'Note: filesystem does not support symlinks. Files will be copied instead.',
+                util.ConsoleNormal)
+
+    def saveVars(self):
+        vars = {
+            'sourcePath': self.sourcePath,
+            'buildPath': self.buildPath,
+            'originalCwd': self.originalCwd,
+            'options': self.options,
+            'args': self.args
+        }
+
+        # Save any environment variables that are relevant to the build.
+        env = {}
+
+        if self.compiler is not None:
+            # Save env vars that will be needed to reconfigure.
+            for key in self.compiler.EnvVars:
+                if key in os.environ:
+                    env[key] = os.environ[key]
+
+            # Save any extra compiler info that must be communicated to the backend.
+            for prop_name in self.compiler.vendor.extra_props:
+                key = '{0}_{1}'.format(self.compiler.vendor.name, prop_name)
+                vars[key] = self.compiler.vendor.extra_props[prop_name]
+
+        vars['env'] = env
+
+        with open(os.path.join(self.cacheFolder, 'vars'), 'wb') as fp:
+            util.DiskPickle(vars, fp)
+
+    def detectCompilers(self, options):
+        if not self.compiler:
+            with util.FolderChanger(self.cacheFolder):
+                self.base_compiler = detect.AutoDetectCxx(self.target, self.options, options)
+                if self.base_compiler is None:
+                    raise Exception('Could not detect a suitable C/C++ compiler')
+                self.compiler = self.base_compiler.clone()
+
+        return self.compiler
+
+    def getLocalFolder(self, context):
+        if len(context.buildFolder):
+            return self.generateFolder(None, context.buildFolder)
+        return None
+
+    def generateFolder(self, parent, folder):
+        parent_path, path = paths.ResolveFolder(parent, folder)
+
+        # Quick check. If this folder is not in our old folder list, and it's in
+        # the DB, then we already have an entry for it that has already negotiated
+        # its parent paths.
+        old_entry = self.db.query_path(path)
+        if old_entry and self.isValidFolderEntry(old_entry):
+            return old_entry
+
+        components = []
+        while folder:
+            folder, name = os.path.split(folder)
+            if not name:
+                break
+            components.append(name)
+
+        path = parent_path
+        while len(components):
+            name = components.pop()
+            path = os.path.join(path, name)
+            entry = self.db.query_path(path)
+            if not entry:
+                if self.refactoring:
+                    util.con_err(util.ConsoleRed, 'New folder introduced: ', util.ConsoleBlue, path,
+                                 util.ConsoleNormal)
+                    raise Exception('Refactoring error: new folder')
+                entry = self.db.add_folder(parent, path)
+            elif entry.type == nodetypes.Output or entry.type == nodetypes.SharedOutput:
+                if entry.type == nodetypes.Output:
+                    cmd_entries = [self.db.query_command_of(entry)]
+                elif entry.type == nodetypes.SharedOutput:
+                    cmd_entries = self.db.query_shared_commands_of(entry)
+
+                for cmd_entry in cmd_entries:
+                    if cmd_entry not in self.old_commands_:
+                        util.con_err(util.ConsoleRed,
+                                     'Folder has the same path as an output file generated by:\n',
+                                     util.ConsoleBlue, cmd_entry.format(), util.ConsoleNormal)
+                        raise Exception('Output has been duplicated: {0}'.format(entry.path))
+
+                if self.refactoring:
+                    util.con_err(util.ConsoleRed, 'Path "', util.ConsoleBlue, entry.path,
+                                 util.ConsoleRed, '" has changed from a file to a folder.',
+                                 util.ConsoleNormal)
+                    raise Exception('Refactoring error: path changed from file to folder')
+
+                self.rm_list_.append(entry.path)
+                self.db.change_to_folder(entry)
+            elif entry.type == nodetypes.Mkdir:
+                # We let the same folder be generated twice, so use discard, not remove.
+                self.old_folders_.discard(entry)
+            else:
+                util.con_err(util.ConsoleRed, 'Folder has the same node signature as: ',
+                             util.ConsoleBlue, entry.format(), util.ConsoleNormal)
+                raise Exception('Output has been duplicated: {0}'.format(entry.path))
+
+            parent = entry
+
+        return entry
+
+    def isValidFolderEntry(self, folder_entry):
+        # If it's a mkdir and it's created, we're done.
+        return folder_entry.type == nodetypes.Mkdir and folder_entry not in self.old_folders_
+
+    def validateOutputFolder(self, path):
+        # Empty path is the root folder, which is null.
+        if not len(path):
+            return None
+
+        # The folder must already exist.
+        folder_entry = self.db.query_path(path)
+        if not folder_entry:
+            util.con_err(util.ConsoleRed, 'Path "', util.ConsoleBlue, path, util.ConsoleRed,
+                         '" specifies a folder that does not exist.', util.ConsoleNormal)
+            raise Exception('path specifies a folder that does not exist')
+
+        if self.isValidFolderEntry(folder_entry):
+            return folder_entry
+
+        # If it's a folder or an output, we can give a better error message.
+        if folder_entry.type == nodetypes.Output or folder_entry.type == nodetypes.Mkdir:
+            util.con_err(util.ConsoleRed, 'Folder "', util.ConsoleBlue, folder_entry.path,
+                         util.ConsoleRed, '" was never created.', util.ConsoleNormal)
+            raise Exception('path {0} was never created', folder_entry.path)
+
+        util.con_err(util.ConsoleRed, 'Attempted to use node "', util.ConsoleBlue,
+                     folder_entry.format(), util.ConsoleRed, '" as a path component.',
                      util.ConsoleNormal)
-        raise Exception('Refactoring error: command removed')
-      self.db.drop_command(cmd_entry)
+        raise Exception('illegal path component')
 
-    for path in self.old_scripts_:
-      self.db.drop_script(path)
+    def parseOutput(self, cwd_entry, path, kind):
+        if path[-1] == os.sep or path[-1] == os.altsep or path == '.' or path == '':
+            util.con_err(util.ConsoleRed, 'Path "', util.ConsoleBlue, path, util.ConsoleRed,
+                         '" looks like a folder; a folder was not expected.', util.ConsoleNormal)
+            raise Exception('Expected folder, but path has a trailing slash')
 
-    self.db.query_dead_sources(lambda e: self.db.drop_source(e))
-    self.db.query_dead_shared_outputs(lambda e: self.db.drop_output(e))
-    self.db.drop_unused_environments()
+        path = os.path.normpath(path)
 
-    class Node:
-      def __init__(self):
-        self.incoming = set()
-        self.outgoing = set()
+        path, name = os.path.split(path)
+        path = nodetypes.combine(cwd_entry, path)
 
-    # Build a tree of dead folders.
-    tracker = {}
-    for entry in self.old_folders_:
-      if entry not in tracker:
-        tracker[entry] = Node()
+        # We should have caught a case like 'x/' earlier.
+        assert len(name)
 
-      if entry.folder is None:
-        continue
+        # If we resolved that there is no prefix path, then take this to mean the
+        # root folder.
+        if path:
+            folder_entry = self.validateOutputFolder(path)
+            output_path = os.path.join(path, name)
+        else:
+            folder_entry = None
+            output_path = name
 
-      # If our parent is not a dead folder, don't create an edge. It should be
-      # impossible for a/b to be dead, a/b/c to be alive, and a/b/c/d to be
-      # dead, since a/b/c will implicitly keep a/b alive.
-      if entry.folder not in self.old_folders_:
-        continue
+        entry = self.db.query_path(output_path)
+        if not entry:
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'New output file introduced: ', util.ConsoleBlue,
+                             output_path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
+            return self.db.add_output(folder_entry, output_path, kind)
 
-      if entry.folder not in tracker:
-        tracker[entry.folder] = Node()
+        if entry.type == kind:
+            return entry
 
-      parent = tracker[entry.folder]
-      child = tracker[entry]
-      parent.incoming.add(entry)
-      child.outgoing.add(entry.folder)
+        if entry.type == nodetypes.Mkdir:
+            if entry not in self.old_folders_:
+                util.con_err(util.ConsoleRed, 'A folder is being re-used as an output file: "',
+                             util.ConsoleBlue, entry.path, util.ConsoleRed, '"', util.ConsoleNormal)
+                raise Exception('Attempted to re-use a folder as generated file')
 
-    # Find the leaves. Sets start out >= 1 items. Remove them as they they
-    # are empty.
-    dead_folders = [entry for entry in self.old_folders_ if len(tracker[entry].incoming) == 0]
-    while len(dead_folders):
-      child_entry = dead_folders.pop()
-      child_node = tracker[child_entry]
+            if self.refactoring:
+                util.con_err(util.ConsoleRed,
+                             'A generated folder has changed to a generated file: ',
+                             util.ConsoleBlue, entry.path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
 
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'Folder removed during refactoring: \n',
-                     util.ConsoleBlue, child_entry.format(),
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error: command removed')
+            # We keep the node in old_folders_. This should be okay, since we've
+            # changed the type to Output now. This way we can stick to one folder
+            # deletion routine, since it's fairly complicated.
+        elif entry.type == nodetypes.Output:
+            # If we're asking for a shared output, make sure we can reuse this one.
+            input_cmd = self.db.query_command_of(entry)
+            if input_cmd and input_cmd not in self.old_commands_:
+                util.con_err(util.ConsoleRed, 'First defined with command: ', input_cmd.format(),
+                             util.ConsoleNormal)
+                raise Exception('Existing output cannot be a shared output: {0}'.format(entry.path))
 
-      self.db.drop_folder(child_entry)
-      for parent_entry in child_node.outgoing:
-        parent_node = tracker[parent_entry]
-        parent_node.incoming.remove(child_entry)
-        if not len(parent_node.incoming):
-          dead_folders.append(parent_entry)
-
-  def postGenerate(self):
-    self.cleanup()
-    self.db.commit()
-    self.db.vacuum()
-    if self.is_bootstrap:
-      self.saveVars()
-      self.db.close()
-
-    if self.had_symlink_fallback:
-      util.con_out(util.ConsoleHeader,
-                   'Note: filesystem does not support symlinks. Files will be copied instead.',
-                   util.ConsoleNormal)
-
-  def saveVars(self):
-    vars = {
-      'sourcePath': self.sourcePath,
-      'buildPath': self.buildPath,
-      'originalCwd': self.originalCwd,
-      'options': self.options,
-      'args': self.args
-    }
-
-    # Save any environment variables that are relevant to the build.
-    env = {}
-
-    if self.compiler is not None:
-      # Save env vars that will be needed to reconfigure.
-      for key in self.compiler.EnvVars:
-        if key in os.environ:
-          env[key] = os.environ[key]
-
-      # Save any extra compiler info that must be communicated to the backend.
-      for prop_name in self.compiler.vendor.extra_props:
-        key = '{0}_{1}'.format(self.compiler.vendor.name, prop_name)
-        vars[key] = self.compiler.vendor.extra_props[prop_name]
-
-    vars['env'] = env
-
-    with open(os.path.join(self.cacheFolder, 'vars'), 'wb') as fp:
-      util.DiskPickle(vars, fp)
-
-  def detectCompilers(self, options):
-    if not self.compiler:
-      with util.FolderChanger(self.cacheFolder):
-        self.base_compiler = detect.AutoDetectCxx(self.target, self.options, options)
-        if self.base_compiler is None:
-          raise Exception('Could not detect a suitable C/C++ compiler')
-        self.compiler = self.base_compiler.clone()
-
-    return self.compiler
-
-  def getLocalFolder(self, context):
-    if len(context.buildFolder):
-      return self.generateFolder(None, context.buildFolder)
-    return None
-
-  def generateFolder(self, parent, folder):
-    parent_path, path = paths.ResolveFolder(parent, folder)
-
-    # Quick check. If this folder is not in our old folder list, and it's in
-    # the DB, then we already have an entry for it that has already negotiated
-    # its parent paths.
-    old_entry = self.db.query_path(path)
-    if old_entry and self.isValidFolderEntry(old_entry):
-      return old_entry
-
-    components = []
-    while folder:
-      folder, name = os.path.split(folder)
-      if not name:
-        break
-      components.append(name)
-
-    path = parent_path
-    while len(components):
-      name = components.pop()
-      path = os.path.join(path, name)
-      entry = self.db.query_path(path)
-      if not entry:
-        if self.refactoring:
-          util.con_err(util.ConsoleRed, 'New folder introduced: ',
-                       util.ConsoleBlue, path,
-                       util.ConsoleNormal)
-          raise Exception('Refactoring error: new folder')
-        entry = self.db.add_folder(parent, path)
-      elif entry.type == nodetypes.Output or entry.type == nodetypes.SharedOutput:
-        if entry.type == nodetypes.Output:
-          cmd_entries = [self.db.query_command_of(entry)]
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'An output has changed to a shared output: ',
+                             util.ConsoleBlue, entry.path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
         elif entry.type == nodetypes.SharedOutput:
-          cmd_entries = self.db.query_shared_commands_of(entry)
+            input_cmds = self.db.query_shared_commands_of(entry)
+            for input_cmd in input_cmds:
+                if input_cmd not in self.old_commands_:
+                    util.con_err(util.ConsoleRed,
+                                 'A shared output cannot be specified as an normal output.',
+                                 util.ConsoleNormal)
+                    raise Exception('Existing shared output cannot be a normal output: {0}'.format(
+                        entry.path))
 
-        for cmd_entry in cmd_entries:
-          if cmd_entry not in self.old_commands_:
-            util.con_err(util.ConsoleRed, 'Folder has the same path as an output file generated by:\n',
-                         util.ConsoleBlue, cmd_entry.format(),
+            if self.refactoring:
+                util.con_err(util.ConsoleRed, 'A shared output has changed to a normal output: ',
+                             util.ConsoleBlue, entry.path, util.ConsoleNormal)
+                raise Exception('Refactoring error')
+        else:
+            util.con_err(util.ConsoleRed,
+                         'An existing node has been specified as an output file: "',
+                         util.ConsoleBlue, entry.format(), util.ConsoleRed, '"', util.ConsoleNormal)
+            raise Exception('Attempted to re-use an incompatible node as an output')
+
+        self.db.change_to_output(entry, kind)
+        return entry
+
+    def parseInput(self, context, source):
+        if util.IsString(source):
+            if not os.path.isabs(source):
+                source = os.path.join(context.currentSourcePath, source)
+            source = os.path.normpath(source)
+
+            entry = self.db.query_path(source)
+            if not entry:
+                return self.db.add_source(source)
+
+            # Otherwise, we have to valid the node.
+            source = entry
+
+        if source.type == nodetypes.Source or source.type == nodetypes.Output:
+            return source
+
+        if source.type == nodetypes.Mkdir:
+            if source not in self.bad_outputs_:
+                util.con_err(util.ConsoleRed, 'Tried to use folder path ', util.ConsoleBlue,
+                             source.path, util.ConsoleRed, ' as a file path.', util.ConsoleNormal)
+                raise Exception('Tried to use folder path as a file path')
+
+        util.con_err(util.ConsoleRed, 'Tried to use incompatible node "', util.ConsoleBlue,
+                     source.format(), util.ConsoleRed, '" as a file path.', util.ConsoleNormal)
+        raise Exception('Tried to use non-file node as a file path')
+
+    def addCommand(self,
+                   context,
+                   node_type,
+                   folder,
+                   data,
+                   inputs,
+                   outputs,
+                   weak_inputs = [],
+                   shared_outputs = [],
+                   env_data = None):
+        assert not folder or isinstance(folder, nodetypes.Entry)
+
+        if inputs is context.ALWAYS_DIRTY:
+            if len(weak_inputs) != 0:
+                message = "Always-dirty commands cannot have weak inputs"
+                util.con_err(util.ConsoleRed, "{0}.".format(message), util.ConsoleNormal)
+                raise Exception(message)
+            if node_type != nodetypes.Command:
+                message = "Node type {0} cannot be always-dirty".format(node_type)
+                util.con_err(util.ConsoleRed, "{0}.".format(message), util.ConsoleNormal)
+                raise Exception(message)
+
+        # Build the set of weak links.
+        weak_links = set()
+        for weak_input in weak_inputs:
+            assert type(weak_input) is nodetypes.Entry
+            assert weak_input.type != nodetypes.Source
+            weak_links.add(weak_input)
+
+        # Build the set of strong links.
+        strong_links = set()
+        if inputs is not context.ALWAYS_DIRTY:
+            for strong_input in inputs:
+                strong_input = self.parseInput(context, strong_input)
+                strong_links.add(strong_input)
+
+        # Build the list of outputs.
+        cmd_entry = None
+        output_nodes = []
+        for output in outputs:
+            output_node = self.parseOutput(folder, output, nodetypes.Output)
+            output_nodes.append(output_node)
+
+            input_entry = self.db.query_command_of(output_node)
+            if not input_entry:
+                continue
+
+            # Make sure this output won't be duplicated.
+            if input_entry not in self.old_commands_:
+                util.con_err(util.ConsoleRed, 'Command: ', input_entry.format(), util.ConsoleNormal)
+                raise Exception('Output has been duplicated: {0}'.format(output_node.path))
+
+            if not cmd_entry:
+                cmd_entry = input_entry
+        # end for
+
+        # Build the list of shared outputs.
+        shared_output_nodes = []
+        for shared_output in shared_outputs:
+            shared_output_node = self.parseOutput(folder, shared_output, nodetypes.SharedOutput)
+            shared_output_nodes.append(shared_output_node)
+
+        output_links = set(output_nodes)
+        shared_links = set(shared_output_nodes)
+
+        # There should be no duplicates in either output list. These error messages
+        # could be better.
+        if len(output_nodes) > len(output_links):
+            util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
                          util.ConsoleNormal)
-            raise Exception('Output has been duplicated: {0}'.format(entry.path))
+            raise Exception('Shared output list contains duplicate files.')
+        if len(shared_output_nodes) > len(shared_links):
+            util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
+                         util.ConsoleNormal)
+            raise Exception('Shared output list contains duplicate files.')
 
-        if self.refactoring:
-          util.con_err(util.ConsoleRed, 'Path "',
-                       util.ConsoleBlue, entry.path,
-                       util.ConsoleRed, '" has changed from a file to a folder.',
-                       util.ConsoleNormal)
-          raise Exception('Refactoring error: path changed from file to folder')
+        # The intersection of output_links and shared_links should be the empty set.
+        duplicates = output_links.intersection(shared_links)
+        if len(duplicates):
+            bad_entry = duplicates.pop()
+            util.con_err(util.ConsoleRed, 'An output has been duplicated as a shared output: ',
+                         util.ConsoleBlue, bad_entry.path, util.ConsoleNormal)
+            raise Exception('An output has been duplicated as a shared output.')
 
-        self.rm_list_.append(entry.path)
-        self.db.change_to_folder(entry)
-      elif entry.type == nodetypes.Mkdir:
-        # We let the same folder be generated twice, so use discard, not remove.
-        self.old_folders_.discard(entry)
-      else:
-        util.con_err(util.ConsoleRed, 'Folder has the same node signature as: ',
-                     util.ConsoleBlue, entry.format(),
-                     util.ConsoleNormal)
-        raise Exception('Output has been duplicated: {0}'.format(entry.path))
+        dirty = nodetypes.DIRTY
+        if inputs == context.ALWAYS_DIRTY:
+            dirty = nodetypes.ALWAYS_DIRTY
 
-      parent = entry
+        if cmd_entry:
+            # Update the entry in the database.
+            self.db.update_command(cmd_entry, node_type, folder, data, dirty, self.refactoring,
+                                   env_data)
 
-    return entry
+            # Disconnect any outputs that are no longer connected to this output.
+            # It's okay to use output_links since there should never be duplicate
+            # outputs.
+            for outgoing in self.db.query_strong_outgoing(cmd_entry):
+                if outgoing not in output_links:
+                    self.db.drop_strong_edge(cmd_entry, outgoing)
+                    self.db.drop_output(outgoing)
+                else:
+                    output_links.remove(outgoing)
 
-  def isValidFolderEntry(self, folder_entry):
-    # If it's a mkdir and it's created, we're done.
-    return folder_entry.type == nodetypes.Mkdir and folder_entry not in self.old_folders_
+            # Do the same for shared outputs. Since there is a many:1 relationship,
+            # we can't drop shared outputs here. We save that for a cleanup step.
+            for outgoing in self.db.query_shared_outputs(cmd_entry):
+                if outgoing not in shared_links:
+                    self.db.drop_shared_output_edge(cmd_entry, outgoing)
+                else:
+                    shared_links.remove(outgoing)
 
-  def validateOutputFolder(self, path):
-    # Empty path is the root folder, which is null.
-    if not len(path):
-      return None
-
-    # The folder must already exist.
-    folder_entry = self.db.query_path(path)
-    if not folder_entry:
-      util.con_err(util.ConsoleRed, 'Path "',
-                   util.ConsoleBlue, path,
-                   util.ConsoleRed, '" specifies a folder that does not exist.',
-                   util.ConsoleNormal)
-      raise Exception('path specifies a folder that does not exist')
-
-    if self.isValidFolderEntry(folder_entry):
-      return folder_entry
-
-    # If it's a folder or an output, we can give a better error message.
-    if folder_entry.type == nodetypes.Output or folder_entry.type == nodetypes.Mkdir:
-      util.con_err(util.ConsoleRed, 'Folder "',
-                   util.ConsoleBlue, folder_entry.path,
-                   util.ConsoleRed, '" was never created.',
-                   util.ConsoleNormal)
-      raise Exception('path {0} was never created', folder_entry.path)
-
-    util.con_err(util.ConsoleRed, 'Attempted to use node "',
-                 util.ConsoleBlue, folder_entry.format(),
-                 util.ConsoleRed, '" as a path component.',
-                 util.ConsoleNormal)
-    raise Exception('illegal path component')
-
-  def parseOutput(self, cwd_entry, path, kind):
-    if path[-1] == os.sep or path[-1] == os.altsep or path == '.' or path == '':
-      util.con_err(util.ConsoleRed, 'Path "',
-                   util.ConsoleBlue, path,
-                   util.ConsoleRed, '" looks like a folder; a folder was not expected.',
-                   util.ConsoleNormal)
-      raise Exception('Expected folder, but path has a trailing slash')
-
-    path = os.path.normpath(path)
-
-    path, name = os.path.split(path)
-    path = nodetypes.combine(cwd_entry, path)
-
-    # We should have caught a case like 'x/' earlier.
-    assert len(name)
-
-    # If we resolved that there is no prefix path, then take this to mean the
-    # root folder.
-    if path:
-      folder_entry = self.validateOutputFolder(path)
-      output_path = os.path.join(path, name)
-    else:
-      folder_entry = None
-      output_path = name
-
-    entry = self.db.query_path(output_path)
-    if not entry:
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'New output file introduced: ',
-                     util.ConsoleBlue, output_path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-      return self.db.add_output(folder_entry, output_path, kind)
-
-    if entry.type == kind:
-      return entry
-
-    if entry.type == nodetypes.Mkdir:
-      if entry not in self.old_folders_:
-        util.con_err(util.ConsoleRed, 'A folder is being re-used as an output file: "',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleRed, '"',
-                     util.ConsoleNormal)
-        raise Exception('Attempted to re-use a folder as generated file')
-
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'A generated folder has changed to a generated file: ',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-
-      # We keep the node in old_folders_. This should be okay, since we've
-      # changed the type to Output now. This way we can stick to one folder
-      # deletion routine, since it's fairly complicated.
-    elif entry.type == nodetypes.Output:
-      # If we're asking for a shared output, make sure we can reuse this one.
-      input_cmd = self.db.query_command_of(entry)
-      if input_cmd and input_cmd not in self.old_commands_:
-        util.con_err(util.ConsoleRed, 'First defined with command: ', input_cmd.format(), util.ConsoleNormal)
-        raise Exception('Existing output cannot be a shared output: {0}'.format(entry.path))
-
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'An output has changed to a shared output: ',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-    elif entry.type == nodetypes.SharedOutput:
-      input_cmds = self.db.query_shared_commands_of(entry)
-      for input_cmd in input_cmds:
-        if input_cmd not in self.old_commands_:
-          util.con_err(util.ConsoleRed, 'A shared output cannot be specified as an normal output.',
-                       util.ConsoleNormal)
-          raise Exception('Existing shared output cannot be a normal output: {0}'.format(entry.path))
-
-      if self.refactoring:
-        util.con_err(util.ConsoleRed, 'A shared output has changed to a normal output: ',
-                     util.ConsoleBlue, entry.path,
-                     util.ConsoleNormal)
-        raise Exception('Refactoring error')
-    else:
-      util.con_err(util.ConsoleRed, 'An existing node has been specified as an output file: "',
-                   util.ConsoleBlue, entry.format(),
-                   util.ConsoleRed, '"',
-                   util.ConsoleNormal)
-      raise Exception('Attempted to re-use an incompatible node as an output')
-
-    self.db.change_to_output(entry, kind)
-    return entry
-
-  def parseInput(self, context, source):
-    if util.IsString(source):
-      if not os.path.isabs(source):
-        source = os.path.join(context.currentSourcePath, source)
-      source = os.path.normpath(source)
-
-      entry = self.db.query_path(source)
-      if not entry:
-        return self.db.add_source(source)
-
-      # Otherwise, we have to valid the node.
-      source = entry
-
-    if source.type == nodetypes.Source or source.type == nodetypes.Output:
-      return source
-
-    if source.type == nodetypes.Mkdir:
-      if source not in self.bad_outputs_:
-        util.con_err(util.ConsoleRed, 'Tried to use folder path ',
-                     util.ConsoleBlue, source.path,
-                     util.ConsoleRed, ' as a file path.',
-                     util.ConsoleNormal)
-        raise Exception('Tried to use folder path as a file path')
-
-    util.con_err(util.ConsoleRed, 'Tried to use incompatible node "',
-                 util.ConsoleBlue, source.format(),
-                 util.ConsoleRed, '" as a file path.',
-                 util.ConsoleNormal)
-    raise Exception('Tried to use non-file node as a file path')
-
-  def addCommand(self, context, node_type, folder, data, inputs, outputs,
-                 weak_inputs=[], shared_outputs=[], env_data = None):
-    assert not folder or isinstance(folder, nodetypes.Entry)
-
-    if inputs is context.ALWAYS_DIRTY:
-      if len(weak_inputs) != 0:
-        message = "Always-dirty commands cannot have weak inputs"
-        util.con_err(util.ConsoleRed, "{0}.".format(message), util.ConsoleNormal)
-        raise Exception(message)
-      if node_type != nodetypes.Command:
-        message = "Node type {0} cannot be always-dirty".format(node_type)
-        util.con_err(util.ConsoleRed, "{0}.".format(message), util.ConsoleNormal)
-        raise Exception(message)
-
-    # Build the set of weak links.
-    weak_links = set()
-    for weak_input in weak_inputs:
-      assert type(weak_input) is nodetypes.Entry
-      assert weak_input.type != nodetypes.Source
-      weak_links.add(weak_input)
-
-    # Build the set of strong links.
-    strong_links = set()
-    if inputs is not context.ALWAYS_DIRTY:
-      for strong_input in inputs:
-        strong_input = self.parseInput(context, strong_input)
-        strong_links.add(strong_input)
-
-    # Build the list of outputs.
-    cmd_entry = None
-    output_nodes = []
-    for output in outputs:
-      output_node = self.parseOutput(folder, output, nodetypes.Output)
-      output_nodes.append(output_node)
-
-      input_entry = self.db.query_command_of(output_node)
-      if not input_entry:
-        continue
-
-      # Make sure this output won't be duplicated.
-      if input_entry not in self.old_commands_:
-        util.con_err(util.ConsoleRed, 'Command: ', input_entry.format(), util.ConsoleNormal)
-        raise Exception('Output has been duplicated: {0}'.format(output_node.path))
-
-      if not cmd_entry:
-        cmd_entry = input_entry
-    # end for
-
-    # Build the list of shared outputs.
-    shared_output_nodes = []
-    for shared_output in shared_outputs:
-      shared_output_node = self.parseOutput(folder, shared_output, nodetypes.SharedOutput)
-      shared_output_nodes.append(shared_output_node)
-
-    output_links = set(output_nodes)
-    shared_links = set(shared_output_nodes)
-
-    # There should be no duplicates in either output list. These error messages
-    # could be better.
-    if len(output_nodes) > len(output_links):
-      util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
-                   util.ConsoleNormal)
-      raise Exception('Shared output list contains duplicate files.')
-    if len(shared_output_nodes) > len(shared_links):
-      util.con_err(util.ConsoleRed, 'The output list contains duplicate files.',
-                   util.ConsoleNormal)
-      raise Exception('Shared output list contains duplicate files.')
-
-    # The intersection of output_links and shared_links should be the empty set.
-    duplicates = output_links.intersection(shared_links)
-    if len(duplicates):
-      bad_entry = duplicates.pop()
-      util.con_err(util.ConsoleRed, 'An output has been duplicated as a shared output: ',
-                   util.ConsoleBlue, bad_entry.path,
-                   util.ConsoleNormal)
-      raise Exception('An output has been duplicated as a shared output.')
-
-    dirty = nodetypes.DIRTY
-    if inputs == context.ALWAYS_DIRTY:
-      dirty = nodetypes.ALWAYS_DIRTY
-
-    if cmd_entry:
-      # Update the entry in the database.
-      self.db.update_command(cmd_entry, node_type, folder, data, dirty, self.refactoring,
-                             env_data)
-
-      # Disconnect any outputs that are no longer connected to this output.
-      # It's okay to use output_links since there should never be duplicate
-      # outputs.
-      for outgoing in self.db.query_strong_outgoing(cmd_entry):
-        if outgoing not in output_links:
-          self.db.drop_strong_edge(cmd_entry, outgoing)
-          self.db.drop_output(outgoing)
+            # Remove us from the list of commands to delete.
+            self.old_commands_.remove(cmd_entry)
         else:
-          output_links.remove(outgoing)
+            # Note that if there are no outputs, we will always add a new command,
+            # and the old (identical) command will be deleted.
+            cmd_entry = self.db.add_command(node_type, folder, data, dirty, env_data)
 
-      # Do the same for shared outputs. Since there is a many:1 relationship,
-      # we can't drop shared outputs here. We save that for a cleanup step.
-      for outgoing in self.db.query_shared_outputs(cmd_entry):
-        if outgoing not in shared_links:
-          self.db.drop_shared_output_edge(cmd_entry, outgoing)
+        # Local helper function to warn about refactoring problems.
+        def refactoring_error(node):
+            util.con_err(util.ConsoleRed, 'New input introduced: ', util.ConsoleBlue,
+                         node.path + '\n', util.ConsoleRed, 'Command: ', util.ConsoleBlue,
+                         cmd_entry.format(), util.ConsoleNormal)
+            raise Exception('Refactoring error: new input introduced')
+
+        if len(output_links) and self.refactoring:
+            refactoring_error(output_links.pop())
+        if len(shared_links) and self.refactoring:
+            refactoring_error(shared_links.pop())
+
+        # Connect each output.
+        for output_node in output_links:
+            self.db.add_strong_edge(cmd_entry, output_node)
+        for shared_output_node in shared_links:
+            self.db.add_shared_output_edge(cmd_entry, shared_output_node)
+
+        # Connect/disconnect strong inputs.
+        strong_inputs = self.db.query_strong_inputs(cmd_entry)
+        strong_added = strong_links - strong_inputs
+        strong_removed = strong_inputs - strong_links
+
+        if len(strong_added) and self.refactoring:
+            refactoring_error(strong_added.pop())
+
+        for strong_input in strong_added:
+            self.db.add_strong_edge(strong_input, cmd_entry)
+        for strong_input in strong_removed:
+            self.db.drop_strong_edge(strong_input, cmd_entry)
+
+        # Connect/disconnect weak inputs.
+        weak_inputs = self.db.query_weak_inputs(cmd_entry)
+        weak_added = weak_links - weak_inputs
+        weak_removed = weak_inputs - weak_links
+
+        if len(weak_added) and self.refactoring:
+            refactoring_error(weak_added.pop())
+
+        for weak_input in weak_added:
+            self.db.add_weak_edge(weak_input, cmd_entry)
+        for weak_input in weak_removed:
+            self.db.drop_weak_edge(weak_input, cmd_entry)
+
+        # If we got new outputs or inputs, we need to re-run the command.
+        changed = len(output_links) + len(strong_added) + len(weak_added)
+        if changed and cmd_entry.dirty == nodetypes.NOT_DIRTY:
+            self.db.mark_dirty(cmd_entry)
+
+        return cmd_entry, output_nodes
+
+    def parseCxxDeps(self, context, binary, inputs, items):
+        for val in items:
+            if util.IsString(val):
+                continue
+
+            if type(val) is nodetypes.Entry:
+                item = val
+            elif util.IsLambda(val.node):
+                item = val.node(context, binary)
+            elif val.node is None:
+                item = self.parseInput(context, val.text).path
+            else:
+                item = val.node
+
+            if type(item) is list:
+                inputs.extend(item)
+            else:
+                inputs.append(item)
+
+    def addCxxObjTask(self, cx, shared_outputs, folder, obj):
+        cxxData = {'argv': obj.argv, 'type': obj.behavior}
+        _, (cxxNode,) = self.addCommand(context = cx,
+                                        weak_inputs = obj.sourcedeps,
+                                        inputs = [obj.inputObj],
+                                        outputs = [obj.outputFile],
+                                        node_type = nodetypes.Cxx,
+                                        folder = folder,
+                                        data = cxxData,
+                                        shared_outputs = shared_outputs,
+                                        env_data = obj.env_data)
+        return cxxNode
+
+    def addCxxRcTask(self, cx, folder, obj):
+        rcData = {
+            'cl_argv': obj.cl_argv,
+            'rc_argv': obj.rc_argv,
+        }
+        _, (_, rcNode) = self.addCommand(context = cx,
+                                         weak_inputs = obj.sourcedeps,
+                                         inputs = [obj.inputObj],
+                                         outputs = [obj.preprocFile, obj.outputFile],
+                                         node_type = nodetypes.Rc,
+                                         folder = folder,
+                                         data = rcData,
+                                         env_data = obj.env_data)
+        return rcNode
+
+    def addCxxTasks(self, cx, binary):
+        # Find dependencies
+        inputs = []
+        self.parseCxxDeps(cx, binary, inputs, binary.compiler.linkflags)
+        self.parseCxxDeps(cx, binary, inputs, binary.compiler.postlink)
+
+        # Add object files.
+        for obj in binary.objects:
+            if obj.type == 'object':
+                inputs.append(self.addCxxObjTask(cx, binary.shared_cc_outputs, obj.folderNode, obj))
+            elif obj.type == 'resource':
+                inputs.append(self.addCxxRcTask(cx, obj.folderNode, obj))
+
+        # Add the link step.
+        folder_node = self.generateFolder(cx.localFolder, binary.localFolder)
+        output_file, debug_file = binary.link(context = cx, folder = folder_node, inputs = inputs)
+
+        return cpp.CppNodes(output_file, debug_file, binary.type)
+
+    def addFileOp(self, cmd, context, source, output_path):
+        # Try to detect if our output_path is actually a folder, via trailing
+        # slash or '.'/'' indicating the context folder.
+        detected_folder = None
+        if util.IsString(output_path):
+            if output_path[-1] == os.sep or output_path[-1] == os.altsep:
+                detected_folder = os.path.join(context.buildFolder, os.path.normpath(output_path))
+            elif output_path == '.' or output_path == '':
+                detected_folder = context.buildFolder
+
+            # Since we're building something relative to the context folder, ensure
+            # that the context folder exists.
+            self.getLocalFolder(context)
         else:
-          shared_links.remove(outgoing)
+            assert output_path.type != nodetypes.Source
+            local_path = os.path.relpath(output_path.path, context.buildFolder)
+            detected_folder = os.path.join(context.buildFolder, local_path)
+            detected_folder = os.path.normpath(detected_folder)
 
-      # Remove us from the list of commands to delete.
-      self.old_commands_.remove(cmd_entry)
-    else:
-      # Note that if there are no outputs, we will always add a new command,
-      # and the old (identical) command will be deleted.
-      cmd_entry = self.db.add_command(node_type, folder, data, dirty, env_data)
+        source_entry = self.parseInput(context, source)
 
-    # Local helper function to warn about refactoring problems.
-    def refactoring_error(node):
-      util.con_err(util.ConsoleRed, 'New input introduced: ',
-                   util.ConsoleBlue, node.path + '\n',
-                   util.ConsoleRed, 'Command: ',
-                   util.ConsoleBlue, cmd_entry.format(),
-                   util.ConsoleNormal)
-      raise Exception('Refactoring error: new input introduced')
+        # This is similar to a "cp a b/", so we append to get "b/a" as the path.
+        if detected_folder is not None:
+            base, output_path = os.path.split(source_entry.path)
+            assert len(output_path)
 
-    if len(output_links) and self.refactoring:
-      refactoring_error(output_links.pop())
-    if len(shared_links) and self.refactoring:
-      refactoring_error(shared_links.pop())
+            output_folder = detected_folder
+        else:
+            output_folder = context.buildFolder
 
-    # Connect each output.
-    for output_node in output_links:
-      self.db.add_strong_edge(cmd_entry, output_node)
-    for shared_output_node in shared_links:
-      self.db.add_shared_output_edge(cmd_entry, shared_output_node)
+        output_path = nodetypes.combine(output_folder, output_path)
 
-    # Connect/disconnect strong inputs.
-    strong_inputs = self.db.query_strong_inputs(cmd_entry)
-    strong_added = strong_links - strong_inputs
-    strong_removed = strong_inputs - strong_links 
+        # For copy operations, it's okay to use the path from the current folder.
+        # However, when performing symlinks, we always want an absolute path.
+        if cmd == nodetypes.Symlink:
+            if source_entry.type == nodetypes.Source:
+                source_path = source_entry.path
+            else:
+                source_path = os.path.join(context.buildPath, source_entry.path)
+        else:
+            source_path = source_entry.path
 
-    if len(strong_added) and self.refactoring:
-      refactoring_error(strong_added.pop())
+        # For clarity of spew, we always execute file operations in the root of
+        # the build folder. This means that no matter what context we're in,
+        # we can use absolute-ish folders and get away with it.
+        return self.addCommand(context = context,
+                               node_type = cmd,
+                               folder = None,
+                               data = (source_path, output_path),
+                               inputs = [source_entry],
+                               outputs = [output_path])
 
-    for strong_input in strong_added:
-      self.db.add_strong_edge(strong_input, cmd_entry)
-    for strong_input in strong_removed:
-      self.db.drop_strong_edge(strong_input, cmd_entry)
+    def addSource(self, context, source_path):
+        return self.graph.addSource(source_path)
 
-    # Connect/disconnect weak inputs.
-    weak_inputs = self.db.query_weak_inputs(cmd_entry)
-    weak_added = weak_links - weak_inputs
-    weak_removed = weak_inputs - weak_links 
+    def addCopy(self, context, source, output_path):
+        return self.addFileOp(nodetypes.Copy, context, source, output_path)
 
-    if len(weak_added) and self.refactoring:
-      refactoring_error(weak_added.pop())
+    def addSymlink(self, context, source, output_path):
+        if util.IsWindows():
+            # Windows pre-Vista does not support symlinks. Windows Vista+ supports
+            # symlinks via mklink, but it's Administrator-only by default.
+            return self.addFileOp(nodetypes.Copy, context, source, output_path)
 
-    for weak_input in weak_added:
-      self.db.add_weak_edge(weak_input, cmd_entry)
-    for weak_input in weak_removed:
-      self.db.drop_weak_edge(weak_input, cmd_entry)
+        if not self.symlink_support:
+            self.had_symlink_fallback = True
+            return self.addFileOp(nodetypes.Copy, context, source, output_path)
 
-    # If we got new outputs or inputs, we need to re-run the command.
-    changed = len(output_links) + len(strong_added) + len(weak_added)
-    if changed and cmd_entry.dirty == nodetypes.NOT_DIRTY:
-      self.db.mark_dirty(cmd_entry)
+        return self.addFileOp(nodetypes.Symlink, context, source, output_path)
 
-    return cmd_entry, output_nodes
+    def addFolder(self, context, folder):
+        return self.generateFolder(context.localFolder, folder)
 
-  def parseCxxDeps(self, context, binary, inputs, items):
-    for val in items:
-      if util.IsString(val):
-        continue
+    def addShellCommand(self,
+                        context,
+                        inputs,
+                        argv,
+                        outputs,
+                        folder = -1,
+                        dep_type = None,
+                        weak_inputs = [],
+                        shared_outputs = [],
+                        env_data = None):
+        if folder == -1:
+            folder = context.localFolder
 
-      if type(val) is nodetypes.Entry:
-        item = val
-      elif util.IsLambda(val.node):
-        item = val.node(context, binary)
-      elif val.node is None:
-        item = self.parseInput(context, val.text).path
-      else:
-        item = val.node
+        if dep_type is None:
+            node_type = nodetypes.Command
+            data = argv
+        else:
+            node_type = nodetypes.Cxx
+            if dep_type not in ['gcc', 'msvc', 'sun', 'fxc']:
+                util.con_err(util.ConsoleRed, 'Invalid dependency spew type: ', util.ConsoleBlue,
+                             dep_type, util.ConsoleNormal)
+                raise Exception('Invalid dependency spew type')
+            data = {
+                'type': dep_type,
+                'argv': argv,
+            }
 
-      if type(item) is list:
-        inputs.extend(item)
-      else:
-        inputs.append(item)
+        if argv is None:
+            raise Exception('argv cannot be None')
 
-  def addCxxObjTask(self, cx, shared_outputs, folder, obj):
-    cxxData = {
-      'argv': obj.argv,
-      'type': obj.behavior
-    }
-    _, (cxxNode,) = self.addCommand(
-      context = cx,
-      weak_inputs = obj.sourcedeps,
-      inputs = [obj.inputObj],
-      outputs = [obj.outputFile],
-      node_type = nodetypes.Cxx,
-      folder = folder,
-      data = cxxData,
-      shared_outputs = shared_outputs,
-      env_data = obj.env_data)
-    return cxxNode
+        return self.addCommand(context = context,
+                               node_type = node_type,
+                               folder = folder,
+                               data = data,
+                               inputs = inputs,
+                               outputs = outputs,
+                               weak_inputs = weak_inputs,
+                               shared_outputs = shared_outputs,
+                               env_data = env_data)
 
-  def addCxxRcTask(self, cx, folder, obj):
-    rcData = {
-      'cl_argv': obj.cl_argv,
-      'rc_argv': obj.rc_argv,
-    }
-    _, (_, rcNode) = self.addCommand(
-      context = cx,
-      weak_inputs = obj.sourcedeps,
-      inputs = [obj.inputObj],
-      outputs = [obj.preprocFile, obj.outputFile],
-      node_type = nodetypes.Rc,
-      folder = folder,
-      data = rcData,
-      env_data = obj.env_data
-    )
-    return rcNode
+    def addConfigureFile(self, context, path):
+        if not os.path.isabs(path) and context is not None:
+            path = os.path.join(context.currentSourcePath, path)
+        path = os.path.normpath(path)
 
-  def addCxxTasks(self, cx, binary):
-    # Find dependencies
-    inputs = []
-    self.parseCxxDeps(cx, binary, inputs, binary.compiler.linkflags)
-    self.parseCxxDeps(cx, binary, inputs, binary.compiler.postlink)
-
-    # Add object files.
-    for obj in binary.objects:
-      if obj.type == 'object':
-        inputs.append(self.addCxxObjTask(cx, binary.shared_cc_outputs, obj.folderNode, obj))
-      elif obj.type == 'resource':
-        inputs.append(self.addCxxRcTask(cx, obj.folderNode, obj))
-
-    # Add the link step.
-    folder_node = self.generateFolder(cx.localFolder, binary.localFolder)
-    output_file, debug_file = binary.link(
-      context = cx,
-      folder = folder_node,
-      inputs = inputs)
-
-    return cpp.CppNodes(output_file, debug_file, binary.type)
-
-  def addFileOp(self, cmd, context, source, output_path):
-    # Try to detect if our output_path is actually a folder, via trailing
-    # slash or '.'/'' indicating the context folder.
-    detected_folder = None
-    if util.IsString(output_path):
-      if output_path[-1] == os.sep or output_path[-1] == os.altsep:
-        detected_folder = os.path.join(context.buildFolder, os.path.normpath(output_path))
-      elif output_path == '.' or output_path == '':
-        detected_folder = context.buildFolder
-
-      # Since we're building something relative to the context folder, ensure
-      # that the context folder exists.
-      self.getLocalFolder(context)
-    else:
-      assert output_path.type != nodetypes.Source
-      local_path = os.path.relpath(output_path.path, context.buildFolder)
-      detected_folder = os.path.join(context.buildFolder, local_path)
-      detected_folder = os.path.normpath(detected_folder)
-
-    source_entry = self.parseInput(context, source)
-
-    # This is similar to a "cp a b/", so we append to get "b/a" as the path.
-    if detected_folder is not None:
-      base, output_path = os.path.split(source_entry.path)
-      assert len(output_path)
-
-      output_folder = detected_folder
-    else:
-      output_folder = context.buildFolder
-
-    output_path = nodetypes.combine(output_folder, output_path)
-
-    # For copy operations, it's okay to use the path from the current folder.
-    # However, when performing symlinks, we always want an absolute path.
-    if cmd == nodetypes.Symlink:
-      if source_entry.type == nodetypes.Source:
-        source_path = source_entry.path
-      else:
-        source_path = os.path.join(context.buildPath, source_entry.path)
-    else:
-      source_path = source_entry.path
-
-    # For clarity of spew, we always execute file operations in the root of
-    # the build folder. This means that no matter what context we're in,
-    # we can use absolute-ish folders and get away with it.
-    return self.addCommand(
-      context = context,
-      node_type = cmd,
-      folder = None,
-      data = (source_path, output_path),
-      inputs = [source_entry],
-      outputs = [output_path]
-    )
-
-  def addSource(self, context, source_path):
-    return self.graph.addSource(source_path)
-
-  def addCopy(self, context, source, output_path):
-    return self.addFileOp(nodetypes.Copy, context, source, output_path)
-
-  def addSymlink(self, context, source, output_path):
-    if util.IsWindows():
-      # Windows pre-Vista does not support symlinks. Windows Vista+ supports
-      # symlinks via mklink, but it's Administrator-only by default.
-      return self.addFileOp(nodetypes.Copy, context, source, output_path)
-
-    if not self.symlink_support:
-      self.had_symlink_fallback = True
-      return self.addFileOp(nodetypes.Copy, context, source, output_path)
-
-    return self.addFileOp(nodetypes.Symlink, context, source, output_path)
-
-  def addFolder(self, context, folder):
-    return self.generateFolder(context.localFolder, folder)
-
-  def addShellCommand(self,
-                      context,
-                      inputs,
-                      argv,
-                      outputs,
-                      folder=-1,
-                      dep_type=None,
-                      weak_inputs=[],
-                      shared_outputs=[],
-                      env_data=None):
-    if folder == -1:
-      folder = context.localFolder
-
-    if dep_type is None:
-      node_type = nodetypes.Command
-      data = argv
-    else:
-      node_type = nodetypes.Cxx
-      if dep_type not in ['gcc', 'msvc', 'sun', 'fxc']:
-        util.con_err(util.ConsoleRed, 'Invalid dependency spew type: ',
-                     util.ConsoleBlue, dep_type,
-                     util.ConsoleNormal)
-        raise Exception('Invalid dependency spew type')
-      data = {
-        'type': dep_type,
-        'argv': argv,
-      }
-
-    if argv is None:
-      raise Exception('argv cannot be None')
-
-    return self.addCommand(
-      context = context,
-      node_type = node_type,
-      folder = folder,
-      data = data,
-      inputs = inputs,
-      outputs = outputs,
-      weak_inputs = weak_inputs,
-      shared_outputs = shared_outputs,
-      env_data = env_data)
-
-  def addConfigureFile(self, context, path):
-    if not os.path.isabs(path) and context is not None:
-      path = os.path.join(context.currentSourcePath, path)
-    path = os.path.normpath(path)
-
-    self.old_scripts_.discard(path)
-    self.db.add_or_update_script(path)
-
+        self.old_scripts_.discard(path)
+        self.db.add_or_update_script(path)

--- a/ambuild2/frontend/v2_1/base/context.py
+++ b/ambuild2/frontend/v2_1/base/context.py
@@ -30,179 +30,185 @@ from ambuild2.frontend.version import Version
 # scripts change.
 
 class BaseContext(object):
-  def __init__(self, generator, parent, vars, script):
-    super(BaseContext, self).__init__()
-    self.generator_ = generator
-    self.parent_ = parent
-    self.script_ = script
+    def __init__(self, generator, parent, vars, script):
+        super(BaseContext, self).__init__()
+        self.generator_ = generator
+        self.parent_ = parent
+        self.script_ = script
 
-    if parent:
-      self.vars_ = copy.copy(parent.vars_)
-    else:
-      self.vars_ = {}
+        if parent:
+            self.vars_ = copy.copy(parent.vars_)
+        else:
+            self.vars_ = {}
 
-    # Merge.
-    for key in vars:
-      self.vars_[key] = vars[key]
-    self.vars_['builder'] = self
+        # Merge.
+        for key in vars:
+            self.vars_[key] = vars[key]
+        self.vars_['builder'] = self
 
-  @property
-  def parent(self):
-    return self.parent_
+    @property
+    def parent(self):
+        return self.parent_
 
-  # Root source folder.
-  @property
-  def sourcePath(self):
-    return self.generator_.sourcePath
+    # Root source folder.
+    @property
+    def sourcePath(self):
+        return self.generator_.sourcePath
 
-  @property
-  def options(self):
-    return self.generator_.options
+    @property
+    def options(self):
+        return self.generator_.options
 
-  @property
-  def target(self):
-    return self.generator_.target
+    @property
+    def target(self):
+        return self.generator_.target
 
-  @property
-  def host(self):
-    return self.generator_.host
+    @property
+    def host(self):
+        return self.generator_.host
 
-  @property
-  def originalCwd(self):
-    return self.generator_.originalCwd
+    @property
+    def originalCwd(self):
+        return self.generator_.originalCwd
 
-  @property
-  def backend(self):
-    return self.generator_.backend
+    @property
+    def backend(self):
+        return self.generator_.backend
 
-  @property
-  def buildPath(self):
-    return self.generator_.buildPath
+    @property
+    def buildPath(self):
+        return self.generator_.buildPath
 
-  @property
-  def apiVersion(self):
-    return Version('2.1.1')
+    @property
+    def apiVersion(self):
+        return Version('2.1.1')
 
-  def Import(self, path, vars={}):
-    return self.generator_.importScript(self, path, vars)
+    def Import(self, path, vars = {}):
+        return self.generator_.importScript(self, path, vars)
 
-  def Eval(self, path, vars={}):
-    return self.generator_.evalScript(self, path, vars)
+    def Eval(self, path, vars = {}):
+        return self.generator_.evalScript(self, path, vars)
 
-  def AddConfigureFile(self, path):
-    return self.generator_.addConfigureFile(self, path)
+    def AddConfigureFile(self, path):
+        return self.generator_.addConfigureFile(self, path)
 
 # Access to input-oriented API.
 class EmptyContext(BaseContext):
-  def __init__(self, generator, parent, vars, script):
-    super(EmptyContext, self).__init__(generator, parent, vars, script)
+    def __init__(self, generator, parent, vars, script):
+        super(EmptyContext, self).__init__(generator, parent, vars, script)
 
 # Access to input- and output-oriented API.
 class BuildContext(BaseContext):
-  # This nonce is an input flag to AddCommand.
-  ALWAYS_DIRTY = object()
+    # This nonce is an input flag to AddCommand.
+    ALWAYS_DIRTY = object()
 
-  # Provide an accessor so users don't have to import the v2_1 namespace.
-  tools = tools
+    # Provide an accessor so users don't have to import the v2_1 namespace.
+    tools = tools
 
-  def __init__(self, generator, parent, vars, script, sourceFolder, buildFolder):
-    super(BuildContext, self).__init__(generator, parent, vars, script)
-    self.localFolder_ = None
-    self.cxx_ = None
+    def __init__(self, generator, parent, vars, script, sourceFolder, buildFolder):
+        super(BuildContext, self).__init__(generator, parent, vars, script)
+        self.localFolder_ = None
+        self.cxx_ = None
 
-    if parent and parent.cxx_:
-      self.cxx_ = parent.cxx_.clone()
+        if parent and parent.cxx_:
+            self.cxx_ = parent.cxx_.clone()
 
-    self.sourceFolder = sourceFolder
-    self.buildFolder = buildFolder
-    self.currentSourcePath = os.path.join(generator.sourcePath, sourceFolder)
-    self.currentSourceFolder = sourceFolder
-    self.buildFolder = buildFolder
+        self.sourceFolder = sourceFolder
+        self.buildFolder = buildFolder
+        self.currentSourcePath = os.path.join(generator.sourcePath, sourceFolder)
+        self.currentSourceFolder = sourceFolder
+        self.buildFolder = buildFolder
 
-    # Make sure everything is normalized.
-    self.currentSourcePath = os.path.normpath(self.currentSourcePath)
-    if self.currentSourceFolder:
-      self.currentSourceFolder = os.path.normpath(self.currentSourceFolder)
-    if self.buildFolder:
-      self.buildFolder = os.path.normpath(self.buildFolder)
+        # Make sure everything is normalized.
+        self.currentSourcePath = os.path.normpath(self.currentSourcePath)
+        if self.currentSourceFolder:
+            self.currentSourceFolder = os.path.normpath(self.currentSourceFolder)
+        if self.buildFolder:
+            self.buildFolder = os.path.normpath(self.buildFolder)
 
-  def Build(self, path, vars={}):
-    return self.generator_.runBuildScript(self, path, vars)
+    def Build(self, path, vars = {}):
+        return self.generator_.runBuildScript(self, path, vars)
 
-  # Any consumed options will be removed from the given dictionary. Callers
-  # can detect unconsumed options by inspecting the dictionary after.
-  def DetectCxx(self, options = {}):
-    # Only the top-level build script should be detecting compilers.
-    if self.cxx_ is None and self.parent_ is None:
-      self.cxx_ = self.generator_.detectCompilers(options).clone()
-    return self.cxx_
+    # Any consumed options will be removed from the given dictionary. Callers
+    # can detect unconsumed options by inspecting the dictionary after.
+    def DetectCxx(self, options = {}):
+        # Only the top-level build script should be detecting compilers.
+        if self.cxx_ is None and self.parent_ is None:
+            self.cxx_ = self.generator_.detectCompilers(options).clone()
+        return self.cxx_
 
-  @property
-  def cxx(self):
-    return self.cxx_
+    @property
+    def cxx(self):
+        return self.cxx_
 
-  # In build systems with dependency graphs, this can return a node
-  # representing buildFolder. Otherwise, it returns buildFolder.
-  @property
-  def localFolder(self):
-    if self.localFolder_ is None:
-      self.localFolder_ = self.generator_.getLocalFolder(self)
-    return self.localFolder_
+    # In build systems with dependency graphs, this can return a node
+    # representing buildFolder. Otherwise, it returns buildFolder.
+    @property
+    def localFolder(self):
+        if self.localFolder_ is None:
+            self.localFolder_ = self.generator_.getLocalFolder(self)
+        return self.localFolder_
 
-  def AddSource(self, source_path):
-    return self.generator_.addSource(self, source_path)
+    def AddSource(self, source_path):
+        return self.generator_.addSource(self, source_path)
 
-  def AddSymlink(self, source, output_path):
-    return self.generator_.addSymlink(self, source, output_path)
+    def AddSymlink(self, source, output_path):
+        return self.generator_.addSymlink(self, source, output_path)
 
-  def AddFolder(self, folder):
-    return self.generator_.addFolder(self, folder)
+    def AddFolder(self, folder):
+        return self.generator_.addFolder(self, folder)
 
-  def AddCopy(self, source, output_path):
-    return self.generator_.addCopy(self, source, output_path)
+    def AddCopy(self, source, output_path):
+        return self.generator_.addCopy(self, source, output_path)
 
-  def AddCommand(self, inputs, argv, outputs, folder=-1, dep_type=None, weak_inputs=[],
-                 shared_outputs=[], env_data=None):
-    return self.generator_.addShellCommand(
-      self,
-      inputs,
-      argv,
-      outputs,
-      folder = folder,
-      dep_type = dep_type,
-      weak_inputs = weak_inputs,
-      shared_outputs = shared_outputs,
-      env_data = env_data)
+    def AddCommand(self,
+                   inputs,
+                   argv,
+                   outputs,
+                   folder = -1,
+                   dep_type = None,
+                   weak_inputs = [],
+                   shared_outputs = [],
+                   env_data = None):
+        return self.generator_.addShellCommand(self,
+                                               inputs,
+                                               argv,
+                                               outputs,
+                                               folder = folder,
+                                               dep_type = dep_type,
+                                               weak_inputs = weak_inputs,
+                                               shared_outputs = shared_outputs,
+                                               env_data = env_data)
 
-  def Context(self, name):
-    return self.generator_.Context(name)
+    def Context(self, name):
+        return self.generator_.Context(name)
 
-  def Add(self, taskbuilder):
-    taskbuilder.finish(self)
-    return taskbuilder.generate(self.generator_, self)
+    def Add(self, taskbuilder):
+        taskbuilder.finish(self)
+        return taskbuilder.generate(self.generator_, self)
 
-  def SetBuildFolder(self, folder):
-    # Cannot set the local build folder after it has been generated.
-    if self.localFolder_ is not None:
-      raise Exception("Cannot set top-level build folder twice!")
+    def SetBuildFolder(self, folder):
+        # Cannot set the local build folder after it has been generated.
+        if self.localFolder_ is not None:
+            raise Exception("Cannot set top-level build folder twice!")
 
-    if folder == '/' or folder == '.' or folder == './':
-      self.buildFolder = ''
-    else:
-      self.buildFolder = os.path.normpath(folder)
+        if folder == '/' or folder == '.' or folder == './':
+            self.buildFolder = ''
+        else:
+            self.buildFolder = os.path.normpath(folder)
 
 # Access to everything.
 class TopLevelBuildContext(BuildContext):
-  def __init__(self, generator, parent, vars, script, sourceFolder, buildFolder):
-    super(TopLevelBuildContext, self).__init__(generator, parent, vars, script, sourceFolder, buildFolder)
+    def __init__(self, generator, parent, vars, script, sourceFolder, buildFolder):
+        super(TopLevelBuildContext, self).__init__(generator, parent, vars, script, sourceFolder,
+                                                   buildFolder)
 
 # The root build context.
 class RootBuildContext(BuildContext):
-  def __init__(self, generator, vars, script):
-    super(RootBuildContext, self).__init__(
-      generator = generator,
-      parent = None,
-      vars = vars,
-      script = script,
-      sourceFolder = '',
-      buildFolder = '')
+    def __init__(self, generator, vars, script):
+        super(RootBuildContext, self).__init__(generator = generator,
+                                               parent = None,
+                                               vars = vars,
+                                               script = script,
+                                               sourceFolder = '',
+                                               buildFolder = '')

--- a/ambuild2/frontend/v2_1/base/gen.py
+++ b/ambuild2/frontend/v2_1/base/gen.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -26,167 +26,166 @@ from ambuild2.frontend.v2_1.base.context import \
     RootBuildContext
 
 class ConfigureException(Exception):
-  def __init__(self, *args, **kwargs):
-    super(ConfigureException, self).__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super(ConfigureException, self).__init__(*args, **kwargs)
 
 class BaseGenerator(object):
-  def __init__(self, sourcePath, buildPath, originalCwd, options, args):
-    super(BaseGenerator, self).__init__()
-    self.sourcePath = sourcePath
-    self.buildPath = os.path.normpath(buildPath)
-    self.originalCwd = originalCwd
-    self.options = options
-    self.args = args
-    self.contextStack_ = []
-    self.configure_failed = False
+    def __init__(self, sourcePath, buildPath, originalCwd, options, args):
+        super(BaseGenerator, self).__init__()
+        self.sourcePath = sourcePath
+        self.buildPath = os.path.normpath(buildPath)
+        self.originalCwd = originalCwd
+        self.options = options
+        self.args = args
+        self.contextStack_ = []
+        self.configure_failed = False
 
-    # Detect the target architecture.
-    self.host = System.Host
-    self.target = System.Host
+        # Detect the target architecture.
+        self.host = System.Host
+        self.target = System.Host
 
-    # Override the target architecture.
-    new_arch = getattr(self.options, 'target_arch', None)
-    if new_arch is not None:
-      self.target = System(self.target.platform, util.NormalizeArchString(new_arch))
+        # Override the target architecture.
+        new_arch = getattr(self.options, 'target_arch', None)
+        if new_arch is not None:
+            self.target = System(self.target.platform, util.NormalizeArchString(new_arch))
 
-  def parseBuildScripts(self):
-    root = os.path.join(self.sourcePath, 'AMBuildScript')
-    self.addConfigureFile(None, root)
+    def parseBuildScripts(self):
+        root = os.path.join(self.sourcePath, 'AMBuildScript')
+        self.addConfigureFile(None, root)
 
-    cx = RootBuildContext(self, {}, root)
-    self.execContext(cx)
+        cx = RootBuildContext(self, {}, root)
+        self.execContext(cx)
 
-  def pushContext(self, cx):
-    self.contextStack_.append(cx)
+    def pushContext(self, cx):
+        self.contextStack_.append(cx)
 
-  def popContext(self):
-    self.contextStack_.pop()
+    def popContext(self):
+        self.contextStack_.pop()
 
-  def importScript(self, context, path, vars={}):
-    if not isinstance(path, util.StringType()):
-      for item in path:
-        self.importScriptImpl(context, item, vars)
-      return None
-    return self.importScriptImpl(context, path, vars)
+    def importScript(self, context, path, vars = {}):
+        if not isinstance(path, util.StringType()):
+            for item in path:
+                self.importScriptImpl(context, item, vars)
+            return None
+        return self.importScriptImpl(context, path, vars)
 
-  def evalScript(self, context, path, vars={}):
-    obj = self.importScriptImpl(context, path, vars)
-    return getattr(obj, 'rvalue', None)
+    def evalScript(self, context, path, vars = {}):
+        obj = self.importScriptImpl(context, path, vars)
+        return getattr(obj, 'rvalue', None)
 
-  def runBuildScript(self, context, path, vars={}):
-    if not isinstance(path, util.StringType()):
-      for item in path:
-        self.runBuildScriptImpl(context, item, vars)
-      return None
-    return self.runBuildScriptImpl(context, path, vars)
+    def runBuildScript(self, context, path, vars = {}):
+        if not isinstance(path, util.StringType()):
+            for item in path:
+                self.runBuildScriptImpl(context, item, vars)
+            return None
+        return self.runBuildScriptImpl(context, path, vars)
 
-  def importScriptImpl(self, parent, path, vars):
-    assert isinstance(path, util.StringType())
+    def importScriptImpl(self, parent, path, vars):
+        assert isinstance(path, util.StringType())
 
-    sourceFolder, _, scriptFile = self.computeScriptPaths(parent, path)
+        sourceFolder, _, scriptFile = self.computeScriptPaths(parent, path)
 
-    # Get the absolute script path.
-    scriptPath = os.path.join(self.sourcePath, scriptFile)
-    self.addConfigureFile(parent, scriptPath)
+        # Get the absolute script path.
+        scriptPath = os.path.join(self.sourcePath, scriptFile)
+        self.addConfigureFile(parent, scriptPath)
 
-    # Make the new context.
-    cx = EmptyContext(self, parent, vars, scriptPath)
-    scriptGlobals = self.execContext(cx)
+        # Make the new context.
+        cx = EmptyContext(self, parent, vars, scriptPath)
+        scriptGlobals = self.execContext(cx)
 
-    # Only return variables that changed.
-    obj = util.Expando()
-    for key in scriptGlobals:
-      if (not key in cx.vars_) or (scriptGlobals[key] is not cx.vars_[key]):
-        setattr(obj, key, scriptGlobals[key])
-    return obj
+        # Only return variables that changed.
+        obj = util.Expando()
+        for key in scriptGlobals:
+            if (not key in cx.vars_) or (scriptGlobals[key] is not cx.vars_[key]):
+                setattr(obj, key, scriptGlobals[key])
+        return obj
 
-  def runBuildScriptImpl(self, parent, path, vars):
-    assert isinstance(path, util.StringType())
+    def runBuildScriptImpl(self, parent, path, vars):
+        assert isinstance(path, util.StringType())
 
-    if parent is not self.contextStack_[-1]:
-      raise Exception('Can only create child build contexts of the currently active context')
+        if parent is not self.contextStack_[-1]:
+            raise Exception('Can only create child build contexts of the currently active context')
 
-    sourceFolder, buildFolder, scriptFile = self.computeScriptPaths(parent, path)
+        sourceFolder, buildFolder, scriptFile = self.computeScriptPaths(parent, path)
 
-    # Get the absolute script path.
-    scriptPath = os.path.join(self.sourcePath, scriptFile)
-    self.addConfigureFile(parent, scriptPath)
+        # Get the absolute script path.
+        scriptPath = os.path.join(self.sourcePath, scriptFile)
+        self.addConfigureFile(parent, scriptPath)
 
-    # Make the new context. We allow top-level contexts in the root build
-    # and otherwise for absolute paths.
-    if isinstance(parent, RootBuildContext) or \
-       (isinstance(parent, TopLevelBuildContext) and path.startswith('/')):
-      constructor = TopLevelBuildContext
-    else:
-      if not paths.IsSubPath(sourceFolder, parent.sourceFolder): 
-        raise Exception("Nested build contexts must be within the same folder structure")
-      constructor = BuildContext
+        # Make the new context. We allow top-level contexts in the root build
+        # and otherwise for absolute paths.
+        if isinstance(parent, RootBuildContext) or \
+           (isinstance(parent, TopLevelBuildContext) and path.startswith('/')):
+            constructor = TopLevelBuildContext
+        else:
+            if not paths.IsSubPath(sourceFolder, parent.sourceFolder):
+                raise Exception("Nested build contexts must be within the same folder structure")
+            constructor = BuildContext
 
-    cx = constructor(
-      generator = self,
-      parent = parent,
-      vars = vars,
-      script = scriptPath,
-      sourceFolder = sourceFolder,
-      buildFolder = buildFolder)
+        cx = constructor(generator = self,
+                         parent = parent,
+                         vars = vars,
+                         script = scriptPath,
+                         sourceFolder = sourceFolder,
+                         buildFolder = buildFolder)
 
-    scriptGlobals = self.execContext(cx)
-    return scriptGlobals.get('rvalue', None)
+        scriptGlobals = self.execContext(cx)
+        return scriptGlobals.get('rvalue', None)
 
-  def execContext(self, context):
-    code = self.compileScript(context.script_)
+    def execContext(self, context):
+        code = self.compileScript(context.script_)
 
-    # Copy vars so changes don't get inherited.
-    scriptGlobals = copy.copy(context.vars_)
+        # Copy vars so changes don't get inherited.
+        scriptGlobals = copy.copy(context.vars_)
 
-    self.pushContext(context)
-    try:
-      exec(code, scriptGlobals)
-    except:
-      self.popContext()
-      raise
-    self.popContext()
+        self.pushContext(context)
+        try:
+            exec(code, scriptGlobals)
+        except:
+            self.popContext()
+            raise
+        self.popContext()
 
-    return scriptGlobals
+        return scriptGlobals
 
-  def compileScript(self, path):
-    with open(path) as fp:
-      chars = fp.read()
+    def compileScript(self, path):
+        with open(path) as fp:
+            chars = fp.read()
 
-      # Python 2.6 can't compile() with Windows line endings?!?!!?
-      chars = chars.replace('\r\n', '\n')
-      chars = chars.replace('\r', '\n')
+            # Python 2.6 can't compile() with Windows line endings?!?!!?
+            chars = chars.replace('\r\n', '\n')
+            chars = chars.replace('\r', '\n')
 
-      return compile(chars, path, 'exec')
+            return compile(chars, path, 'exec')
 
-  def computeScriptPaths(self, parent, target):
-    # By default, all generated files for a build script are placed in a path
-    # matching its layout in the source tree.
-    path, name = os.path.split(target)
-    if parent:
-      if path.startswith('/'):
-        # Navigate relative to the source root.
-        path = path.lstrip('/')
+    def computeScriptPaths(self, parent, target):
+        # By default, all generated files for a build script are placed in a path
+        # matching its layout in the source tree.
+        path, name = os.path.split(target)
+        if parent:
+            if path.startswith('/'):
+                # Navigate relative to the source root.
+                path = path.lstrip('/')
 
-        base_folder = ''
-        build_base = ''
-      else:
-        # Navigate based on our relative folder.
-        base_folder = parent.currentSourceFolder
-        build_base = parent.buildFolder
+                base_folder = ''
+                build_base = ''
+            else:
+                # Navigate based on our relative folder.
+                base_folder = parent.currentSourceFolder
+                build_base = parent.buildFolder
 
-      sourceFolder = os.path.join(base_folder, path)
-      buildFolder = os.path.join(build_base, path)
-    else:
-      sourceFolder = ''
-      buildFolder = ''
+            sourceFolder = os.path.join(base_folder, path)
+            buildFolder = os.path.join(build_base, path)
+        else:
+            sourceFolder = ''
+            buildFolder = ''
 
-    return sourceFolder, buildFolder, os.path.join(sourceFolder, name)
+        return sourceFolder, buildFolder, os.path.join(sourceFolder, name)
 
-  def generateBuildFiles(self):
-    build_py = os.path.join(self.buildPath, 'build.py')
-    with open(build_py, 'w') as fp:
-      fp.write("""
+    def generateBuildFiles(self):
+        build_py = os.path.join(self.buildPath, 'build.py')
+        with open(build_py, 'w') as fp:
+            fp.write("""
 #!{exe}
 # vim set: ts=8 sts=2 sw=2 tw=99 et:
 import sys
@@ -194,41 +193,49 @@ from ambuild2 import run
 
 if not run.CompatBuild(r"{build}"):
   sys.exit(1)
-""".format(exe=sys.executable, build=self.buildPath))
+""".format(exe = sys.executable, build = self.buildPath))
 
-    with open(os.path.join(self.buildPath, 'Makefile'), 'w') as fp:
-      fp.write("""
+        with open(os.path.join(self.buildPath, 'Makefile'), 'w') as fp:
+            fp.write("""
 all:
 	"{exe}" "{py}"
-""".format(exe=sys.executable, py=build_py))
+""".format(exe = sys.executable, py = build_py))
 
-  def generate(self):
-    self.preGenerate()
-    self.parseBuildScripts()
-    self.postGenerate()
-    if self.options.make_scripts:
-      self.generateBuildFiles()
-    return True
+    def generate(self):
+        self.preGenerate()
+        self.parseBuildScripts()
+        self.postGenerate()
+        if self.options.make_scripts:
+            self.generateBuildFiles()
+        return True
 
-  def getLocalFolder(self, context):
-    return context.buildFolder
+    def getLocalFolder(self, context):
+        return context.buildFolder
 
-  @property
-  def backend(self):
-    raise Exception('Must be implemented!')
+    @property
+    def backend(self):
+        raise Exception('Must be implemented!')
 
-  def addSymlink(self, context, source, output_path):
-    raise Exception('Must be implemented!')
+    def addSymlink(self, context, source, output_path):
+        raise Exception('Must be implemented!')
 
-  def addFolder(self, context, folder):
-    raise Exception('Must be implemented!')
+    def addFolder(self, context, folder):
+        raise Exception('Must be implemented!')
 
-  def addCopy(self, context, source, output_path):
-    raise Exception('Must be implemented!')
+    def addCopy(self, context, source, output_path):
+        raise Exception('Must be implemented!')
 
-  def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[], env_data=None):
-    raise Exception('Must be implemented!')
+    def addShellCommand(self,
+                        context,
+                        inputs,
+                        argv,
+                        outputs,
+                        folder = -1,
+                        dep_type = None,
+                        weak_inputs = [],
+                        shared_outputs = [],
+                        env_data = None):
+        raise Exception('Must be implemented!')
 
-  def addConfigureFile(self, context, path):
-    raise Exception('Must be implemented!')
+    def addConfigureFile(self, context, path):
+        raise Exception('Must be implemented!')

--- a/ambuild2/frontend/v2_1/cpp/__init__.py
+++ b/ambuild2/frontend/v2_1/cpp/__init__.py
@@ -2,8 +2,7 @@ from ambuild2.frontend.v2_1.cpp.compiler import Compiler
 from ambuild2.frontend.v2_1.cpp.builders import Dep
 
 class CppNodes(object):
-  def __init__(self, output, debug_outputs, type):
-    self.binary = output
-    self.debug = debug_outputs
-    self.type = type
-
+    def __init__(self, output, debug_outputs, type):
+        self.binary = output
+        self.debug = debug_outputs
+        self.type = type

--- a/ambuild2/frontend/v2_1/cpp/builders.py
+++ b/ambuild2/frontend/v2_1/cpp/builders.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import subprocess
@@ -20,568 +20,559 @@ from ambuild2 import util
 from ambuild2.frontend import paths
 
 class Dep(object):
-  def __init__(self, text, node):
-    self.text = text
-    self.node = node
+    def __init__(self, text, node):
+        self.text = text
+        self.node = node
 
-  @staticmethod
-  def resolve(cx, builder, item):
-    if type(item) is Dep:
-      # If the dep is a file dependency (no node attached), and has a relative
-      # path, make it absolute so the linker knows where to look.
-      if item.node is None and not os.path.isabs(item.text):
-        return os.path.join(cx.currentSourcePath, item.text)
-      return item.text
+    @staticmethod
+    def resolve(cx, builder, item):
+        if type(item) is Dep:
+            # If the dep is a file dependency (no node attached), and has a relative
+            # path, make it absolute so the linker knows where to look.
+            if item.node is None and not os.path.isabs(item.text):
+                return os.path.join(cx.currentSourcePath, item.text)
+            return item.text
 
-    if hasattr(item, 'path'):
-      if os.path.isabs(item.path):
-        return item.path
+        if hasattr(item, 'path'):
+            if os.path.isabs(item.path):
+                return item.path
 
-      local_path = os.path.join(cx.buildFolder, builder.localFolder)
-      return os.path.relpath(item.path, local_path)
+            local_path = os.path.join(cx.buildFolder, builder.localFolder)
+            return os.path.relpath(item.path, local_path)
 
-    return item
+        return item
 
 class BuilderProxy(object):
-  def __init__(self, builder, compiler, name):
-    self.constructor_ = builder.constructor_
-    self.sources = builder.sources[:]
-    self.custom = builder.custom[:]
-    self.compiler = compiler
-    self.name_ = name
-    self.localFolder = name
+    def __init__(self, builder, compiler, name):
+        self.constructor_ = builder.constructor_
+        self.sources = builder.sources[:]
+        self.custom = builder.custom[:]
+        self.compiler = compiler
+        self.name_ = name
+        self.localFolder = name
 
-  @property
-  def outputFile(self):
-    return self.constructor_.buildName(self.compiler, self.name_)
+    @property
+    def outputFile(self):
+        return self.constructor_.buildName(self.compiler, self.name_)
 
-  @property
-  def type(self):
-    return self.constructor_.type
+    @property
+    def type(self):
+        return self.constructor_.type
 
-  @staticmethod
-  def Dep(text, node=None):
-    return Dep(text, node)
+    @staticmethod
+    def Dep(text, node = None):
+        return Dep(text, node)
 
 class Project(object):
-  def __init__(self, constructor, compiler, name):
-    super(Project, self).__init__()
-    self.constructor_ = constructor
-    self.compiler = compiler
-    self.name = name
-    self.sources = []
-    self.proxies_ = []
-    self.builders_ = []
-    self.custom = []
+    def __init__(self, constructor, compiler, name):
+        super(Project, self).__init__()
+        self.constructor_ = constructor
+        self.compiler = compiler
+        self.name = name
+        self.sources = []
+        self.proxies_ = []
+        self.builders_ = []
+        self.custom = []
 
-  def finish(self, cx):
-    for task in self.proxies_:
-      builder = task.constructor_(task.compiler, task.name_)
-      builder.localFolder = task.localFolder
-      builder.sources = task.sources
-      builder.custom = task.custom
-      builder.finish(cx)
-      self.builders_.append(builder)
+    def finish(self, cx):
+        for task in self.proxies_:
+            builder = task.constructor_(task.compiler, task.name_)
+            builder.localFolder = task.localFolder
+            builder.sources = task.sources
+            builder.custom = task.custom
+            builder.finish(cx)
+            self.builders_.append(builder)
 
-  def generate(self, generator, cx):
-    outputs = []
-    for builder in self.builders_:
-      outputs += [builder.generate(generator, cx)]
-    return outputs
+    def generate(self, generator, cx):
+        outputs = []
+        for builder in self.builders_:
+            outputs += [builder.generate(generator, cx)]
+        return outputs
 
-  def Configure(self, name, tag):
-    compiler = self.compiler.clone()
-    proxy = BuilderProxy(self, compiler, name)
-    self.proxies_.append(proxy)
-    return proxy
+    def Configure(self, name, tag):
+        compiler = self.compiler.clone()
+        proxy = BuilderProxy(self, compiler, name)
+        self.proxies_.append(proxy)
+        return proxy
 
 def NameForObjectFile(file):
-  return re.sub('[^a-zA-Z0-9_]+', '_', os.path.splitext(file)[0])
+    return re.sub('[^a-zA-Z0-9_]+', '_', os.path.splitext(file)[0])
 
 class ObjectFileBase(object):
-  def __init__(self, parent, inputObj, outputFile):
-    super(ObjectFileBase, self).__init__()
-    self.env_data = parent.env_data
-    self.folderNode = parent.localFolderNode
-    self.inputObj = inputObj
-    self.outputFile = outputFile
-    self.sourcedeps = parent.sourcedeps
+    def __init__(self, parent, inputObj, outputFile):
+        super(ObjectFileBase, self).__init__()
+        self.env_data = parent.env_data
+        self.folderNode = parent.localFolderNode
+        self.inputObj = inputObj
+        self.outputFile = outputFile
+        self.sourcedeps = parent.sourcedeps
 
-  @property
-  def type(self):
-    raise Exception("Must be implemented!")
+    @property
+    def type(self):
+        raise Exception("Must be implemented!")
 
 class ObjectFile(ObjectFileBase):
-  def __init__(self, parent, inputObj, outputFile, argv):
-    super(ObjectFile, self).__init__(parent, inputObj, outputFile)
-    self.argv = argv
-    self.behavior = parent.compiler.vendor.behavior
+    def __init__(self, parent, inputObj, outputFile, argv):
+        super(ObjectFile, self).__init__(parent, inputObj, outputFile)
+        self.argv = argv
+        self.behavior = parent.compiler.vendor.behavior
 
-  @property
-  def type(self):
-    return 'object'
+    @property
+    def type(self):
+        return 'object'
 
 class RCFile(ObjectFileBase):
-  def __init__(self, parent, inputObj, preprocFile, outputFile, cl_argv, rc_argv):
-    super(RCFile, self).__init__(parent, inputObj, outputFile)
-    self.preprocFile = preprocFile
-    self.cl_argv = cl_argv
-    self.rc_argv = rc_argv
+    def __init__(self, parent, inputObj, preprocFile, outputFile, cl_argv, rc_argv):
+        super(RCFile, self).__init__(parent, inputObj, outputFile)
+        self.preprocFile = preprocFile
+        self.cl_argv = cl_argv
+        self.rc_argv = rc_argv
 
-  @property
-  def type(self):
-    return 'resource'
+    @property
+    def type(self):
+        return 'resource'
 
 class ObjectArgvBuilder(object):
-  def __init__(self):
-    super(ObjectArgvBuilder, self).__init__()
-    self.outputFolder = None
-    self.outputPath = None
-    self.localFolderNode = None
-    self.vendor = None
-    self.compiler = None
-    self.cc_argv = None
-    self.cxx_argv = None
-    self.objects = []
-    self.resources = []
-    self.used_cxx = False
-    self.sourcedeps = []
-    self.env_data = None
+    def __init__(self):
+        super(ObjectArgvBuilder, self).__init__()
+        self.outputFolder = None
+        self.outputPath = None
+        self.localFolderNode = None
+        self.vendor = None
+        self.compiler = None
+        self.cc_argv = None
+        self.cxx_argv = None
+        self.objects = []
+        self.resources = []
+        self.used_cxx = False
+        self.sourcedeps = []
+        self.env_data = None
 
-  def setOutputs(self, localFolderNode, outputFolder, outputPath):
-    self.outputFolder = outputFolder
-    self.outputPath = outputPath
-    self.localFolderNode = localFolderNode
+    def setOutputs(self, localFolderNode, outputFolder, outputPath):
+        self.outputFolder = outputFolder
+        self.outputPath = outputPath
+        self.localFolderNode = localFolderNode
 
-  def setCompiler(self, compiler, addl_include_dirs, addl_source_deps):
-    self.vendor = compiler.vendor
-    self.compiler = compiler
+    def setCompiler(self, compiler, addl_include_dirs, addl_source_deps):
+        self.vendor = compiler.vendor
+        self.compiler = compiler
 
-    # Set up the C compiler argv.
-    self.cc_argv = compiler.cc_argv[:]
-    self.cc_argv += compiler.cflags
-    if compiler.symbol_files is not None:
-      self.cc_argv += self.vendor.debugInfoArgv
-    self.cc_argv += compiler.c_only_flags
-    self.cc_argv += [self.vendor.definePrefix + define for define in compiler.defines]
-    for include in compiler.includes + addl_include_dirs:
-      self.cc_argv += self.vendor.formatInclude(self.outputPath, include)
+        # Set up the C compiler argv.
+        self.cc_argv = compiler.cc_argv[:]
+        self.cc_argv += compiler.cflags
+        if compiler.symbol_files is not None:
+            self.cc_argv += self.vendor.debugInfoArgv
+        self.cc_argv += compiler.c_only_flags
+        self.cc_argv += [self.vendor.definePrefix + define for define in compiler.defines]
+        for include in compiler.includes + addl_include_dirs:
+            self.cc_argv += self.vendor.formatInclude(self.outputPath, include)
 
-    # Set up the C++ compiler argv.
-    self.cxx_argv = compiler.cxx_argv[:]
-    self.cxx_argv += compiler.cflags
-    if compiler.symbol_files is not None:
-      self.cxx_argv += self.vendor.debugInfoArgv
-    self.cxx_argv += compiler.cxxflags
-    self.cxx_argv += [self.vendor.definePrefix + define for define in compiler.defines]
-    self.cxx_argv += [self.vendor.definePrefix + define for define in compiler.cxxdefines]
-    for include in compiler.includes + compiler.cxxincludes + addl_include_dirs:
-      self.cxx_argv += self.vendor.formatInclude(self.outputPath, include)
+        # Set up the C++ compiler argv.
+        self.cxx_argv = compiler.cxx_argv[:]
+        self.cxx_argv += compiler.cflags
+        if compiler.symbol_files is not None:
+            self.cxx_argv += self.vendor.debugInfoArgv
+        self.cxx_argv += compiler.cxxflags
+        self.cxx_argv += [self.vendor.definePrefix + define for define in compiler.defines]
+        self.cxx_argv += [self.vendor.definePrefix + define for define in compiler.cxxdefines]
+        for include in compiler.includes + compiler.cxxincludes + addl_include_dirs:
+            self.cxx_argv += self.vendor.formatInclude(self.outputPath, include)
 
-    self.env_data = compiler.env_data
+        self.env_data = compiler.env_data
 
-    # Set up source dependencies.
-    self.sourcedeps += compiler.sourcedeps + addl_source_deps
+        # Set up source dependencies.
+        self.sourcedeps += compiler.sourcedeps + addl_source_deps
 
-  def buildItem(self, inputObj, sourceName, sourceFile):
-    sourceNameSansExtension, extension = os.path.splitext(sourceName)
-    encodedName = NameForObjectFile(sourceNameSansExtension)
+    def buildItem(self, inputObj, sourceName, sourceFile):
+        sourceNameSansExtension, extension = os.path.splitext(sourceName)
+        encodedName = NameForObjectFile(sourceNameSansExtension)
 
-    if extension == '.rc':
-      return self.buildRcItem(inputObj, sourceFile, encodedName)
-    return self.buildCxxItem(inputObj, sourceFile, encodedName, extension)
+        if extension == '.rc':
+            return self.buildRcItem(inputObj, sourceFile, encodedName)
+        return self.buildCxxItem(inputObj, sourceFile, encodedName, extension)
 
-  def buildCxxItem(self, inputObj, sourceFile, encodedName, extension):
-    if extension == '.c':
-      argv = self.cc_argv[:]
-    else:
-      argv = self.cxx_argv[:]
-      self.used_cxx = True
-    objectFile = encodedName + self.vendor.objSuffix
+    def buildCxxItem(self, inputObj, sourceFile, encodedName, extension):
+        if extension == '.c':
+            argv = self.cc_argv[:]
+        else:
+            argv = self.cxx_argv[:]
+            self.used_cxx = True
+        objectFile = encodedName + self.vendor.objSuffix
 
-    argv += self.vendor.objectArgs(sourceFile, objectFile)
-    return ObjectFile(self, inputObj, objectFile, argv)
+        argv += self.vendor.objectArgs(sourceFile, objectFile)
+        return ObjectFile(self, inputObj, objectFile, argv)
 
-  def buildRcItem(self, inputObj, sourceFile, encodedName):
-    objectFile = encodedName + '.res'
+    def buildRcItem(self, inputObj, sourceFile, encodedName):
+        objectFile = encodedName + '.res'
 
-    defines = self.compiler.defines + self.compiler.cxxdefines + self.compiler.rcdefines
-    cl_argv = self.cc_argv[:]
-    cl_argv += [self.vendor.definePrefix + define for define in defines]
-    for include in (self.compiler.includes + self.compiler.cxxincludes):
-      cl_argv += self.vendor.formatInclude(objectFile, include)
-    cl_argv += self.vendor.preprocessArgv(sourceFile, encodedName + '.i')
+        defines = self.compiler.defines + self.compiler.cxxdefines + self.compiler.rcdefines
+        cl_argv = self.cc_argv[:]
+        cl_argv += [self.vendor.definePrefix + define for define in defines]
+        for include in (self.compiler.includes + self.compiler.cxxincludes):
+            cl_argv += self.vendor.formatInclude(objectFile, include)
+        cl_argv += self.vendor.preprocessArgv(sourceFile, encodedName + '.i')
 
-    rc_argv = ['rc', '/nologo']
-    for define in defines:
-      rc_argv += ['/d', define]
-    for include in (self.compiler.includes + self.compiler.cxxincludes):
-      rc_argv += ['/i', self.vendor.IncludePath(objectFile, include)]
-    rc_argv += ['/fo' + objectFile, sourceFile]
+        rc_argv = ['rc', '/nologo']
+        for define in defines:
+            rc_argv += ['/d', define]
+        for include in (self.compiler.includes + self.compiler.cxxincludes):
+            rc_argv += ['/i', self.vendor.IncludePath(objectFile, include)]
+        rc_argv += ['/fo' + objectFile, sourceFile]
 
-    return RCFile(self,
-                  inputObj, encodedName + '.i', objectFile,
-                  cl_argv, rc_argv)
+        return RCFile(self, inputObj, encodedName + '.i', objectFile, cl_argv, rc_argv)
 
 def ComputeSourcePath(context, localFolderNode, item):
-  # This is a path into the source tree.
-  if util.IsString(item):
-    if os.path.isabs(item):
-      sourceFile = item
-    else:
-      sourceFile = os.path.join(context.currentSourcePath, item)
-    return os.path.normpath(sourceFile)
+    # This is a path into the source tree.
+    if util.IsString(item):
+        if os.path.isabs(item):
+            sourceFile = item
+        else:
+            sourceFile = os.path.join(context.currentSourcePath, item)
+        return os.path.normpath(sourceFile)
 
-  # This is a node computed by a previous step. Compute a relative path.
-  return os.path.relpath(item.path, localFolderNode.path)
+    # This is a node computed by a previous step. Compute a relative path.
+    return os.path.relpath(item.path, localFolderNode.path)
 
 class CustomSource(object):
-  def __init__(self, source, weak_deps=[]):
-    super(CustomSource, self).__init__()
-    self.source = source
-    self.weak_deps = weak_deps
+    def __init__(self, source, weak_deps = []):
+        super(CustomSource, self).__init__()
+        self.source = source
+        self.weak_deps = weak_deps
 
 class CustomToolCommand(object):
-  def __init__(self, cx, module, localFolderNode, data):
-    super(CustomToolCommand, self).__init__()
-    self.context = cx
-    self.module_ = module
-    self.localFolderNode = localFolderNode
-    self.data = data
-    self.sources = []
-    self.sourcedeps = []
+    def __init__(self, cx, module, localFolderNode, data):
+        super(CustomToolCommand, self).__init__()
+        self.context = cx
+        self.module_ = module
+        self.localFolderNode = localFolderNode
+        self.data = data
+        self.sources = []
+        self.sourcedeps = []
 
-  @property
-  def compiler(self):
-    return self.module_.compiler
+    @property
+    def compiler(self):
+        return self.module_.compiler
 
-  @staticmethod
-  def NameForObjectFile(path):
-    return NameForObjectFile(path)
+    @staticmethod
+    def NameForObjectFile(path):
+        return NameForObjectFile(path)
 
-  def ComputeSourcePath(self, path):
-    return ComputeSourcePath(self.module_.context, self.localFolderNode, path)
+    def ComputeSourcePath(self, path):
+        return ComputeSourcePath(self.module_.context, self.localFolderNode, path)
 
-  @staticmethod
-  def CustomSource(source, weak_deps = []):
-    return CustomSource(source, weak_deps)
+    @staticmethod
+    def CustomSource(source, weak_deps = []):
+        return CustomSource(source, weak_deps)
 
 class Module(object):
-  def __init__(self, context, compiler, name):
-    super(Module, self).__init__()
-    self.context = context
-    self.compiler = compiler
-    self.name = name
-    self.sources = []
-    self.custom = []
+    def __init__(self, context, compiler, name):
+        super(Module, self).__init__()
+        self.context = context
+        self.compiler = compiler
+        self.name = name
+        self.sources = []
+        self.custom = []
 
 class BinaryBuilder(object):
-  def __init__(self, compiler, name):
-    super(BinaryBuilder, self).__init__()
-    self.compiler = compiler
-    self.sources = []
-    self.custom = []
-    self.name_ = name
-    self.used_cxx_ = False
-    self.linker_ = None
-    self.modules_ = []
-    self.localFolder = name
+    def __init__(self, compiler, name):
+        super(BinaryBuilder, self).__init__()
+        self.compiler = compiler
+        self.sources = []
+        self.custom = []
+        self.name_ = name
+        self.used_cxx_ = False
+        self.linker_ = None
+        self.modules_ = []
+        self.localFolder = name
 
-  @property
-  def outputFile(self):
-    return self.buildName(self.compiler, self.name_)
+    @property
+    def outputFile(self):
+        return self.buildName(self.compiler, self.name_)
 
-  def generate(self, generator, cx):
-    return generator.addCxxTasks(cx, self)
+    def generate(self, generator, cx):
+        return generator.addCxxTasks(cx, self)
 
-  # Make an item that can be passed into linkflags/postlink but has an attached
-  # dependency.
-  def Dep(self, text, node=None):
-    return Dep(text, node)
+    # Make an item that can be passed into linkflags/postlink but has an attached
+    # dependency.
+    def Dep(self, text, node = None):
+        return Dep(text, node)
 
-  # Create a sub-component of the binary.
-  def Module(self, context, name):
-    module = Module(
-      context = context,
-      compiler = self.compiler.clone(),
-      name = name)
-    self.modules_.append(module)
-    return module
+    # Create a sub-component of the binary.
+    def Module(self, context, name):
+        module = Module(context = context, compiler = self.compiler.clone(), name = name)
+        self.modules_.append(module)
+        return module
 
-  # Exposed only for frontends.
-  @property
-  def linker(self):
-    return self.linker_
+    # Exposed only for frontends.
+    @property
+    def linker(self):
+        return self.linker_
 
-  # Compute the build folder.
-  def getBuildFolder(self, builder):
-    return os.path.join(builder.buildFolder, self.localFolder)
+    # Compute the build folder.
+    def getBuildFolder(self, builder):
+        return os.path.join(builder.buildFolder, self.localFolder)
 
-  def linkFlags(self, cx):
-    argv = [Dep.resolve(cx, self, item) for item in self.compiler.linkflags]
-    argv += [Dep.resolve(cx, self, item) for item in self.compiler.postlink]
-    return argv
+    def linkFlags(self, cx):
+        argv = [Dep.resolve(cx, self, item) for item in self.compiler.linkflags]
+        argv += [Dep.resolve(cx, self, item) for item in self.compiler.postlink]
+        return argv
 
-  def buildModules(self, cx):
-    for module in self.modules_:
-      self.buildModule(cx, module)
+    def buildModules(self, cx):
+        for module in self.modules_:
+            self.buildModule(cx, module)
 
-  def buildModule(self, cx, module):
-    localFolder, outputFolder, outputPath = self.computeModuleFolders(cx, module)
-    localFolderNode = cx.AddFolder(localFolder)
+    def buildModule(self, cx, module):
+        localFolder, outputFolder, outputPath = self.computeModuleFolders(cx, module)
+        localFolderNode = cx.AddFolder(localFolder)
 
-    must_include_builddir = False
+        must_include_builddir = False
 
-    # Run custom tools attached to this module.
-    addl_source_deps = []
-    for custom in module.custom:
-      cmd = CustomToolCommand(
-        cx = cx,
-        module = module,
-        localFolderNode = localFolderNode,
-        data = custom)
-      custom.tool.evaluate(cmd)
+        # Run custom tools attached to this module.
+        addl_source_deps = []
+        for custom in module.custom:
+            cmd = CustomToolCommand(cx = cx,
+                                    module = module,
+                                    localFolderNode = localFolderNode,
+                                    data = custom)
+            custom.tool.evaluate(cmd)
 
-      # Integrate any additional outputs.
-      module.sources += cmd.sources
-      if cmd.sourcedeps:
-        addl_source_deps += cmd.sourcedeps
-        must_include_builddir = True
+            # Integrate any additional outputs.
+            module.sources += cmd.sources
+            if cmd.sourcedeps:
+                addl_source_deps += cmd.sourcedeps
+                must_include_builddir = True
 
-    # If custom tools run, they may place new headers in the objdir. For now
-    # we put them implicitly in the include path. We might need to make this
-    # explicit (or the path customizable) later.
-    if must_include_builddir:
-      addl_include_dirs = [outputPath]
-    else:
-      addl_include_dirs = []
+        # If custom tools run, they may place new headers in the objdir. For now
+        # we put them implicitly in the include path. We might need to make this
+        # explicit (or the path customizable) later.
+        if must_include_builddir:
+            addl_include_dirs = [outputPath]
+        else:
+            addl_include_dirs = []
 
-    builder = ObjectArgvBuilder()
-    builder.setOutputs(localFolderNode, outputFolder, outputPath)
-    builder.setCompiler(module.compiler, addl_include_dirs, addl_source_deps)
+        builder = ObjectArgvBuilder()
+        builder.setOutputs(localFolderNode, outputFolder, outputPath)
+        builder.setCompiler(module.compiler, addl_include_dirs, addl_source_deps)
 
-    # Parse all source file entries.
-    for entry in module.sources:
-      if isinstance(entry, CustomSource):
-        item = entry.source
-        extra_weak_deps = entry.weak_deps
-      else:
-        item = entry
-        extra_weak_deps = None
+        # Parse all source file entries.
+        for entry in module.sources:
+            if isinstance(entry, CustomSource):
+                item = entry.source
+                extra_weak_deps = entry.weak_deps
+            else:
+                item = entry
+                extra_weak_deps = None
 
-      sourceFile = ComputeSourcePath(module.context, localFolderNode, item)
+            sourceFile = ComputeSourcePath(module.context, localFolderNode, item)
 
-      # If the item is a string, use the computed source path as the dependent
-      # item. Otherwise, use the raw item, since it's probably an output from
-      # a precursor step.
-      #
-      # For the short-form name, which is used to compute an object file name,
-      # we use the given source string. If the item is a dependent step then
-      # use the path to its output.
-      if util.IsString(item):
-        inputObj = sourceFile
-        sourceName = item
-      else:
-        inputObj = item
-        sourceName = sourceFile
+            # If the item is a string, use the computed source path as the dependent
+            # item. Otherwise, use the raw item, since it's probably an output from
+            # a precursor step.
+            #
+            # For the short-form name, which is used to compute an object file name,
+            # we use the given source string. If the item is a dependent step then
+            # use the path to its output.
+            if util.IsString(item):
+                inputObj = sourceFile
+                sourceName = item
+            else:
+                inputObj = item
+                sourceName = sourceFile
 
-      # Build the object we pass to the generator. Include any extra source deps
-      # if the file has extended requirements.
-      obj_item = builder.buildItem(inputObj, sourceName, sourceFile)
-      if extra_weak_deps is not None:
-        obj_item.sourcedeps += extra_weak_deps
+            # Build the object we pass to the generator. Include any extra source deps
+            # if the file has extended requirements.
+            obj_item = builder.buildItem(inputObj, sourceName, sourceFile)
+            if extra_weak_deps is not None:
+                obj_item.sourcedeps += extra_weak_deps
 
-      self.objects.append(obj_item)
+            self.objects.append(obj_item)
 
-    # Propagate the used_cxx bit.
-    if builder.used_cxx:
-      self.used_cxx_ = True
+        # Propagate the used_cxx bit.
+        if builder.used_cxx:
+            self.used_cxx_ = True
 
-  def computeModuleFolders(self, cx, module):
-    buildBase = self.getBuildFolder(cx)
-    buildPath = os.path.join(cx.buildPath, buildBase)
+    def computeModuleFolders(self, cx, module):
+        buildBase = self.getBuildFolder(cx)
+        buildPath = os.path.join(cx.buildPath, buildBase)
 
-    if module.context.sourceFolder == '' and cx.sourceFolder == '':
-      # Special degenerate case that fails os.path.relpath().
-      subfolder = ''
-    elif paths.IsSubPath(module.context.sourceFolder, cx.sourceFolder):
-      # If this module is a subpath of the original context, we use the difference.
-      subfolder = os.path.relpath(module.context.sourceFolder, cx.sourceFolder)
-      if subfolder == '.':
-        subfolder = ''
-    else:
-      # Otherwise... do our best approximation and use a replica of the source
-      # folder path. This is not ideal since we could have a collision, if for
-      # example we compile:
-      #   toplevel/module1/crab.cc -> toplevel/toplevel.so/module1/crab.o
-      #   module1/crab.cc          -> toplevel/toplevel.so/module1/crab.o
-      #
-      # This is bad organization on the project's part, so hopefully we don't
-      # have to make a workaround for it.
-      subfolder = module.context.sourceFolder
+        if module.context.sourceFolder == '' and cx.sourceFolder == '':
+            # Special degenerate case that fails os.path.relpath().
+            subfolder = ''
+        elif paths.IsSubPath(module.context.sourceFolder, cx.sourceFolder):
+            # If this module is a subpath of the original context, we use the difference.
+            subfolder = os.path.relpath(module.context.sourceFolder, cx.sourceFolder)
+            if subfolder == '.':
+                subfolder = ''
+        else:
+            # Otherwise... do our best approximation and use a replica of the source
+            # folder path. This is not ideal since we could have a collision, if for
+            # example we compile:
+            #   toplevel/module1/crab.cc -> toplevel/toplevel.so/module1/crab.o
+            #   module1/crab.cc          -> toplevel/toplevel.so/module1/crab.o
+            #
+            # This is bad organization on the project's part, so hopefully we don't
+            # have to make a workaround for it.
+            subfolder = module.context.sourceFolder
 
-    # Local is relative to the context of the module. buildFolder is relative
-    # to the build root.
-    localFolder = os.path.normpath(os.path.join(self.localFolder, subfolder))
-    buildFolder = os.path.normpath(os.path.join(buildBase, subfolder))
-    buildPath = os.path.normpath(os.path.join(buildPath, subfolder))
-    return localFolder, buildFolder, buildPath
+        # Local is relative to the context of the module. buildFolder is relative
+        # to the build root.
+        localFolder = os.path.normpath(os.path.join(self.localFolder, subfolder))
+        buildFolder = os.path.normpath(os.path.join(buildBase, subfolder))
+        buildPath = os.path.normpath(os.path.join(buildPath, subfolder))
+        return localFolder, buildFolder, buildPath
 
-  def finish(self, cx):
-    # Wrap sources into an initial module.
-    root = Module(cx, self.compiler, 'root')
-    root.sources = self.sources
-    root.custom = self.custom
-    self.modules_.insert(0, root)
+    def finish(self, cx):
+        # Wrap sources into an initial module.
+        root = Module(cx, self.compiler, 'root')
+        root.sources = self.sources
+        root.custom = self.custom
+        self.modules_.insert(0, root)
 
-    # Prep shared outputs.
-    self.shared_cc_outputs = []
-    if self.compiler.symbol_files and self.compiler.family == 'msvc':
-      self.shared_cc_outputs += [self.compiler.vendor.shared_pdb_name]
+        # Prep shared outputs.
+        self.shared_cc_outputs = []
+        if self.compiler.symbol_files and self.compiler.family == 'msvc':
+            self.shared_cc_outputs += [self.compiler.vendor.shared_pdb_name]
 
-    # Prep outputs.
-    self.objects = []
+        # Prep outputs.
+        self.objects = []
 
-    # Compute source file argvs.
-    self.buildModules(cx)
+        # Compute source file argvs.
+        self.buildModules(cx)
 
-    if self.used_cxx_:
-      self.linker_argv_ = self.compiler.cxx_argv
-    else:
-      self.linker_argv_ = self.compiler.cc_argv
-    self.linker_ = self.compiler.vendor
+        if self.used_cxx_:
+            self.linker_argv_ = self.compiler.cxx_argv
+        else:
+            self.linker_argv_ = self.compiler.cc_argv
+        self.linker_ = self.compiler.vendor
 
-    # Translate object file paths relative to the link build context. This
-    # should never result in ../ appearing in the object path.
-    files = []
-    localBuildFolder = self.getBuildFolder(cx)
-    for obj in self.objects:
-      objPath = os.path.join(obj.folderNode.path, obj.outputFile)
-      files.append(os.path.relpath(objPath, localBuildFolder))
+        # Translate object file paths relative to the link build context. This
+        # should never result in ../ appearing in the object path.
+        files = []
+        localBuildFolder = self.getBuildFolder(cx)
+        for obj in self.objects:
+            objPath = os.path.join(obj.folderNode.path, obj.outputFile)
+            files.append(os.path.relpath(objPath, localBuildFolder))
 
-    self.argv = self.generateBinary(cx, files)
-    self.linker_outputs = [self.outputFile]
-    self.debug_entry = None
+        self.argv = self.generateBinary(cx, files)
+        self.linker_outputs = [self.outputFile]
+        self.debug_entry = None
 
-    if self.linker_.behavior == 'msvc':
-      if isinstance(self, Library):
-        # In theory, .dlls should have exports, so MSVC will generate these
-        # files. If this turns out not to be true, we may have to get fancier.
-        self.linker_outputs += [self.name_ + '.lib']
-        self.linker_outputs += [self.name_ + '.exp']
+        if self.linker_.behavior == 'msvc':
+            if isinstance(self, Library):
+                # In theory, .dlls should have exports, so MSVC will generate these
+                # files. If this turns out not to be true, we may have to get fancier.
+                self.linker_outputs += [self.name_ + '.lib']
+                self.linker_outputs += [self.name_ + '.exp']
 
-    if self.linker_.like('emscripten'):
-      if isinstance(self, Program):
-        # This might not be correct if the user is actually still using asm.js,
-        # we would need to look for `-s WASM=0` in the linker args to check.
-        self.linker_outputs += [self.name_ + '.wasm']
+        if self.linker_.like('emscripten'):
+            if isinstance(self, Program):
+                # This might not be correct if the user is actually still using asm.js,
+                # we would need to look for `-s WASM=0` in the linker args to check.
+                self.linker_outputs += [self.name_ + '.wasm']
 
-    if self.compiler.symbol_files == 'separate':
-      self.perform_symbol_steps(cx)
+        if self.compiler.symbol_files == 'separate':
+            self.perform_symbol_steps(cx)
 
-  def perform_symbol_steps(self, cx):
-    if self.linker_.family == 'msvc':
-      # Note, pdb is last since we read the pdb as outputs[-1].
-      self.linker_outputs += [self.name_ + '.pdb']
-    elif cx.target.platform == 'mac':
-      bundle_folder = os.path.join(self.localFolder, self.outputFile + '.dSYM')
-      bundle_entry = cx.AddFolder(bundle_folder)
-      bundle_layout = [
-        'Contents',
-        'Contents/Resources',
-        'Contents/Resources/DWARF',
-      ]
-      for folder in bundle_layout:
-        cx.AddFolder(os.path.join(bundle_folder, folder))
-      self.linker_outputs += [
-        self.outputFile + '.dSYM/Contents/Info.plist',
-        self.outputFile + '.dSYM/Contents/Resources/DWARF/' + self.outputFile
-      ]
-      self.debug_entry = bundle_entry
-      self.argv = ['ambuild_dsymutil_wrapper.sh', self.outputFile] + self.argv
-    elif cx.target.platform == 'linux':
-      self.linker_outputs += [
-        self.outputFile + '.dbg'
-      ]
-      self.argv = ['ambuild_objcopy_wrapper.sh', self.outputFile] + self.argv
+    def perform_symbol_steps(self, cx):
+        if self.linker_.family == 'msvc':
+            # Note, pdb is last since we read the pdb as outputs[-1].
+            self.linker_outputs += [self.name_ + '.pdb']
+        elif cx.target.platform == 'mac':
+            bundle_folder = os.path.join(self.localFolder, self.outputFile + '.dSYM')
+            bundle_entry = cx.AddFolder(bundle_folder)
+            bundle_layout = [
+                'Contents',
+                'Contents/Resources',
+                'Contents/Resources/DWARF',
+            ]
+            for folder in bundle_layout:
+                cx.AddFolder(os.path.join(bundle_folder, folder))
+            self.linker_outputs += [
+                self.outputFile + '.dSYM/Contents/Info.plist',
+                self.outputFile + '.dSYM/Contents/Resources/DWARF/' + self.outputFile
+            ]
+            self.debug_entry = bundle_entry
+            self.argv = ['ambuild_dsymutil_wrapper.sh', self.outputFile] + self.argv
+        elif cx.target.platform == 'linux':
+            self.linker_outputs += [self.outputFile + '.dbg']
+            self.argv = ['ambuild_objcopy_wrapper.sh', self.outputFile] + self.argv
 
-  def link(self, context, folder, inputs):
-    # The existence of .ilk files on Windows does not seem reliable, so we
-    # treat it as "shared" which does not participate in the DAG (yet).
-    shared_outputs = []
-    if self.linker_.behavior == 'msvc':
-      if not isinstance(self, StaticLibrary) and '/INCREMENTAL:NO' not in self.argv:
-        shared_outputs += [self.name_ + '.ilk']
+    def link(self, context, folder, inputs):
+        # The existence of .ilk files on Windows does not seem reliable, so we
+        # treat it as "shared" which does not participate in the DAG (yet).
+        shared_outputs = []
+        if self.linker_.behavior == 'msvc':
+            if not isinstance(self, StaticLibrary) and '/INCREMENTAL:NO' not in self.argv:
+                shared_outputs += [self.name_ + '.ilk']
 
-    ignore, outputs = context.AddCommand(
-      inputs = inputs,
-      argv = self.argv,
-      outputs = self.linker_outputs,
-      folder = folder,
-      weak_inputs = self.compiler.weaklinkdeps,
-      shared_outputs = shared_outputs,
-      env_data = self.compiler.env_data)
-    if not self.debug_entry and self.compiler.symbol_files:
-      if self.linker_.behavior != 'msvc' and self.compiler.symbol_files == 'bundled':
-        self.debug_entry = outputs[0]
-      else:
-        self.debug_entry = outputs[-1]
-    return outputs[0], self.debug_entry
+        ignore, outputs = context.AddCommand(inputs = inputs,
+                                             argv = self.argv,
+                                             outputs = self.linker_outputs,
+                                             folder = folder,
+                                             weak_inputs = self.compiler.weaklinkdeps,
+                                             shared_outputs = shared_outputs,
+                                             env_data = self.compiler.env_data)
+        if not self.debug_entry and self.compiler.symbol_files:
+            if self.linker_.behavior != 'msvc' and self.compiler.symbol_files == 'bundled':
+                self.debug_entry = outputs[0]
+            else:
+                self.debug_entry = outputs[-1]
+        return outputs[0], self.debug_entry
 
 class Program(BinaryBuilder):
-  def __init__(self, compiler, name):
-    super(Program, self).__init__(compiler, name)
+    def __init__(self, compiler, name):
+        super(Program, self).__init__(compiler, name)
 
-  @staticmethod
-  def buildName(compiler, name):
-    return compiler.vendor.nameForExecutable(name)
+    @staticmethod
+    def buildName(compiler, name):
+        return compiler.vendor.nameForExecutable(name)
 
-  @property
-  def type(self):
-    return 'program'
+    @property
+    def type(self):
+        return 'program'
 
-  def generateBinary(self, cx, files):
-    return self.compiler.vendor.programLinkArgv(
-      cmd_argv = self.linker_argv_,
-      files = files,
-      linkFlags = self.linkFlags(cx),
-      symbolFile = self.name_ if self.compiler.symbol_files else None,
-      outputFile = self.outputFile)
+    def generateBinary(self, cx, files):
+        return self.compiler.vendor.programLinkArgv(
+            cmd_argv = self.linker_argv_,
+            files = files,
+            linkFlags = self.linkFlags(cx),
+            symbolFile = self.name_ if self.compiler.symbol_files else None,
+            outputFile = self.outputFile)
 
 class Library(BinaryBuilder):
-  def __init__(self, compiler, name):
-    super(Library, self).__init__(compiler, name)
+    def __init__(self, compiler, name):
+        super(Library, self).__init__(compiler, name)
 
-  @staticmethod
-  def buildName(compiler, name):
-    return compiler.vendor.nameForSharedLibrary(name)
+    @staticmethod
+    def buildName(compiler, name):
+        return compiler.vendor.nameForSharedLibrary(name)
 
-  @property
-  def type(self):
-    return 'library'
+    @property
+    def type(self):
+        return 'library'
 
-  def generateBinary(self, cx, files):
-    return self.compiler.vendor.libLinkArgv(
-      cmd_argv = self.linker_argv_,
-      files = files,
-      linkFlags = self.linkFlags(cx),
-      symbolFile = self.name_ if self.compiler.symbol_files else None,
-      outputFile = self.outputFile)
+    def generateBinary(self, cx, files):
+        return self.compiler.vendor.libLinkArgv(
+            cmd_argv = self.linker_argv_,
+            files = files,
+            linkFlags = self.linkFlags(cx),
+            symbolFile = self.name_ if self.compiler.symbol_files else None,
+            outputFile = self.outputFile)
 
 class StaticLibrary(BinaryBuilder):
-  def __init__(self, compiler, name):
-    super(StaticLibrary, self).__init__(compiler, name)
+    def __init__(self, compiler, name):
+        super(StaticLibrary, self).__init__(compiler, name)
 
-  @staticmethod
-  def buildName(compiler, name):
-    return compiler.vendor.nameForStaticLibrary(name)
+    @staticmethod
+    def buildName(compiler, name):
+        return compiler.vendor.nameForStaticLibrary(name)
 
-  @property
-  def type(self):
-    return 'static'
+    @property
+    def type(self):
+        return 'static'
 
-  def generateBinary(self, cx, files):
-    return self.linker_.staticLinkArgv(files, self.outputFile)
+    def generateBinary(self, cx, files):
+        return self.linker_.staticLinkArgv(files, self.outputFile)
 
-  def perform_symbol_steps(self, cx):
-    pass
+    def perform_symbol_steps(self, cx):
+        pass

--- a/ambuild2/frontend/v2_1/cpp/compiler.py
+++ b/ambuild2/frontend/v2_1/cpp/compiler.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import copy
@@ -22,182 +22,180 @@ from ambuild2 import util
 
 # Base compiler object.
 class Compiler(object):
-  EnvVars = ['CFLAGS', 'CXXFLAGS', 'CC', 'CXX']
+    EnvVars = ['CFLAGS', 'CXXFLAGS', 'CC', 'CXX']
 
-  attrs_ = [
-    'includes',         # C and C++ include paths
-    'cxxincludes',      # C++-only include paths
-    'cflags',           # C and C++ compiler flags
-    'cxxflags',         # C++-only compiler flags
-    'defines',          # C and C++ #defines
-    'cxxdefines',       # C++-only #defines
+    attrs_ = [
+        'includes',  # C and C++ include paths
+        'cxxincludes',  # C++-only include paths
+        'cflags',  # C and C++ compiler flags
+        'cxxflags',  # C++-only compiler flags
+        'defines',  # C and C++ #defines
+        'cxxdefines',  # C++-only #defines
+        'c_only_flags',  # Flags for C but not C++.
+        'rcdefines',  # Resource Compiler (RC) defines
 
-    'c_only_flags',     # Flags for C but not C++.
+        # Link flags. If any members are not strings, they will be interpreted as
+        # Dep entries created from BinaryBuilder.
+        'linkflags',
 
-    'rcdefines',        # Resource Compiler (RC) defines
+        # An array of objects to link, after all link flags have been specified.
+        # Entries may either be strings containing a path, or Dep entries created
+        # from BinaryBuilder.
+        'postlink',
 
-    # Link flags. If any members are not strings, they will be interpreted as
-    # Dep entries created from BinaryBuilder.
-    'linkflags',
+        # An array of nodes which should be weak dependencies on each source
+        # compilation command.
+        'sourcedeps',
 
-    # An array of objects to link, after all link flags have been specified.
-    # Entries may either be strings containing a path, or Dep entries created
-    # from BinaryBuilder.
-    'postlink',
+        # An array of nodes which should be weak dependencies on each linker
+        # command.
+        'weaklinkdeps',
+    ]
 
-    # An array of nodes which should be weak dependencies on each source
-    # compilation command.
-    'sourcedeps',
+    def __init__(self, vendor, options = None):
+        self.vendor = vendor
+        for attr in self.attrs_:
+            setattr(self, attr, [])
+        if getattr(options, 'symbol_files', False):
+            self.symbol_files = 'separate'
+        else:
+            self.symbol_files = 'bundled'
 
-    # An array of nodes which should be weak dependencies on each linker
-    # command.
-    'weaklinkdeps',
-  ]
+    def inherit(self, other):
+        for attr in self.attrs_:
+            setattr(self, attr, copy.copy(getattr(other, attr)))
 
-  def __init__(self, vendor, options = None):
-    self.vendor = vendor
-    for attr in self.attrs_:
-      setattr(self, attr, [])
-    if getattr(options, 'symbol_files', False):
-      self.symbol_files = 'separate'
-    else:
-      self.symbol_files = 'bundled'
+        self.symbol_files_ = other.symbol_files_
 
-  def inherit(self, other):
-    for attr in self.attrs_:
-      setattr(self, attr, copy.copy(getattr(other, attr)))
+    def clone(self):
+        raise Exception('Must be implemented!')
 
-    self.symbol_files_ = other.symbol_files_
+    # Returns whether this compiler acts like another compiler. Current responses
+    # are:
+    #
+    #    msvc:        msvc
+    #    gcc:         gcc
+    #    clang:       gcc, clang
+    #    apple-clang: gcc, clang, apple-clang
+    #    sun:         sun
+    #
+    def like(self, name):
+        return self.vendor.like(name)
 
-  def clone(self):
-    raise Exception('Must be implemented!')
+    # Returns the meta family the compiler belongs to. The meta family is the
+    # most generic compiler that this compiler aims to emulate.
+    # Responses are one of: msvc, gcc, sun
+    @property
+    def behavior(self):
+        return self.vendor.behavior
 
-  # Returns whether this compiler acts like another compiler. Current responses
-  # are:
-  #
-  #    msvc:        msvc
-  #    gcc:         gcc
-  #    clang:       gcc, clang
-  #    apple-clang: gcc, clang, apple-clang
-  #    sun:         sun
-  #
-  def like(self, name):
-    return self.vendor.like(name)
+    # Returns the family the compiler belongs to.
+    # Responses are one of: msvc, gcc, clang, sun
+    @property
+    def family(self):
+        return self.vendor.family
 
-  # Returns the meta family the compiler belongs to. The meta family is the
-  # most generic compiler that this compiler aims to emulate.
-  # Responses are one of: msvc, gcc, sun
-  @property
-  def behavior(self):
-    return self.vendor.behavior
+    # Returns a version object representing the compiler. The version is
+    # prefixed by the compiler name.
+    @property
+    def version(self):
+        return self.vendor.version
 
-  # Returns the family the compiler belongs to.
-  # Responses are one of: msvc, gcc, clang, sun
-  @property
-  def family(self):
-    return self.vendor.family
+    # Returns how symbol files are generated, either 'bundled' or 'separate'.
+    @property
+    def symbol_files(self):
+        return self.symbol_files_
 
-  # Returns a version object representing the compiler. The version is
-  # prefixed by the compiler name.
-  @property
-  def version(self):
-    return self.vendor.version
+    # Sets how symbol files are generated. Must be 'bundled' or 'separate'.
+    # Default is 'bundled' if the underlying compiler supports it. If the vendor
+    # does not support the requested symbol file type, the value remains
+    # unchanged.
+    @symbol_files.setter
+    def symbol_files(self, value):
+        if value not in ['bundled', 'separate']:
+            raise Exception("Symbol files value must be 'bundled' or 'separate'")
+        self.symbol_files_ = self.vendor.parseDebugInfoType(value)
 
-  # Returns how symbol files are generated, either 'bundled' or 'separate'.
-  @property
-  def symbol_files(self):
-    return self.symbol_files_
+    def Program(self, name):
+        raise Exception('Must be implemented!')
 
-  # Sets how symbol files are generated. Must be 'bundled' or 'separate'.
-  # Default is 'bundled' if the underlying compiler supports it. If the vendor
-  # does not support the requested symbol file type, the value remains
-  # unchanged.
-  @symbol_files.setter
-  def symbol_files(self, value):
-    if value not in ['bundled', 'separate']:
-      raise Exception("Symbol files value must be 'bundled' or 'separate'")
-    self.symbol_files_ = self.vendor.parseDebugInfoType(value)
+    def Library(self, name):
+        raise Exception('Must be implemented!')
 
-  def Program(self, name):
-    raise Exception('Must be implemented!')
+    def StaticLibrary(self, name):
+        raise Exception('Must be implemented!')
 
-  def Library(self, name):
-    raise Exception('Must be implemented!')
+    def ProgramProject(self, name):
+        raise Exception('Must be implemented!')
 
-  def StaticLibrary(self, name):
-    raise Exception('Must be implemented!')
+    def LibraryProject(self, name):
+        raise Exception('Must be implemented!')
 
-  def ProgramProject(self, name):
-    raise Exception('Must be implemented!')
+    def StaticLibraryProject(self, name):
+        raise Exception('Must be implemented!')
 
-  def LibraryProject(self, name):
-    raise Exception('Must be implemented!')
-
-  def StaticLibraryProject(self, name):
-    raise Exception('Must be implemented!')
-
-  @staticmethod
-  def Dep(text, node=None):
-    return builders.Dep(text, node)
+    @staticmethod
+    def Dep(text, node = None):
+        return builders.Dep(text, node)
 
 class CliCompiler(Compiler):
-  def __init__(self, vendor, cc_argv, cxx_argv, options = None, env_data = None):
-    super(CliCompiler, self).__init__(vendor, options)
-    self.cc_argv = cc_argv
-    self.cxx_argv = cxx_argv
-    self.found_pkg_config_ = False
-    self.env_data = env_data
+    def __init__(self, vendor, cc_argv, cxx_argv, options = None, env_data = None):
+        super(CliCompiler, self).__init__(vendor, options)
+        self.cc_argv = cc_argv
+        self.cxx_argv = cxx_argv
+        self.found_pkg_config_ = False
+        self.env_data = env_data
 
-  def clone(self):
-    cc = CliCompiler(self.vendor, self.cc_argv, self.cxx_argv)
-    cc.inherit(self)
-    return cc
+    def clone(self):
+        cc = CliCompiler(self.vendor, self.cc_argv, self.cxx_argv)
+        cc.inherit(self)
+        return cc
 
-  def inherit(self, other):
-    super(CliCompiler, self).inherit(other)
-    self.env_data = other.env_data
+    def inherit(self, other):
+        super(CliCompiler, self).inherit(other)
+        self.env_data = other.env_data
 
-  def Program(self, name):
-    return builders.Program(self.clone(), name)
+    def Program(self, name):
+        return builders.Program(self.clone(), name)
 
-  def Library(self, name):
-    return builders.Library(self.clone(), name)
+    def Library(self, name):
+        return builders.Library(self.clone(), name)
 
-  def StaticLibrary(self, name):
-    return builders.StaticLibrary(self.clone(), name)
+    def StaticLibrary(self, name):
+        return builders.StaticLibrary(self.clone(), name)
 
-  def ProgramProject(self, name):
-    return builders.Project(builders.Program, self.clone(), name)
+    def ProgramProject(self, name):
+        return builders.Project(builders.Program, self.clone(), name)
 
-  def LibraryProject(self, name):
-    return builders.Project(builders.Library, self.clone(), name)
+    def LibraryProject(self, name):
+        return builders.Project(builders.Library, self.clone(), name)
 
-  def StaticLibraryProject(self, name):
-    return builders.Project(builders.StaticLibrary, self.clone(), name)
+    def StaticLibraryProject(self, name):
+        return builders.Project(builders.StaticLibrary, self.clone(), name)
 
-  @staticmethod
-  def run_pkg_config(argv):
-    output = subprocess.check_output(args = ['pkg-config'] + argv)
-    output = util.DecodeConsoleText(sys.stdout, output)
-    return [item.strip() for item in output.strip().split(' ') if item.strip() != '']
+    @staticmethod
+    def run_pkg_config(argv):
+        output = subprocess.check_output(args = ['pkg-config'] + argv)
+        output = util.DecodeConsoleText(sys.stdout, output)
+        return [item.strip() for item in output.strip().split(' ') if item.strip() != '']
 
-  # Helper for running pkg-config.
-  def pkg_config(self, pkg, link = 'dynamic'):
-    if not self.found_pkg_config_:
-      try:
-        self.run_pkg_config(['--version'])
-        self.found_pkg_config = True
-      except:
-        raise Exception('failed to find pkg-config!')
+    # Helper for running pkg-config.
+    def pkg_config(self, pkg, link = 'dynamic'):
+        if not self.found_pkg_config_:
+            try:
+                self.run_pkg_config(['--version'])
+                self.found_pkg_config = True
+            except:
+                raise Exception('failed to find pkg-config!')
 
-    for include in self.run_pkg_config(['--cflags-only-I', pkg]):
-      if include.startswith('-I'):
-        self.includes += [include[2:].strip()]
-      else:
-        self.cflags += [include]
-    self.cflags += self.run_pkg_config(['--cflags-only-other', pkg])
+        for include in self.run_pkg_config(['--cflags-only-I', pkg]):
+            if include.startswith('-I'):
+                self.includes += [include[2:].strip()]
+            else:
+                self.cflags += [include]
+        self.cflags += self.run_pkg_config(['--cflags-only-other', pkg])
 
-    if link == 'dynamic':
-      self.linkflags += self.run_pkg_config(['--libs', pkg])
-    elif link == 'static':
-      self.linkflags += self.run_pkg_config(['--libs', '--static', pkg])
+        if link == 'dynamic':
+            self.linkflags += self.run_pkg_config(['--libs', pkg])
+        elif link == 'static':
+            self.linkflags += self.run_pkg_config(['--libs', '--static', pkg])

--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
@@ -28,14 +28,14 @@ from ambuild2.frontend.v2_1.cpp.msvc import MSVC
 from ambuild2.frontend.v2_1.cpp.sunpro import SunPro
 
 class CommandAndVendor(object):
-  def __init__(self, argv, vendor):
-    self.argv = argv
-    self.vendor = vendor
-    self.arch = None
+    def __init__(self, argv, vendor):
+        self.argv = argv
+        self.vendor = vendor
+        self.arch = None
 
 class CompilerNotFoundException(Exception):
-  def __init__(self, message):
-    super(CompilerNotFoundException, self).__init__(message)
+    def __init__(self, message):
+        super(CompilerNotFoundException, self).__init__(message)
 
 kClangTuple = ('clang', 'clang++', 'gcc')
 kGccTuple = ('gcc', 'g++', 'gcc')
@@ -43,197 +43,202 @@ kIntelTuple = ('icc', 'icc', 'gcc')
 kMsvcTuple = ('cl', 'cl', 'msvc')
 
 def FindToolsInEnv(env, tools):
-  found = {}
-  paths = env.get('PATH', '').split(';')
-  for path in paths:
-    for tool in tools:
-      if tool in found:
-        continue
-      candidate = os.path.join(path, tool)
-      if os.path.exists(candidate):
-        found[tool] = candidate
-    if len(found) == len(tools):
-      return found, True
-  return found, False
+    found = {}
+    paths = env.get('PATH', '').split(';')
+    for path in paths:
+        for tool in tools:
+            if tool in found:
+                continue
+            candidate = os.path.join(path, tool)
+            if os.path.exists(candidate):
+                found[tool] = candidate
+        if len(found) == len(tools):
+            return found, True
+    return found, False
 
 def AutoDetectCxx(target, gen_options, detect_options):
-  locator = CompilerLocator(target, gen_options, detect_options)
-  return locator.detect()
+    locator = CompilerLocator(target, gen_options, detect_options)
+    return locator.detect()
 
 class CompilerLocator(object):
-  def __init__(self, target, gen_options, detect_options):
-    self.target_ = target
-    self.gen_options_ = gen_options
-    self.detect_options_ = detect_options
+    def __init__(self, target, gen_options, detect_options):
+        self.target_ = target
+        self.gen_options_ = gen_options
+        self.detect_options_ = detect_options
 
-  def detect(self):
-    if 'CC' in os.environ or 'CXX' in os.environ:
-      return self.detect_from_env()
+    def detect(self):
+        if 'CC' in os.environ or 'CXX' in os.environ:
+            return self.detect_from_env()
 
-    if util.Platform() == 'windows':
-      compiler = self.detect_msvc()
-      if compiler:
-        return compiler
+        if util.Platform() == 'windows':
+            compiler = self.detect_msvc()
+            if compiler:
+                return compiler
 
-    return self.detect_defaults()
+        return self.detect_defaults()
 
-  def detect_defaults(self):
-    cc, cxx = self.find_default_compiler()
-    return self.create_cli(cc, cxx)
+    def detect_defaults(self):
+        cc, cxx = self.find_default_compiler()
+        return self.create_cli(cc, cxx)
 
-  def detect_from_env(self):
-    if 'CC' not in os.environ:
-      raise Exception('CXX set in environment, but not CC')
-    if 'CXX' not in os.environ:
-      raise Exception('CC set in environment, but not CXX')
+    def detect_from_env(self):
+        if 'CC' not in os.environ:
+            raise Exception('CXX set in environment, but not CC')
+        if 'CXX' not in os.environ:
+            raise Exception('CC set in environment, but not CXX')
 
-    cc = self.find_compiler(os.environ, 'CC', os.environ['CC'])
-    if cc is None:
-      raise CompilerNotFoundException('Unable to find a suitable C compiler')
+        cc = self.find_compiler(os.environ, 'CC', os.environ['CC'])
+        if cc is None:
+            raise CompilerNotFoundException('Unable to find a suitable C compiler')
 
-    cxx = self.find_compiler(os.environ, 'CXX', os.environ['CXX'])
-    if cxx is None:
-      raise CompilerNotFoundException('Unable to find a suitable C++ compiler')
+        cxx = self.find_compiler(os.environ, 'CXX', os.environ['CXX'])
+        if cxx is None:
+            raise CompilerNotFoundException('Unable to find a suitable C++ compiler')
 
-    return self.create_cli(cc, cxx)
+        return self.create_cli(cc, cxx)
 
-  def create_cli(self, cc, cxx):
-    # Ensure that the two compilers have the same vendor.
-    if not cxx.vendor.equals(cc.vendor):
-      message = 'C and C++ compiler are different: CC={0}, CXX={1}'
-      message = message.format(cc.vendor, cxx.vendor)
+    def create_cli(self, cc, cxx):
+        # Ensure that the two compilers have the same vendor.
+        if not cxx.vendor.equals(cc.vendor):
+            message = 'C and C++ compiler are different: CC={0}, CXX={1}'
+            message = message.format(cc.vendor, cxx.vendor)
 
-      util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
-      raise Exception(message)
+            util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
+            raise Exception(message)
 
-    if cxx.arch != cc.arch:
-      message = "C architecture {0} does not match C++ architecture {1}".format(cc.arch, cxx.arch)
-      util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
-      raise Exception(message)
+        if cxx.arch != cc.arch:
+            message = "C architecture {0} does not match C++ architecture {1}".format(
+                cc.arch, cxx.arch)
+            util.con_err(util.ConsoleRed, message, util.ConsoleNormal)
+            raise Exception(message)
 
-    return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, self.gen_options_)
+        return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, self.gen_options_)
 
-  def detect_msvc(self):
-    # If the caller has already configured the environment, we'll expect it to
-    # be always configured for us in the future.
-    _, has_cl = FindToolsInEnv(os.environ, ['cl.exe'])
-    if has_cl:
-      return self.find_default_compiler()
+    def detect_msvc(self):
+        # If the caller has already configured the environment, we'll expect it to
+        # be always configured for us in the future.
+        _, has_cl = FindToolsInEnv(os.environ, ['cl.exe'])
+        if has_cl:
+            return self.find_default_compiler()
 
-    force_msvc = self.detect_options_.pop('force_msvc_version', None)
+        force_msvc = self.detect_options_.pop('force_msvc_version', None)
 
-    installs = msvc_utils.MSVCFinder().find_all()
-    for install in installs:
-      if force_msvc and install.version != force_msvc:
-        continue
-      if self.target_.arch not in install.vcvars:
-        continue
+        installs = msvc_utils.MSVCFinder().find_all()
+        for install in installs:
+            if force_msvc and install.version != force_msvc:
+                continue
+            if self.target_.arch not in install.vcvars:
+                continue
 
-      compiler = self.try_msvc_install(install)
-      if compiler is not None:
-        return compiler
+            compiler = self.try_msvc_install(install)
+            if compiler is not None:
+                return compiler
 
-    raise CompilerNotFoundException('Unable to find a suitable C/C++ compiler')
+        raise CompilerNotFoundException('Unable to find a suitable C/C++ compiler')
 
-  def try_msvc_install(self, install):
-    bat_file = install.vcvars[self.target_.arch]
-    try:
-      env_cmds = msvc_utils.DeduceEnv(bat_file)
-      env = util.BuildEnv(env_cmds)
-    except:
-      util.con_err(util.ConsoleRed, "Could not run or analyze {}".format(bat_file), util.ConsoleNormal)
-      return None
+    def try_msvc_install(self, install):
+        bat_file = install.vcvars[self.target_.arch]
+        try:
+            env_cmds = msvc_utils.DeduceEnv(bat_file)
+            env = util.BuildEnv(env_cmds)
+        except:
+            util.con_err(util.ConsoleRed, "Could not run or analyze {}".format(bat_file),
+                         util.ConsoleNormal)
+            return None
 
-    necessary_tools = ['cl.exe', 'rc.exe', 'lib.exe']
-    tools, _ = FindToolsInEnv(env, necessary_tools)
-    for tool in necessary_tools:
-      if tool not in tools:
-        util.con_err(util.ConsoleRed, "Could not find {} for {}".format(tool, bat_file))
+        necessary_tools = ['cl.exe', 'rc.exe', 'lib.exe']
+        tools, _ = FindToolsInEnv(env, necessary_tools)
+        for tool in necessary_tools:
+            if tool not in tools:
+                util.con_err(util.ConsoleRed, "Could not find {} for {}".format(tool, bat_file))
+                return None
+
+        cc, _ = self.run_compiler(env, 'CC', 'cl', 'msvc', abs_path = tools['cl.exe'])
+        if not cc:
+            return None
+        cxx, _ = self.run_compiler(env, 'CXX', 'cl', 'msvc', abs_path = tools['cl.exe'])
+        if not cxx:
+            return None
+
+        # We use tuples here so the data is hashable without going through Pickle.
+        tool_list = (
+            ('cl', tools['cl.exe']),
+            ('rc', tools['rc.exe']),
+            ('lib', tools['lib.exe']),
+        )
+        env_data = (
+            ('env_cmds', env_cmds),
+            ('tools', tool_list),
+        )
+        return compiler.CliCompiler(cxx.vendor,
+                                    cc.argv,
+                                    cxx.argv,
+                                    options = self.gen_options_,
+                                    env_data = env_data)
+
+    def find_default_compiler(self):
+        candidates = []
+        if util.Platform() == 'windows':
+            candidates.append(kMsvcTuple)
+        candidates.extend([kClangTuple, kGccTuple, kIntelTuple])
+
+        for cc_cmd, cxx_cmd, cc_family in candidates:
+            cc = self.find_compiler(os.environ, 'CC', cc_cmd, cc_family)
+            if cc is None:
+                continue
+            cxx = self.find_compiler(os.environ, 'CXX', cxx_cmd, cc_family)
+            if cxx is not None:
+                return cc, cxx
+
+        raise CompilerNotFoundException('Unable to find a suitable C/C++ compiler')
+
+    def find_compiler(self, env, mode, cmd, cc_family = None):
+        families = []
+        if "EMSDK" in env and cmd[:2] == 'em':
+            families.append('emscripten')
+        if cc_family is not None:
+            families.append(cc_family)
+        else:
+            # On Windows, check for MSVC compatibility before checking GCC.
+            if util.Platform() == 'windows':
+                families.append('msvc')
+            families.append('gcc')
+
+        for family in families:
+            compiler, e = self.run_compiler(env, mode, cmd, family)
+            if compiler is not None:
+                return compiler
+            if isinstance(e, CompilerNotFoundException):
+                # No reason to keep trying the same command.
+                break
+
         return None
 
-    cc, _ = self.run_compiler(env, 'CC', 'cl', 'msvc', abs_path = tools['cl.exe'])
-    if not cc:
-      return None
-    cxx, _ = self.run_compiler(env, 'CXX', 'cl', 'msvc', abs_path = tools['cl.exe'])
-    if not cxx:
-      return None
-
-    # We use tuples here so the data is hashable without going through Pickle.
-    tool_list = (
-      ('cl', tools['cl.exe']),
-      ('rc', tools['rc.exe']),
-      ('lib', tools['lib.exe']),
-    )
-    env_data = (
-      ('env_cmds', env_cmds),
-      ('tools', tool_list),
-    )
-    return compiler.CliCompiler(cxx.vendor, cc.argv, cxx.argv, options = self.gen_options_,
-                                env_data = env_data)
-
-  def find_default_compiler(self):
-    candidates = []
-    if util.Platform() == 'windows':
-      candidates.append(kMsvcTuple)
-    candidates.extend([kClangTuple, kGccTuple, kIntelTuple])
-
-    for cc_cmd, cxx_cmd, cc_family in candidates:
-      cc = self.find_compiler(os.environ, 'CC', cc_cmd, cc_family)
-      if cc is None:
-        continue
-      cxx = self.find_compiler(os.environ, 'CXX', cxx_cmd, cc_family)
-      if cxx is not None:
-        return cc, cxx
-
-    raise CompilerNotFoundException('Unable to find a suitable C/C++ compiler')
-
-  def find_compiler(self, env, mode, cmd, cc_family = None):
-    families = []
-    if "EMSDK" in env and cmd[:2] == 'em':
-      families.append('emscripten')
-    if cc_family is not None:
-      families.append(cc_family)
-    else:
-      # On Windows, check for MSVC compatibility before checking GCC.
-      if util.Platform() == 'windows':
-        families.append('msvc')
-      families.append('gcc')
-
-    for family in families:
-      compiler, e = self.run_compiler(env, mode, cmd, family)
-      if compiler is not None:
-        return compiler
-      if isinstance(e, CompilerNotFoundException):
-        # No reason to keep trying the same command.
-        break
-
-    return None
-
-  def run_compiler(self, env, mode, cmd, assumed_family, abs_path = None):
-    try:
-      return VerifyCompiler(env, mode, cmd, assumed_family, abs_path), None
-    except Exception as e:
-      util.con_out(util.ConsoleHeader, 'Compiler {0} for {1} failed: '.format(cmd, mode),
-                   util.ConsoleRed, str(e), util.ConsoleNormal)
-      return None, e
+    def run_compiler(self, env, mode, cmd, assumed_family, abs_path = None):
+        try:
+            return VerifyCompiler(env, mode, cmd, assumed_family, abs_path), None
+        except Exception as e:
+            util.con_out(util.ConsoleHeader, 'Compiler {0} for {1} failed: '.format(cmd, mode),
+                         util.ConsoleRed, str(e), util.ConsoleNormal)
+            return None, e
 
 def VerifyCompiler(env, mode, cmd, assumed_family, abs_path):
-  base_argv = shlex.split(cmd)
+    base_argv = shlex.split(cmd)
 
-  if 'CFLAGS' in env:
-    base_argv.extend(env['CFLAGS'].split())
-  if mode == 'CXX' and 'CXXFLAGS' in env:
-    base_argv.extend(env['CXXFLAGS'].split())
+    if 'CFLAGS' in env:
+        base_argv.extend(env['CFLAGS'].split())
+    if mode == 'CXX' and 'CXXFLAGS' in env:
+        base_argv.extend(env['CXXFLAGS'].split())
 
-  argv = base_argv[:]
-  if abs_path is not None:
-    argv[0] = abs_path
-  if mode == 'CXX':
-    filename = 'test.cpp'
-  else:
-    filename = 'test.c'
-  file = open(filename, 'w')
-  file.write("""
+    argv = base_argv[:]
+    if abs_path is not None:
+        argv[0] = abs_path
+    if mode == 'CXX':
+        filename = 'test.cpp'
+    else:
+        filename = 'test.c'
+    file = open(filename, 'w')
+    file.write("""
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -274,84 +279,77 @@ int main()
   exit(0);
 }
 """)
-  file.close()
+    file.close()
 
-  executable = 'test'
-  if mode == 'CXX':
-    executable += 'p'
-  if assumed_family == 'emscripten':
-    executable += '.js'
-  else:
-    executable += util.ExecutableSuffix
+    executable = 'test'
+    if mode == 'CXX':
+        executable += 'p'
+    if assumed_family == 'emscripten':
+        executable += '.js'
+    else:
+        executable += util.ExecutableSuffix
 
-  # Make sure the exe is gone.
-  if os.path.exists(executable):
-    os.unlink(executable)
+    # Make sure the exe is gone.
+    if os.path.exists(executable):
+        os.unlink(executable)
 
-  argv.extend([filename, '-o', executable])
+    argv.extend([filename, '-o', executable])
 
-  # For MSVC, we need to detect the inclusion pattern for foreign-language
-  # systems.
-  if assumed_family == 'msvc':
-    argv += ['-nologo', '-showIncludes']
+    # For MSVC, we need to detect the inclusion pattern for foreign-language
+    # systems.
+    if assumed_family == 'msvc':
+        argv += ['-nologo', '-showIncludes']
 
-  util.con_out(
-    util.ConsoleHeader,
-    'Checking {0} compiler (vendor test {1})... '.format(mode, assumed_family),
-    util.ConsoleBlue,
-    '{0}'.format(argv),
-    util.ConsoleNormal
-  )
-  p = util.CreateProcess(argv, env = env)
-  if p == None:
-    raise CompilerNotFoundException('compiler not found')
-  if util.WaitForProcess(p) != 0:
-    raise Exception('compiler failed with return code {0}'.format(p.returncode))
+    util.con_out(util.ConsoleHeader,
+                 'Checking {0} compiler (vendor test {1})... '.format(mode, assumed_family),
+                 util.ConsoleBlue, '{0}'.format(argv), util.ConsoleNormal)
+    p = util.CreateProcess(argv, env = env)
+    if p == None:
+        raise CompilerNotFoundException('compiler not found')
+    if util.WaitForProcess(p) != 0:
+        raise Exception('compiler failed with return code {0}'.format(p.returncode))
 
-  inclusion_pattern = None
-  if assumed_family == 'msvc':
-    inclusion_pattern = MSVC.DetectInclusionPattern(p.stdoutText)
+    inclusion_pattern = None
+    if assumed_family == 'msvc':
+        inclusion_pattern = MSVC.DetectInclusionPattern(p.stdoutText)
 
-  executable_argv = [executable]
-  if assumed_family == 'emscripten':
-    exe = 'node'
-    executable_argv[0:0] = [exe]
-  else:
-    exe = util.MakePath('.', executable)
+    executable_argv = [executable]
+    if assumed_family == 'emscripten':
+        exe = 'node'
+        executable_argv[0:0] = [exe]
+    else:
+        exe = util.MakePath('.', executable)
 
-  p = util.CreateProcess(executable_argv, executable = exe, env = env)
-  if p == None:
-    raise Exception('failed to create executable with {0}'.format(cmd))
-  if util.WaitForProcess(p) != 0:
-    raise Exception('executable failed with return code {0}'.format(p.returncode))
-  lines = p.stdoutText.splitlines()
-  if len(lines) != 2:
-    raise Exception('invalid executable output')
-  if lines[1] != mode:
-    raise Exception('requested {0} compiler, found {1}'.format(mode, lines[1]))
+    p = util.CreateProcess(executable_argv, executable = exe, env = env)
+    if p == None:
+        raise Exception('failed to create executable with {0}'.format(cmd))
+    if util.WaitForProcess(p) != 0:
+        raise Exception('executable failed with return code {0}'.format(p.returncode))
+    lines = p.stdoutText.splitlines()
+    if len(lines) != 2:
+        raise Exception('invalid executable output')
+    if lines[1] != mode:
+        raise Exception('requested {0} compiler, found {1}'.format(mode, lines[1]))
 
-  vendor, version = lines[0].split(' ')
-  if vendor == 'gcc':
-    v = GCC(version)
-  elif vendor == 'emscripten':
-    v = Emscripten(version)
-  elif vendor == 'apple-clang':
-    v = Clang(version, 'apple')
-  elif vendor == 'clang':
-    v = Clang(version)
-  elif vendor == 'msvc':
-    v = MSVC(version)
-  elif vendor == 'sun':
-    v = SunPro(version)
-  else:
-    raise Exception('Unknown vendor {0}'.format(vendor))
+    vendor, version = lines[0].split(' ')
+    if vendor == 'gcc':
+        v = GCC(version)
+    elif vendor == 'emscripten':
+        v = Emscripten(version)
+    elif vendor == 'apple-clang':
+        v = Clang(version, 'apple')
+    elif vendor == 'clang':
+        v = Clang(version)
+    elif vendor == 'msvc':
+        v = MSVC(version)
+    elif vendor == 'sun':
+        v = SunPro(version)
+    else:
+        raise Exception('Unknown vendor {0}'.format(vendor))
 
-  if inclusion_pattern is not None:
-    v.extra_props['inclusion_pattern'] = inclusion_pattern
+    if inclusion_pattern is not None:
+        v.extra_props['inclusion_pattern'] = inclusion_pattern
 
-  util.con_out(
-    util.ConsoleHeader,
-    'found {0} version {1}'.format(vendor, version),
-    util.ConsoleNormal
-  )
-  return CommandAndVendor(base_argv, v)
+    util.con_out(util.ConsoleHeader, 'found {0} version {1}'.format(vendor, version),
+                 util.ConsoleNormal)
+    return CommandAndVendor(base_argv, v)

--- a/ambuild2/frontend/v2_1/cpp/gcc.py
+++ b/ambuild2/frontend/v2_1/cpp/gcc.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -19,118 +19,118 @@ from ambuild2 import util
 from ambuild2.frontend.v2_1.cpp.vendor import Vendor
 
 class GCCLookalike(Vendor):
-  def __init__(self, version):
-    super(GCCLookalike, self).__init__(version)
+    def __init__(self, version):
+        super(GCCLookalike, self).__init__(version)
 
-  @property
-  def behavior(self):
-    return 'gcc'
+    @property
+    def behavior(self):
+        return 'gcc'
 
-  @property
-  def definePrefix(self):
-    return '-D'
+    @property
+    def definePrefix(self):
+        return '-D'
 
-  @property
-  def objSuffix(self):
-    return '.o'
+    @property
+    def objSuffix(self):
+        return '.o'
 
-  @property
-  def debugInfoArgv(self):
-    return []
+    @property
+    def debugInfoArgv(self):
+        return []
 
-  def parseDebugInfoType(self, debuginfo):
-    return debuginfo
+    def parseDebugInfoType(self, debuginfo):
+        return debuginfo
 
-  def formatInclude(self, outputPath, includePath):
-    return ['-I', os.path.normpath(includePath)]
+    def formatInclude(self, outputPath, includePath):
+        return ['-I', os.path.normpath(includePath)]
 
-  def preprocessArgs(self, sourceFile, outFile):
-    return ['-I', os.path.normpath(includePath)]
+    def preprocessArgs(self, sourceFile, outFile):
+        return ['-I', os.path.normpath(includePath)]
 
-  def objectArgs(self, sourceFile, objFile):
-    return ['-H', '-c', sourceFile, '-o', objFile]
+    def objectArgs(self, sourceFile, objFile):
+        return ['-H', '-c', sourceFile, '-o', objFile]
 
-  def staticLinkArgv(self, files, outputFile):
-    return ['ar', 'rcs', outputFile] + files
+    def staticLinkArgv(self, files, outputFile):
+        return ['ar', 'rcs', outputFile] + files
 
-  def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    return cmd_argv + files + linkFlags + ['-o', outputFile]
+    def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        return cmd_argv + files + linkFlags + ['-o', outputFile]
 
-  def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    argv = cmd_argv + files + linkFlags
-    if util.IsMac():
-      argv += ['-dynamiclib']
-    else:
-      argv += ['-shared']
-    argv += ['-o', outputFile]
-    return argv
+    def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        argv = cmd_argv + files + linkFlags
+        if util.IsMac():
+            argv += ['-dynamiclib']
+        else:
+            argv += ['-shared']
+        argv += ['-o', outputFile]
+        return argv
 
 class GCC(GCCLookalike):
-  def __init__(self, version):
-    super(GCC, self).__init__(version)
+    def __init__(self, version):
+        super(GCC, self).__init__(version)
 
-  @property
-  def name(self):
-    return 'gcc'
+    @property
+    def name(self):
+        return 'gcc'
 
-  @property
-  def family(self):
-    return 'gcc'
+    @property
+    def family(self):
+        return 'gcc'
 
-  def like(self, name):
-    return name == 'gcc'
+    def like(self, name):
+        return name == 'gcc'
 
 class Clang(GCCLookalike):
-  def __init__(self, version, vendor_prefix = None):
-    # Set this first, since the constructor will need it.
-    self.vendor_name = 'clang'
-    if vendor_prefix is not None:
-      self.vendor_name = '{0}-clang'.format(vendor_prefix)
-    super(Clang, self).__init__(version)
+    def __init__(self, version, vendor_prefix = None):
+        # Set this first, since the constructor will need it.
+        self.vendor_name = 'clang'
+        if vendor_prefix is not None:
+            self.vendor_name = '{0}-clang'.format(vendor_prefix)
+        super(Clang, self).__init__(version)
 
-  @property
-  def name(self):
-    return self.vendor_name
+    @property
+    def name(self):
+        return self.vendor_name
 
-  @property
-  def family(self):
-    return 'clang'
+    @property
+    def family(self):
+        return 'clang'
 
-  def like(self, name):
-    return name == 'gcc' or name == 'clang' or name == self.name
+    def like(self, name):
+        return name == 'gcc' or name == 'clang' or name == self.name
 
-  @property
-  def debugInfoArgv(self):
-    return ['-g3']
+    @property
+    def debugInfoArgv(self):
+        return ['-g3']
 
 class Emscripten(Clang):
-  def __init__(self, version):
-    # Set this first, since the constructor will need it.
-    super(Emscripten, self).__init__(version, 'emscripten')
+    def __init__(self, version):
+        # Set this first, since the constructor will need it.
+        super(Emscripten, self).__init__(version, 'emscripten')
 
-  def nameForExecutable(self, name):
-    return name + '.js'
+    def nameForExecutable(self, name):
+        return name + '.js'
 
-  def nameForSharedLibrary(self, name):
-    return name + '.bc'
+    def nameForSharedLibrary(self, name):
+        return name + '.bc'
 
-  def nameForStaticLibrary(self, name):
-    return util.StaticLibPrefix + name + '.a'
+    def nameForStaticLibrary(self, name):
+        return util.StaticLibPrefix + name + '.a'
 
-  @property
-  def name(self):
-    return 'emscripten'
+    @property
+    def name(self):
+        return 'emscripten'
 
-  @property
-  def family(self):
-    return 'emscripten'
+    @property
+    def family(self):
+        return 'emscripten'
 
-  def like(self, name):
-    return name == 'gcc' or name == 'clang' or name == 'emscripten-clang' or name == 'emscripten'
+    def like(self, name):
+        return name == 'gcc' or name == 'clang' or name == 'emscripten-clang' or name == 'emscripten'
 
-  @property
-  def debugInfoArgv(self):
-    return []
+    @property
+    def debugInfoArgv(self):
+        return []
 
-  def staticLinkArgv(self, files, outputFile):
-    return ['emar', 'rcs', outputFile] + files
+    def staticLinkArgv(self, files, outputFile):
+        return ['emar', 'rcs', outputFile] + files

--- a/ambuild2/frontend/v2_1/cpp/msvc.py
+++ b/ambuild2/frontend/v2_1/cpp/msvc.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -21,122 +21,122 @@ from ambuild2.frontend.v2_1.cpp.vendor import Vendor
 
 # Microsoft Visual C++
 class MSVC(Vendor):
-  def __init__(self, version):
-    super(MSVC, self).__init__(version)
+    def __init__(self, version):
+        super(MSVC, self).__init__(version)
 
-  @property
-  def name(self):
-    return 'msvc'
+    @property
+    def name(self):
+        return 'msvc'
 
-  @property
-  def behavior(self):
-    return 'msvc'
+    @property
+    def behavior(self):
+        return 'msvc'
 
-  @property
-  def family(self):
-    return 'msvc'
+    @property
+    def family(self):
+        return 'msvc'
 
-  def like(self, name):
-    return name == 'msvc'
+    def like(self, name):
+        return name == 'msvc'
 
-  @property
-  def definePrefix(self):
-    return '/D'
+    @property
+    def definePrefix(self):
+        return '/D'
 
-  @property
-  def objSuffix(self):
-    return '.obj'
+    @property
+    def objSuffix(self):
+        return '.obj'
 
-  @property
-  def debugInfoArgv(self):
-    if int(self.version_string) >= 1800:
-      return ['/Zi', '/FS']
-    return ['/Zi']
+    @property
+    def debugInfoArgv(self):
+        if int(self.version_string) >= 1800:
+            return ['/Zi', '/FS']
+        return ['/Zi']
 
-  def parseDebugInfoType(self, debuginfo):
-    if debuginfo == 'bundled':
-      return 'separate'
-    return debuginfo
+    def parseDebugInfoType(self, debuginfo):
+        if debuginfo == 'bundled':
+            return 'separate'
+        return debuginfo
 
-  def objectArgs(self, sourceFile, objFile):
-    return ['/showIncludes', '/nologo', '/c', sourceFile, '/Fo' + objFile]
+    def objectArgs(self, sourceFile, objFile):
+        return ['/showIncludes', '/nologo', '/c', sourceFile, '/Fo' + objFile]
 
-  def staticLinkArgv(self, files, outputFile):
-    return ['lib', '/OUT:' + outputFile] + files
+    def staticLinkArgv(self, files, outputFile):
+        return ['lib', '/OUT:' + outputFile] + files
 
-  def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    argv = cmd_argv + files
-    argv += ['/link']
-    argv += linkFlags
-    argv += [
-      '/OUT:' + outputFile,
-      '/nologo',
-    ]
-    if symbolFile:
-      argv += ['/DEBUG', '/PDB:"' + symbolFile + '.pdb"']
-    return argv
+    def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        argv = cmd_argv + files
+        argv += ['/link']
+        argv += linkFlags
+        argv += [
+            '/OUT:' + outputFile,
+            '/nologo',
+        ]
+        if symbolFile:
+            argv += ['/DEBUG', '/PDB:"' + symbolFile + '.pdb"']
+        return argv
 
-  def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    argv = cmd_argv + files
-    argv += ['/link']
-    argv += linkFlags
-    argv += [
-      '/OUT:' + outputFile,
-      '/nologo',
-      '/DLL',
-    ]
-    if symbolFile:
-      argv += ['/DEBUG', '/PDB:"' + symbolFile + '.pdb"']
-    return argv
+    def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        argv = cmd_argv + files
+        argv += ['/link']
+        argv += linkFlags
+        argv += [
+            '/OUT:' + outputFile,
+            '/nologo',
+            '/DLL',
+        ]
+        if symbolFile:
+            argv += ['/DEBUG', '/PDB:"' + symbolFile + '.pdb"']
+        return argv
 
-  def preprocessArgv(self, sourceFile, outFile):
-    return ['/showIncludes', '/nologo', '/P', '/c', sourceFile, '/Fi' + outFile]
+    def preprocessArgv(self, sourceFile, outFile):
+        return ['/showIncludes', '/nologo', '/P', '/c', sourceFile, '/Fi' + outFile]
 
-  @staticmethod
-  def IncludePath(outputPath, includePath):
-    # Hack - try and get a relative path because CL, with either 
-    # /Zi or /ZI, combined with subprocess, apparently tries and
-    # looks for paths like c:\bleh\"c:\bleh" <-- wtf
-    # .. this according to Process Monitor
-    outputPath = os.path.normcase(outputPath)
-    includePath = os.path.normcase(includePath)
-    outputDrive = os.path.splitdrive(outputPath)[0]
-    includeDrive = os.path.splitdrive(includePath)[0]
-    if outputDrive == includeDrive:
-      return os.path.relpath(includePath, outputPath)
-    return includePath
+    @staticmethod
+    def IncludePath(outputPath, includePath):
+        # Hack - try and get a relative path because CL, with either
+        # /Zi or /ZI, combined with subprocess, apparently tries and
+        # looks for paths like c:\bleh\"c:\bleh" <-- wtf
+        # .. this according to Process Monitor
+        outputPath = os.path.normcase(outputPath)
+        includePath = os.path.normcase(includePath)
+        outputDrive = os.path.splitdrive(outputPath)[0]
+        includeDrive = os.path.splitdrive(includePath)[0]
+        if outputDrive == includeDrive:
+            return os.path.relpath(includePath, outputPath)
+        return includePath
 
-  def formatInclude(self, outputPath, includePath):
-    return ['/I', MSVC.IncludePath(outputPath, includePath)]
+    def formatInclude(self, outputPath, includePath):
+        return ['/I', MSVC.IncludePath(outputPath, includePath)]
 
-  @staticmethod
-  def DetectInclusionPattern(text):
-    for line in [raw.strip() for raw in text.split('\n')]:
-      m = re.match(r'(.*)\s+([A-Za-z]:\\.*stdio\.h)$', line)
-      if m is None:
-        continue
-  
-      phrase = m.group(1)
-      return re.escape(phrase) + r'\s+([A-Za-z]:\\.*)$'
-  
-    raise Exception('Could not find compiler inclusion pattern')
+    @staticmethod
+    def DetectInclusionPattern(text):
+        for line in [raw.strip() for raw in text.split('\n')]:
+            m = re.match(r'(.*)\s+([A-Za-z]:\\.*stdio\.h)$', line)
+            if m is None:
+                continue
 
-  ##
-  # MSVC-specific properties.
-  ##
-  @property
-  def shared_pdb_name(self):
-    cl_version = int(self.version_string)
+            phrase = m.group(1)
+            return re.escape(phrase) + r'\s+([A-Za-z]:\\.*)$'
 
-    # Truncate down to the major version then correct the offset
-    # There is some evidence that the first digit of the minor version can be used for the PDB, but I can't reproduce it
-    cl_version = int(cl_version / 100) - 6
+        raise Exception('Could not find compiler inclusion pattern')
 
-    # Microsoft introduced a discontinuity with vs2015
-    if cl_version >= 13:
-      cl_version += 1
+    ##
+    # MSVC-specific properties.
+    ##
+    @property
+    def shared_pdb_name(self):
+        cl_version = int(self.version_string)
 
-    # Pad it back out again
-    cl_version *= 10
+        # Truncate down to the major version then correct the offset
+        # There is some evidence that the first digit of the minor version can be used for the PDB, but I can't reproduce it
+        cl_version = int(cl_version / 100) - 6
 
-    return 'vc{0}.pdb'.format(cl_version)
+        # Microsoft introduced a discontinuity with vs2015
+        if cl_version >= 13:
+            cl_version += 1
+
+        # Pad it back out again
+        cl_version *= 10
+
+        return 'vc{0}.pdb'.format(cl_version)

--- a/ambuild2/frontend/v2_1/cpp/sunpro.py
+++ b/ambuild2/frontend/v2_1/cpp/sunpro.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -19,50 +19,50 @@ from ambuild2 import util
 from ambuild2.frontend.v2_1.cpp.vendor import Vendor
 
 class SunPro(Vendor):
-  def __init__(self, version):
-    super(SunPro, self).__init__(version)
+    def __init__(self, version):
+        super(SunPro, self).__init__(version)
 
-  @property
-  def name(self):
-    return 'sun'
+    @property
+    def name(self):
+        return 'sun'
 
-  @property
-  def behavior(self):
-    return 'sun'
+    @property
+    def behavior(self):
+        return 'sun'
 
-  @property
-  def family(self):
-    return 'sun'
+    @property
+    def family(self):
+        return 'sun'
 
-  def like(self, name):
-    return name == 'sun'
+    def like(self, name):
+        return name == 'sun'
 
-  @property
-  def definePrefix(self):
-    return '/D'
+    @property
+    def definePrefix(self):
+        return '/D'
 
-  @property
-  def objSuffix(self):
-    return '.o'
+    @property
+    def objSuffix(self):
+        return '.o'
 
-  @property
-  def debugInfoArgv(self):
-    return ['-g3']
+    @property
+    def debugInfoArgv(self):
+        return ['-g3']
 
-  def parseDebugInfoType(self, debuginfo):
-    return debuginfo
+    def parseDebugInfoType(self, debuginfo):
+        return debuginfo
 
-  def objectArgs(self, sourceFile, objFile):
-    return ['-H', '-c', sourceFile, '-o', objFile]
+    def objectArgs(self, sourceFile, objFile):
+        return ['-H', '-c', sourceFile, '-o', objFile]
 
-  def formatInclude(self, outputPath, includePath):
-    return ['-I', os.path.normpath(includePath)]
+    def formatInclude(self, outputPath, includePath):
+        return ['-I', os.path.normpath(includePath)]
 
-  def staticLinkArgv(self, files, outputFile):
-    return ['ar', 'rcs', outputFile] + files
+    def staticLinkArgv(self, files, outputFile):
+        return ['ar', 'rcs', outputFile] + files
 
-  def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    return cmd_argv + files + linkFlags + ['-o', outputFile]
+    def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        return cmd_argv + files + linkFlags + ['-o', outputFile]
 
-  def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    return cmd_argv + files + linkFlags + ['-o', outputFile]
+    def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        return cmd_argv + files + linkFlags + ['-o', outputFile]

--- a/ambuild2/frontend/v2_1/cpp/vendor.py
+++ b/ambuild2/frontend/v2_1/cpp/vendor.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
@@ -20,74 +20,74 @@ from ambuild2 import util
 from ambuild2.frontend.version import Version
 
 class Vendor(object):
-  def __init__(self, version):
-    super(Vendor, self).__init__()
-    self.version_string = version
-    self.version = Version('{0}-{1}'.format(self.name, version))
-    self.extra_props = {}
+    def __init__(self, version):
+        super(Vendor, self).__init__()
+        self.version_string = version
+        self.version = Version('{0}-{1}'.format(self.name, version))
+        self.extra_props = {}
 
-  def nameForExecutable(self, name):
-    return name + util.ExecutableSuffix
+    def nameForExecutable(self, name):
+        return name + util.ExecutableSuffix
 
-  def nameForSharedLibrary(self, name):
-    return name + util.SharedLibSuffix
+    def nameForSharedLibrary(self, name):
+        return name + util.SharedLibSuffix
 
-  def nameForStaticLibrary(self, name):
-    return util.StaticLibPrefix + name + util.StaticLibSuffix
+    def nameForStaticLibrary(self, name):
+        return util.StaticLibPrefix + name + util.StaticLibSuffix
 
-  def equals(self, other):
-    return self.name == other.name and \
-           self.version == other.version and \
-           self.extra_props == other.extra_props
+    def equals(self, other):
+        return self.name == other.name and \
+               self.version == other.version and \
+               self.extra_props == other.extra_props
 
-  def __str__(self):
-    return '{0}-{1}'.format(self.name, self.version_string)
+    def __str__(self):
+        return '{0}-{1}'.format(self.name, self.version_string)
 
-  @property
-  def behavior(self):
-    raise Exception("Must be implemented")
+    @property
+    def behavior(self):
+        raise Exception("Must be implemented")
 
-  @property
-  def name(self):
-    raise Exception("Must be implemented")
+    @property
+    def name(self):
+        raise Exception("Must be implemented")
 
-  @property
-  def family(self):
-    raise Exception("Must be implemented")
+    @property
+    def family(self):
+        raise Exception("Must be implemented")
 
-  def like(self, name):
-    raise Exception("Must be implemented")
+    def like(self, name):
+        raise Exception("Must be implemented")
 
-  @property
-  def definePrefix(self):
-    raise Exception("Must be implemented")
+    @property
+    def definePrefix(self):
+        raise Exception("Must be implemented")
 
-  @property
-  def objSuffix(self):
-    raise Exception("Must be implemented")
+    @property
+    def objSuffix(self):
+        raise Exception("Must be implemented")
 
-  @property
-  def debugInfoArgv(self):
-    raise Exception("Must be implemented")
+    @property
+    def debugInfoArgv(self):
+        raise Exception("Must be implemented")
 
-  def parseDebugInfoType(self, debuginfo):
-    raise Exception("Must be implemented")
+    def parseDebugInfoType(self, debuginfo):
+        raise Exception("Must be implemented")
 
-  def formatInclude(self, outputPath, includePath):
-    raise Exception("Must be implemented")
+    def formatInclude(self, outputPath, includePath):
+        raise Exception("Must be implemented")
 
-  def objectArgs(self, sourceFile, objFile):
-    raise Exception("Must be implemented")
+    def objectArgs(self, sourceFile, objFile):
+        raise Exception("Must be implemented")
 
-  # Note: this should return a complete initial argv, not partial.
-  # AMBuild does not detect AR/LIB separately yet.
-  def staticLinkArgv(self, files, outputFile):
-    raise Exception("Must be implemented")
+    # Note: this should return a complete initial argv, not partial.
+    # AMBuild does not detect AR/LIB separately yet.
+    def staticLinkArgv(self, files, outputFile):
+        raise Exception("Must be implemented")
 
-  # For this and libLinkArgv(), the symbolFile should not have an extension.
-  # The vendor chooses the extension if it supports symbol files at all.
-  def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    raise Exception("Must be implemented")
+    # For this and libLinkArgv(), the symbolFile should not have an extension.
+    # The vendor chooses the extension if it supports symbol files at all.
+    def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        raise Exception("Must be implemented")
 
-  def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
-    raise Exception("Must be implemented")
+    def libLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
+        raise Exception("Must be implemented")

--- a/ambuild2/frontend/v2_1/prep.py
+++ b/ambuild2/frontend/v2_1/prep.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can Headeristribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, sys
@@ -22,125 +22,150 @@ from optparse import OptionParser, Values, SUPPRESS_HELP
 from ambuild2.frontend.system import System
 
 class Preparer(object):
-  def __init__(self, sourcePath, buildPath):
-    self.sourcePath = sourcePath
-    self.buildPath = buildPath
-    self.host = System.Host
-    self.target_arch = None
-    self.default_arch = None
+    def __init__(self, sourcePath, buildPath):
+        self.sourcePath = sourcePath
+        self.buildPath = buildPath
+        self.host = System.Host
+        self.target_arch = None
+        self.default_arch = None
 
-    self.options = OptionParser("usage: %prog [options]")
-    self.options.add_option("-g", "--gen", type="string", dest="generator", default="ambuild2",
-                            help="Build system generator to use. See --list-gen")
-    self.options.add_option("--list-gen", action="store_true", dest="list_gen", default=False,
-                            help="List available build system generators, then exit.")
-    self.options.add_option("--make-scripts", action="store_true", dest="make_scripts", default=False,
-                            help="Generate extra command-line files for building (build.py, Makefile).")
-    self.options.add_option("--no-color", action="store_true", dest="no_color", default=False,
-                            help="Disable color output in the terminal.")
-    self.options.add_option("--symbol-files", action="store_true", dest="symbol_files", default=False,
-                            help="Split debugging symbols from binaries into separate symbol files.")
+        self.options = OptionParser("usage: %prog [options]")
+        self.options.add_option("-g",
+                                "--gen",
+                                type = "string",
+                                dest = "generator",
+                                default = "ambuild2",
+                                help = "Build system generator to use. See --list-gen")
+        self.options.add_option("--list-gen",
+                                action = "store_true",
+                                dest = "list_gen",
+                                default = False,
+                                help = "List available build system generators, then exit.")
+        self.options.add_option(
+            "--make-scripts",
+            action = "store_true",
+            dest = "make_scripts",
+            default = False,
+            help = "Generate extra command-line files for building (build.py, Makefile).")
+        self.options.add_option("--no-color",
+                                action = "store_true",
+                                dest = "no_color",
+                                default = False,
+                                help = "Disable color output in the terminal.")
+        self.options.add_option(
+            "--symbol-files",
+            action = "store_true",
+            dest = "symbol_files",
+            default = False,
+            help = "Split debugging symbols from binaries into separate symbol files.")
 
-    # Generator specific options.
-    self.options.add_option("--vs-version", type="string", dest="vs_version", default="12",
-                            help=SUPPRESS_HELP)
-    self.options.add_option("--vs-split", action='store_true', dest="vs_split", default=False,
-                            help=SUPPRESS_HELP)
+        # Generator specific options.
+        self.options.add_option("--vs-version",
+                                type = "string",
+                                dest = "vs_version",
+                                default = "12",
+                                help = SUPPRESS_HELP)
+        self.options.add_option("--vs-split",
+                                action = 'store_true',
+                                dest = "vs_split",
+                                default = False,
+                                help = SUPPRESS_HELP)
 
-  @staticmethod
-  def default_build_folder(prep):
-    return 'obj-' + util.Platform() + '-' + platform.machine()
+    @staticmethod
+    def default_build_folder(prep):
+        return 'obj-' + util.Platform() + '-' + platform.machine()
 
-  def Configure(self): 
-    if self.target_arch is None:
-      self.options.add_option("--target-arch", type="string", dest="target_arch", default=None,
-                              help="Override the target architecture.")
+    def Configure(self):
+        if self.target_arch is None:
+            self.options.add_option("--target-arch",
+                                    type = "string",
+                                    dest = "target_arch",
+                                    default = None,
+                                    help = "Override the target architecture.")
 
-    v_options, args = self.options.parse_args()
+        v_options, args = self.options.parse_args()
 
-    # In order to support pickling, we need to rewrite |options| to not use
-    # optparse.Values, since its implementation changes across Python versions.
-    options = util.Expando()
-    ignore_attrs = set(dir(Values))
-    for attr in dir(v_options):
-      if attr in ignore_attrs:
-        continue
-      setattr(options, attr, getattr(v_options, attr))
+        # In order to support pickling, we need to rewrite |options| to not use
+        # optparse.Values, since its implementation changes across Python versions.
+        options = util.Expando()
+        ignore_attrs = set(dir(Values))
+        for attr in dir(v_options):
+            if attr in ignore_attrs:
+                continue
+            setattr(options, attr, getattr(v_options, attr))
 
-    if self.target_arch is not None:
-      # Configure.py has hardcoded arch.
-      assert getattr(options, 'target_arch', None) is None
-      options.target_arch = self.target_arch
-    elif options.target_arch is None and self.default_arch is not None:
-      # Configure.py has default arch, user specified no arch.
-      options.target_arch = self.default_arch
-      self.target_arch = self.default_arch
-    else:
-      # Take any user specified arch.
-      self.target_arch = options.target_arch
+        if self.target_arch is not None:
+            # Configure.py has hardcoded arch.
+            assert getattr(options, 'target_arch', None) is None
+            options.target_arch = self.target_arch
+        elif options.target_arch is None and self.default_arch is not None:
+            # Configure.py has default arch, user specified no arch.
+            options.target_arch = self.default_arch
+            self.target_arch = self.default_arch
+        else:
+            # Take any user specified arch.
+            self.target_arch = options.target_arch
 
-    if options.list_gen:
-      print('Available build system generators:')
-      print('  {0:24} - AMBuild 2 (default)'.format('ambuild2'))
-      print('  {0:24} - Visual Studio'.format('vs'))
-      print('')
-      print('Extra options:')
-      print('  --vs-version=N        Visual Studio: IDE version (2015 or 14 default)')
-      print('  --vs-split            Visual Studio: generate one project file per configuration')
-      sys.exit(0)
+        if options.list_gen:
+            print('Available build system generators:')
+            print('  {0:24} - AMBuild 2 (default)'.format('ambuild2'))
+            print('  {0:24} - Visual Studio'.format('vs'))
+            print('')
+            print('Extra options:')
+            print('  --vs-version=N        Visual Studio: IDE version (2015 or 14 default)')
+            print(
+                '  --vs-split            Visual Studio: generate one project file per configuration'
+            )
+            sys.exit(0)
 
-    if options.no_color:
-      util.DisableConsoleColors()
+        if options.no_color:
+            util.DisableConsoleColors()
 
-    source_abspath = os.path.normpath(os.path.abspath(self.sourcePath))
-    build_abspath = os.path.normpath(os.path.abspath(self.buildPath))
-    if source_abspath == build_abspath:
-      if util.IsString(self.default_build_folder):
-        objfolder = self.default_build_folder
-      else:
-        objfolder = self.default_build_folder(self)
-      new_buildpath = os.path.join(self.buildPath, objfolder)
+        source_abspath = os.path.normpath(os.path.abspath(self.sourcePath))
+        build_abspath = os.path.normpath(os.path.abspath(self.buildPath))
+        if source_abspath == build_abspath:
+            if util.IsString(self.default_build_folder):
+                objfolder = self.default_build_folder
+            else:
+                objfolder = self.default_build_folder(self)
+            new_buildpath = os.path.join(self.buildPath, objfolder)
 
-      util.con_err(
-        util.ConsoleHeader,
-        'Warning: build is being configured in the source tree.',
-        util.ConsoleNormal
-      )
-      if os.path.exists(os.path.join(new_buildpath)):
-        has_amb2 = os.path.exists(os.path.join(new_buildpath, '.ambuild2'))
-        if not has_amb2 and len(os.listdir(new_buildpath)) and options.generator == 'ambuild2':
-          util.con_err(util.ConsoleRed, 'Tried to use ',
-                       util.ConsoleBlue, objfolder,
-                       util.ConsoleRed, ' as a build folder, but it is not empty!',
-                       util.ConsoleNormal)
-          raise Exception('build folder has unrecognized files')
+            util.con_err(util.ConsoleHeader,
+                         'Warning: build is being configured in the source tree.',
+                         util.ConsoleNormal)
+            if os.path.exists(os.path.join(new_buildpath)):
+                has_amb2 = os.path.exists(os.path.join(new_buildpath, '.ambuild2'))
+                if not has_amb2 and len(
+                        os.listdir(new_buildpath)) and options.generator == 'ambuild2':
+                    util.con_err(util.ConsoleRed, 'Tried to use ', util.ConsoleBlue, objfolder,
+                                 util.ConsoleRed, ' as a build folder, but it is not empty!',
+                                 util.ConsoleNormal)
+                    raise Exception('build folder has unrecognized files')
 
-        util.con_err(util.ConsoleHeader, 'Re-using build folder: ',
-                     util.ConsoleBlue, '{0}'.format(objfolder),
-                     util.ConsoleNormal)
-      else:
-        util.con_err(util.ConsoleHeader, 'Creating "',
-                     util.ConsoleBlue, '{0}'.format(objfolder),
-                     util.ConsoleHeader, '" as a build folder.',
-                     util.ConsoleNormal)
-        os.mkdir(new_buildpath)
-      self.buildPath = new_buildpath
+                util.con_err(util.ConsoleHeader, 'Re-using build folder: ', util.ConsoleBlue,
+                             '{0}'.format(objfolder), util.ConsoleNormal)
+            else:
+                util.con_err(util.ConsoleHeader, 'Creating "', util.ConsoleBlue,
+                             '{0}'.format(objfolder), util.ConsoleHeader, '" as a build folder.',
+                             util.ConsoleNormal)
+                os.mkdir(new_buildpath)
+            self.buildPath = new_buildpath
 
-    if options.generator == 'ambuild2':
-      from ambuild2.frontend.v2_1.amb2 import gen
-      builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
-    elif options.generator == 'vs':
-      from ambuild2.frontend.v2_1.vs import gen
-      builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
-    else:
-      sys.stderr.write('Unrecognized build generator: ' + options.generator + '\n')
-      sys.exit(1)
+        if options.generator == 'ambuild2':
+            from ambuild2.frontend.v2_1.amb2 import gen
+            builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
+        elif options.generator == 'vs':
+            from ambuild2.frontend.v2_1.vs import gen
+            builder = gen.Generator(self.sourcePath, self.buildPath, os.getcwd(), options, args)
+        else:
+            sys.stderr.write('Unrecognized build generator: ' + options.generator + '\n')
+            sys.exit(1)
 
-    with util.FolderChanger(self.buildPath):
-      try:
-        if not builder.generate():
-          sys.stderr.write('Configure failed.\n')
-          sys.exit(1)
-      except Exception as e:
-        traceback.print_exc()
-        util.con_err(util.ConsoleRed, 'Configure failed: {}'.format(e), util.ConsoleNormal)
+        with util.FolderChanger(self.buildPath):
+            try:
+                if not builder.generate():
+                    sys.stderr.write('Configure failed.\n')
+                    sys.exit(1)
+            except Exception as e:
+                traceback.print_exc()
+                util.con_err(util.ConsoleRed, 'Configure failed: {}'.format(e), util.ConsoleNormal)

--- a/ambuild2/frontend/v2_1/tools/fxc.py
+++ b/ambuild2/frontend/v2_1/tools/fxc.py
@@ -1,179 +1,175 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can Headeristribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, re
 import argparse
 
 class FxcTool(object):
-  def __init__(self):
-    super(FxcTool, self).__init__()
-    self.output_files = []
-    self.output_nodes = []
+    def __init__(self):
+        super(FxcTool, self).__init__()
+        self.output_files = []
+        self.output_nodes = []
 
-  def evaluate(self, cmd):
-    for shader in cmd.data.shaders:
-      self.evaluate_shader(cmd, shader)
+    def evaluate(self, cmd):
+        for shader in cmd.data.shaders:
+            self.evaluate_shader(cmd, shader)
 
-    argv = [
-      'python',
-      __file__,
-      '--prefix', cmd.data.output,
-    ]
-    if cmd.data.namespace:
-      argv += ['--namespace', cmd.data.namespace]
-    if cmd.data.listDefineName:
-      argv += ['--list-define-name', cmd.data.listDefineName]
+        argv = [
+            'python',
+            __file__,
+            '--prefix',
+            cmd.data.output,
+        ]
+        if cmd.data.namespace:
+            argv += ['--namespace', cmd.data.namespace]
+        if cmd.data.listDefineName:
+            argv += ['--list-define-name', cmd.data.listDefineName]
 
-    argv += self.output_files
+        argv += self.output_files
 
-    _, (cxx_file, h_file) = cmd.context.AddCommand(
-      inputs = [__file__],
-      argv = argv,
-      outputs = [
-        '{0}-bytecode.cxx'.format(cmd.data.output),
-        '{0}-include.h'.format(cmd.data.output),
-      ],
-      folder = cmd.localFolderNode)
+        _, (cxx_file,
+            h_file) = cmd.context.AddCommand(inputs = [__file__],
+                                             argv = argv,
+                                             outputs = [
+                                                 '{0}-bytecode.cxx'.format(cmd.data.output),
+                                                 '{0}-include.h'.format(cmd.data.output),
+                                             ],
+                                             folder = cmd.localFolderNode)
 
-    cmd.sources += [cmd.CustomSource(
-      source = cxx_file,
-      weak_deps = self.output_nodes
-    )]
-    cmd.sourcedeps += [h_file]
+        cmd.sources += [cmd.CustomSource(source = cxx_file, weak_deps = self.output_nodes)]
+        cmd.sourcedeps += [h_file]
 
-  def evaluate_shader(self, cmd, shader):
-    source = shader['source']
-    var_prefix = shader['variable']
-    profile = shader['profile']
-    entrypoint = shader.get('entry', 'main')
+    def evaluate_shader(self, cmd, shader):
+        source = shader['source']
+        var_prefix = shader['variable']
+        profile = shader['profile']
+        entrypoint = shader.get('entry', 'main')
 
-    output_file = '{0}.{1}.{2}.h'.format(
-      cmd.NameForObjectFile(source),
-      var_prefix,
-      entrypoint)
+        output_file = '{0}.{1}.{2}.h'.format(cmd.NameForObjectFile(source), var_prefix, entrypoint)
 
-    sourceFile = cmd.ComputeSourcePath(source)
+        sourceFile = cmd.ComputeSourcePath(source)
 
-    argv = [
-      'fxc',
-      '/T', profile,
-      '/E', entrypoint,
-      '/Fh', output_file,
-      '/Vn', '{0}_Bytes_Impl'.format(var_prefix),
-      '/Vi',
-      '/nologo',
-      sourceFile,
-    ]
-    outputs = [output_file]
-    folder = cmd.localFolderNode
+        argv = [
+            'fxc',
+            '/T',
+            profile,
+            '/E',
+            entrypoint,
+            '/Fh',
+            output_file,
+            '/Vn',
+            '{0}_Bytes_Impl'.format(var_prefix),
+            '/Vi',
+            '/nologo',
+            sourceFile,
+        ]
+        outputs = [output_file]
+        folder = cmd.localFolderNode
 
-    _, (output_node,) = cmd.context.AddCommand(
-      inputs = [sourceFile],
-      argv = argv,
-      outputs = [output_file],
-      folder = cmd.localFolderNode,
-      dep_type = 'fxc')
+        _, (output_node,) = cmd.context.AddCommand(inputs = [sourceFile],
+                                                   argv = argv,
+                                                   outputs = [output_file],
+                                                   folder = cmd.localFolderNode,
+                                                   dep_type = 'fxc')
 
-    self.output_files += [output_file]
-    self.output_nodes += [output_node]
+        self.output_files += [output_file]
+        self.output_nodes += [output_node]
 
 class FxcJob(object):
-  def __init__(self, output, namespace):
-    super(FxcJob, self).__init__()
-    self.tool = FxcTool()
-    self.output = output
-    self.shaders = []
-    self.namespace = namespace
-    self.listDefineName = None
+    def __init__(self, output, namespace):
+        super(FxcJob, self).__init__()
+        self.tool = FxcTool()
+        self.output = output
+        self.shaders = []
+        self.namespace = namespace
+        self.listDefineName = None
 
 def fxc_helper_tool():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--prefix', type=str, required=True,
-                      help='Prefix for prefix files')
-  parser.add_argument('--namespace', type=str,
-                      help='Optional fully-qualified namespace')
-  parser.add_argument('--list-define-name', type=str,
-                      help='Optional name for shader list define')
-  parser.add_argument('sources', type=str, nargs='+',
-                      help='Source list')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--prefix', type = str, required = True, help = 'Prefix for prefix files')
+    parser.add_argument('--namespace', type = str, help = 'Optional fully-qualified namespace')
+    parser.add_argument('--list-define-name',
+                        type = str,
+                        help = 'Optional name for shader list define')
+    parser.add_argument('sources', type = str, nargs = '+', help = 'Source list')
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  bytecode_fp = open('{0}-bytecode.cxx'.format(args.prefix), 'w')
-  include_fp = open('{0}-include.h'.format(args.prefix), 'w')
+    bytecode_fp = open('{0}-bytecode.cxx'.format(args.prefix), 'w')
+    include_fp = open('{0}-include.h'.format(args.prefix), 'w')
 
-  header = '// Auto-generated by {0}\n'.format(__file__)
-  bytecode_fp.write(header)
-  include_fp.write(header)
+    header = '// Auto-generated by {0}\n'.format(__file__)
+    bytecode_fp.write(header)
+    include_fp.write(header)
 
-  bytecode_fp.write("#define WIN32_LEAN_AND_MEAN\n")
-  bytecode_fp.write("#include <stddef.h>\n")
-  bytecode_fp.write("#include <stdint.h>\n")
-  bytecode_fp.write("#include <Windows.h>\n")
-  bytecode_fp.write('\n')
-
-  include_fp.write("#pragma once\n")
-  include_fp.write("#include <stddef.h>\n")
-  include_fp.write("#include <stdint.h>\n")
-  include_fp.write('\n')
-
-  fqns = args.namespace.split('::') if args.namespace else []
-  if fqns:
-    for part in fqns:
-      bytecode_fp.write('namespace {0} {{\n'.format(part))
-      include_fp.write('namespace {0} {{\n'.format(part))
+    bytecode_fp.write("#define WIN32_LEAN_AND_MEAN\n")
+    bytecode_fp.write("#include <stddef.h>\n")
+    bytecode_fp.write("#include <stdint.h>\n")
+    bytecode_fp.write("#include <Windows.h>\n")
     bytecode_fp.write('\n')
+
+    include_fp.write("#pragma once\n")
+    include_fp.write("#include <stddef.h>\n")
+    include_fp.write("#include <stdint.h>\n")
     include_fp.write('\n')
 
-  var_prefixes = []
+    fqns = args.namespace.split('::') if args.namespace else []
+    if fqns:
+        for part in fqns:
+            bytecode_fp.write('namespace {0} {{\n'.format(part))
+            include_fp.write('namespace {0} {{\n'.format(part))
+        bytecode_fp.write('\n')
+        include_fp.write('\n')
 
-  for source_file in args.sources:
-    m = re.match('([^.]+)\.([^.]+)\.([^.]+)\.h', source_file)
-    var_prefix = m.group(2)
-    if m is None:
-      raise Exception('Sources must be in objname.varprefix.entrypoint.h form')
+    var_prefixes = []
 
-    bytecode_line = """#include "{0}"
+    for source_file in args.sources:
+        m = re.match('([^.]+)\.([^.]+)\.([^.]+)\.h', source_file)
+        var_prefix = m.group(2)
+        if m is None:
+            raise Exception('Sources must be in objname.varprefix.entrypoint.h form')
+
+        bytecode_line = """#include "{0}"
 extern const uint8_t* {1}_Bytes = {1}_Bytes_Impl;
 extern const size_t {1}_Length = sizeof({1}_Bytes_Impl);
 """.format(source_file, var_prefix)
-    bytecode_fp.write(bytecode_line)
+        bytecode_fp.write(bytecode_line)
 
-    include_fp.write("""extern const uint8_t* {0}_Bytes;
+        include_fp.write("""extern const uint8_t* {0}_Bytes;
 extern const size_t {0}_Length;
 """.format(var_prefix))
 
-    var_prefixes.append(var_prefix)
+        var_prefixes.append(var_prefix)
 
-  bytecode_fp.write('\n')
-  include_fp.write('\n')
-
-  if args.list_define_name:
-    include_fp.write('#define {0}(_) \\\n'.format(args.list_define_name))
-    for var_prefix in var_prefixes:
-      include_fp.write('  _({0}) \\\n'.format(var_prefix))
-    include_fp.write('  // terminator\n')
+    bytecode_fp.write('\n')
     include_fp.write('\n')
 
-  for part in fqns:
-    bytecode_fp.write('}} // namespace {0}\n'.format(part))
-    include_fp.write('}} // namespace {0}\n'.format(part))
+    if args.list_define_name:
+        include_fp.write('#define {0}(_) \\\n'.format(args.list_define_name))
+        for var_prefix in var_prefixes:
+            include_fp.write('  _({0}) \\\n'.format(var_prefix))
+        include_fp.write('  // terminator\n')
+        include_fp.write('\n')
 
-  bytecode_fp.close()
-  include_fp.close()
+    for part in fqns:
+        bytecode_fp.write('}} // namespace {0}\n'.format(part))
+        include_fp.write('}} // namespace {0}\n'.format(part))
+
+    bytecode_fp.close()
+    include_fp.close()
 
 if __name__ == '__main__':
-  fxc_helper_tool()
+    fxc_helper_tool()

--- a/ambuild2/frontend/v2_1/vs/cxx.py
+++ b/ambuild2/frontend/v2_1/vs/cxx.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, types
@@ -25,192 +25,192 @@ from ambuild2.frontend.v2_1.cpp import Dep, CppNodes
 from ambuild2.frontend.v2_1.cpp.msvc import MSVC
 
 class Project(object):
-  def __init__(self, ctor, compiler, name):
-    self.ctor_ = ctor
-    self.name_ = name
-    self.compiler = compiler
-    self.sources = []
-    self.builders_ = []
+    def __init__(self, ctor, compiler, name):
+        self.ctor_ = ctor
+        self.name_ = name
+        self.compiler = compiler
+        self.sources = []
+        self.builders_ = []
 
-  def Configure(self, name, tag):
-    compiler = self.compiler.clone()
-    builder = self.ctor_(self, compiler, name, tag)
-    builder.sources = self.sources[:]
-    self.builders_ += [builder]
-    return builder
+    def Configure(self, name, tag):
+        compiler = self.compiler.clone()
+        builder = self.ctor_(self, compiler, name, tag)
+        builder.sources = self.sources[:]
+        self.builders_ += [builder]
+        return builder
 
-  def default(self):
-    # Attach finish/generate methods to this builder, so it generates a
-    # projeet file. This is a wrapper around the older API which does not
-    # wrap binaries in projects.
-    builder = self.Configure(self.name_, 'Default')
-    builder.finish = self.finish
-    builder.generate = lambda generator, cx: self.generate(generator, cx)[0]
-    return builder
+    def default(self):
+        # Attach finish/generate methods to this builder, so it generates a
+        # projeet file. This is a wrapper around the older API which does not
+        # wrap binaries in projects.
+        builder = self.Configure(self.name_, 'Default')
+        builder.finish = self.finish
+        builder.generate = lambda generator, cx: self.generate(generator, cx)[0]
+        return builder
 
-  def finish(self, cx):
-    pass
+    def finish(self, cx):
+        pass
 
-  def generate(self, generator, cx):
-    if generator.options.vs_split:
-      return self.generate_split(generator, cx)
-    return self.generate_combined(generator, cx)
+    def generate(self, generator, cx):
+        if generator.options.vs_split:
+            return self.generate_split(generator, cx)
+        return self.generate_combined(generator, cx)
 
-  def generate_split(self, generator, cx):
-    outputs = []
-    for builder in self.builders_:
-      project = Project(self.ctor_, self.compiler, builder.name_)
-      project.sources = self.sources[:]
-      project.builders_ = [builder]
-      outputs += project.generate_combined(generator, cx)
-    return outputs
+    def generate_split(self, generator, cx):
+        outputs = []
+        for builder in self.builders_:
+            project = Project(self.ctor_, self.compiler, builder.name_)
+            project.sources = self.sources[:]
+            project.builders_ = [builder]
+            outputs += project.generate_combined(generator, cx)
+        return outputs
 
-  def generate_combined(self, generator, cx):
-    outputs = []
-    proj_path = paths.Join(cx.localFolder, self.name_ + self.compiler.projectFileSuffix)
-    node = nodes.ProjectNode(cx, proj_path, self)
-    for builder in self.builders_:
-      tag_folder = generator.addFolder(cx, builder.localFolder)
-      objFile = paths.Join(tag_folder, builder.outputFile)
-      pdbFile = paths.Join(tag_folder, builder.name_ + '.pdb')
-      objNode = generator.addOutput(cx, objFile, node)
-      pdbNode = generator.addOutput(cx, pdbFile, node)
-      outputs.append(CppNodes(objNode, pdbNode, builder.type))
-    generator.addProjectNode(cx, node)
-    return outputs
+    def generate_combined(self, generator, cx):
+        outputs = []
+        proj_path = paths.Join(cx.localFolder, self.name_ + self.compiler.projectFileSuffix)
+        node = nodes.ProjectNode(cx, proj_path, self)
+        for builder in self.builders_:
+            tag_folder = generator.addFolder(cx, builder.localFolder)
+            objFile = paths.Join(tag_folder, builder.outputFile)
+            pdbFile = paths.Join(tag_folder, builder.name_ + '.pdb')
+            objNode = generator.addOutput(cx, objFile, node)
+            pdbNode = generator.addOutput(cx, pdbFile, node)
+            outputs.append(CppNodes(objNode, pdbNode, builder.type))
+        generator.addProjectNode(cx, node)
+        return outputs
 
-  def export(self, node):
-    export_vcxproj.export(node)
+    def export(self, node):
+        export_vcxproj.export(node)
 
 class VisualStudio(MSVC):
-  def __init__(self, version):
-    super(MSVC, self).__init__(version)
+    def __init__(self, version):
+        super(MSVC, self).__init__(version)
 
-  def like(self, name):
-    return name == 'vs' or name == 'msvc'
+    def like(self, name):
+        return name == 'vs' or name == 'msvc'
 
 class Compiler(compiler.Compiler):
-  def __init__(self, vendor):
-    super(Compiler, self).__init__(vendor)
+    def __init__(self, vendor):
+        super(Compiler, self).__init__(vendor)
 
-  def clone(self):
-    cc = Compiler(self.vendor)
-    cc.inherit(self)
-    return cc
+    def clone(self):
+        cc = Compiler(self.vendor)
+        cc.inherit(self)
+        return cc
 
-  @property
-  def projectFileSuffix(self):
-    # Assume the compiler version is related to the IDE version.
-    if self.version >= 'msvc-1600':
-      return '.vcxproj'
-    if self.version >= 'msvc-1300':
-      return '.vcproj'
-    raise Exception('Unhandled version: {0}'.format(self.version))
+    @property
+    def projectFileSuffix(self):
+        # Assume the compiler version is related to the IDE version.
+        if self.version >= 'msvc-1600':
+            return '.vcxproj'
+        if self.version >= 'msvc-1300':
+            return '.vcproj'
+        raise Exception('Unhandled version: {0}'.format(self.version))
 
-  @staticmethod
-  def GetVersionFromVS(vs_version):
-    vs_version = int(vs_version)
-    msvc_version = (vs_version * 100) + 600
+    @staticmethod
+    def GetVersionFromVS(vs_version):
+        vs_version = int(vs_version)
+        msvc_version = (vs_version * 100) + 600
 
-    # Microsoft skipped version 13, of course.
-    if vs_version >= 14:
-      msvc_version -= 100
-    # In VS 2017, the numbering continues from 1910
-    if vs_version == 15:
-      msvc_version = 1910
-    return msvc_version
+        # Microsoft skipped version 13, of course.
+        if vs_version >= 14:
+            msvc_version -= 100
+        # In VS 2017, the numbering continues from 1910
+        if vs_version == 15:
+            msvc_version = 1910
+        return msvc_version
 
-  def ProgramProject(self, name):
-    return Project(Program, self, name)
+    def ProgramProject(self, name):
+        return Project(Program, self, name)
 
-  def LibraryProject(self, name):
-    return Project(Library, self, name)
+    def LibraryProject(self, name):
+        return Project(Library, self, name)
 
-  def StaticLibraryProject(self, name):
-    return Project(StaticLibrary, self, name)
+    def StaticLibraryProject(self, name):
+        return Project(StaticLibrary, self, name)
 
-  def Program(self, name):
-    return Project(Program, self, name).default()
+    def Program(self, name):
+        return Project(Program, self, name).default()
 
-  def Library(self, name):
-    return Project(Library, self, name).default()
+    def Library(self, name):
+        return Project(Library, self, name).default()
 
-  def StaticLibrary(self, name):
-    return Project(StaticLibrary, self, name).default()
+    def StaticLibrary(self, name):
+        return Project(StaticLibrary, self, name).default()
 
-  def like(self, name):
-    return name == 'msvc'
+    def like(self, name):
+        return name == 'msvc'
 
 class BinaryBuilder(object):
-  def __init__(self, project, compiler, name, tag):
-    super(BinaryBuilder, self).__init__()
-    self.project_ = project
-    self.compiler = compiler
-    self.sources = []
-    self.name_ = name
-    self.tag_ = tag
+    def __init__(self, project, compiler, name, tag):
+        super(BinaryBuilder, self).__init__()
+        self.project_ = project
+        self.compiler = compiler
+        self.sources = []
+        self.name_ = name
+        self.tag_ = tag
 
-  def Dep(self, text, node=None): 
-    return Dep(text, node)
+    def Dep(self, text, node = None):
+        return Dep(text, node)
 
-  @property
-  def localFolder(self):
-    # If this is a one-off binary, we need to make sure its folder name won't
-    # create conflicts.
-    if hasattr(self, 'generate'):
-      return '{0} - {1}'.format(self.name_, self.tag_)
+    @property
+    def localFolder(self):
+        # If this is a one-off binary, we need to make sure its folder name won't
+        # create conflicts.
+        if hasattr(self, 'generate'):
+            return '{0} - {1}'.format(self.name_, self.tag_)
 
-    # Otherwise - we basically expect one project per context.
-    return self.tag_
+        # Otherwise - we basically expect one project per context.
+        return self.tag_
 
-  @property
-  def outputFile(self):
-    return self.buildOutputName(self.name_)
+    @property
+    def outputFile(self):
+        return self.buildOutputName(self.name_)
 
 class Program(BinaryBuilder):
-  def __init__(self, project, compiler, name, tag):
-    super(Program, self).__init__(project, compiler, name, tag)
+    def __init__(self, project, compiler, name, tag):
+        super(Program, self).__init__(project, compiler, name, tag)
 
-  @staticmethod
-  def buildOutputName(name):
-    return '{0}.exe'.format(name)
+    @staticmethod
+    def buildOutputName(name):
+        return '{0}.exe'.format(name)
 
-  @property
-  def type(self):
-    return 'program'
+    @property
+    def type(self):
+        return 'program'
 
-  @property
-  def configurationType(self):
-    return 'Application'
+    @property
+    def configurationType(self):
+        return 'Application'
 
 class Library(BinaryBuilder):
-  def __init__(self, project, compiler, name, tag):
-    super(Library, self).__init__(project, compiler, name, tag)
+    def __init__(self, project, compiler, name, tag):
+        super(Library, self).__init__(project, compiler, name, tag)
 
-  @staticmethod
-  def buildOutputName(name):
-    return '{0}.dll'.format(name)
+    @staticmethod
+    def buildOutputName(name):
+        return '{0}.dll'.format(name)
 
-  @property
-  def type(self):
-    return 'library'
+    @property
+    def type(self):
+        return 'library'
 
-  @property
-  def configurationType(self):
-    return 'DynamicLibrary'
+    @property
+    def configurationType(self):
+        return 'DynamicLibrary'
 
 class StaticLibrary(BinaryBuilder):
-  def __init__(self, project, compiler, name, tag):
-    super(StaticLibrary, self).__init__(project, compiler, name, tag)
+    def __init__(self, project, compiler, name, tag):
+        super(StaticLibrary, self).__init__(project, compiler, name, tag)
 
-  @staticmethod
-  def buildOutputName(name):
-    return '{0}.lib'.format(name)
+    @staticmethod
+    def buildOutputName(name):
+        return '{0}.lib'.format(name)
 
-  @property
-  def type(self):
-    return 'static'
+    @property
+    def type(self):
+        return 'static'
 
-  @property
-  def configurationType(self):
-    return 'StaticLibrary'
+    @property
+    def configurationType(self):
+        return 'StaticLibrary'

--- a/ambuild2/frontend/v2_1/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_1/vs/export_vcxproj.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, re
@@ -21,307 +21,307 @@ from ambuild2.frontend.v2_1.cpp import Dep
 from ambuild2.frontend.v2_1.vs.xmlbuilder import XmlBuilder
 
 def export(node):
-  with open(node.path, 'w') as fp:
-    export_fp(node, fp)
+    with open(node.path, 'w') as fp:
+        export_fp(node, fp)
 
 def export_fp(node, fp):
-  xml = XmlBuilder(fp)
+    xml = XmlBuilder(fp)
 
-  version = node.project.compiler.version
-  if version >= 'msvc-1910':
-    toolsVersion = '15.0'
-  elif version >= 'msvc-1900':
-    toolsVersion = '14.0'
-  elif version >= 'msvc-1800':
-    toolsVersion = '12.0'
-  elif version >= 'msvc-1600':
-    toolsVersion = '4.0'
+    version = node.project.compiler.version
+    if version >= 'msvc-1910':
+        toolsVersion = '15.0'
+    elif version >= 'msvc-1900':
+        toolsVersion = '14.0'
+    elif version >= 'msvc-1800':
+        toolsVersion = '12.0'
+    elif version >= 'msvc-1600':
+        toolsVersion = '4.0'
 
-  scope = xml.block('Project',
-    DefaultTargets = 'Build',
-    ToolsVersion = toolsVersion,
-    xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003'
-  )
-  with scope:
-    export_body(node, xml)
+    scope = xml.block('Project',
+                      DefaultTargets = 'Build',
+                      ToolsVersion = toolsVersion,
+                      xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003')
+    with scope:
+        export_body(node, xml)
 
 def export_body(node, xml):
-  with xml.block('ItemGroup', Label = 'ProjectConfigurations'):
-    export_configuration_headers(node, xml)
+    with xml.block('ItemGroup', Label = 'ProjectConfigurations'):
+        export_configuration_headers(node, xml)
 
-  with xml.block('PropertyGroup', Label = 'Globals'):
-    xml.tag('ProjectGuid', '{{{0}}}'.format(node.uuid))
-    xml.tag('RootNamespace', node.project.name_)
-    xml.tag('Keyword', 'Win32Proj')
-    if node.project.compiler.version >= 'msvc-1910':
-      xml.tag('WindowsTargetPlatformVersion', os.getenv('WindowsSDKVersion', None).rstrip('\\'))
+    with xml.block('PropertyGroup', Label = 'Globals'):
+        xml.tag('ProjectGuid', '{{{0}}}'.format(node.uuid))
+        xml.tag('RootNamespace', node.project.name_)
+        xml.tag('Keyword', 'Win32Proj')
+        if node.project.compiler.version >= 'msvc-1910':
+            xml.tag('WindowsTargetPlatformVersion',
+                    os.getenv('WindowsSDKVersion', None).rstrip('\\'))
 
-  xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.Default.props')
-  export_configuration_properties(node, xml)
+    xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+    export_configuration_properties(node, xml)
 
-  xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.props')
-  with xml.block('ImportGroup', Label = 'ExtensionSettings'):
-    pass
-  export_configuration_user_props(node, xml)
+    xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.props')
+    with xml.block('ImportGroup', Label = 'ExtensionSettings'):
+        pass
+    export_configuration_user_props(node, xml)
 
-  with xml.block('PropertyGroup', Label = "UserMacros"):
-    pass
+    with xml.block('PropertyGroup', Label = "UserMacros"):
+        pass
 
-  with xml.block('PropertyGroup'):
-    export_configuration_paths(node, xml)
+    with xml.block('PropertyGroup'):
+        export_configuration_paths(node, xml)
 
-  for builder in node.project.builders_:
-    with xml.block('ItemDefinitionGroup', Condition = condition_for(builder)):
-      export_configuration_options(node, xml, builder)
+    for builder in node.project.builders_:
+        with xml.block('ItemDefinitionGroup', Condition = condition_for(builder)):
+            export_configuration_options(node, xml, builder)
 
-  export_source_files(node, xml)
+    export_source_files(node, xml)
 
-  xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.cpp.targets')
-  with xml.block('ImportGroup', Label = 'ExtensionTargets'):
-    pass
+    xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.cpp.targets')
+    with xml.block('ImportGroup', Label = 'ExtensionTargets'):
+        pass
 
 def condition_for(builder):
-  full_tag = '{0}|Win32'.format(builder.tag_)
-  return "'$(Configuration)|$(Platform)'=='{0}'".format(full_tag)
+    full_tag = '{0}|Win32'.format(builder.tag_)
+    return "'$(Configuration)|$(Platform)'=='{0}'".format(full_tag)
 
 def export_configuration_headers(node, xml):
-  for builder in node.project.builders_:
-    full_tag = '{0}|Win32'.format(builder.tag_)
-    with xml.block('ProjectConfiguration', Include = full_tag):
-      xml.tag('Configuration', builder.tag_)
-      xml.tag('Platform', 'Win32')
+    for builder in node.project.builders_:
+        full_tag = '{0}|Win32'.format(builder.tag_)
+        with xml.block('ProjectConfiguration', Include = full_tag):
+            xml.tag('Configuration', builder.tag_)
+            xml.tag('Platform', 'Win32')
 
 def export_configuration_properties(node, xml):
-  for builder in node.project.builders_:
-    condition = condition_for(builder)
-    with xml.block('PropertyGroup', Condition = condition, Label = 'Configuration'):
-      xml.tag('ConfigurationType', builder.configurationType)
-      xml.tag('CharacterSet', 'MultiByte')
-      if '/GL' in builder.compiler.cxxflags:
-        xml.tag('WholeProgramOptimization', 'true')
-      
-      version = builder.compiler.version
-      if version >= 'msvc-1910':
-        xml.tag('PlatformToolset', 'v141')
-      elif version >= 'msvc-1900':
-        xml.tag('PlatformToolset', 'v140')
-      elif version >= 'msvc-1800':
-        xml.tag('PlatformToolset', 'v120')
-      elif version >= 'msvc-1700':
-        xml.tag('PlatformToolset', 'v110')
+    for builder in node.project.builders_:
+        condition = condition_for(builder)
+        with xml.block('PropertyGroup', Condition = condition, Label = 'Configuration'):
+            xml.tag('ConfigurationType', builder.configurationType)
+            xml.tag('CharacterSet', 'MultiByte')
+            if '/GL' in builder.compiler.cxxflags:
+                xml.tag('WholeProgramOptimization', 'true')
+
+            version = builder.compiler.version
+            if version >= 'msvc-1910':
+                xml.tag('PlatformToolset', 'v141')
+            elif version >= 'msvc-1900':
+                xml.tag('PlatformToolset', 'v140')
+            elif version >= 'msvc-1800':
+                xml.tag('PlatformToolset', 'v120')
+            elif version >= 'msvc-1700':
+                xml.tag('PlatformToolset', 'v110')
 
 def export_configuration_user_props(node, xml):
-  for builder in node.project.builders_:
-    condition = condition_for(builder)
-    with xml.block('ImportGroup', Condition = condition, Label = 'PropertySheets'):
-      xml.tag('Import',
-        Project = "$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props",
-        Condition = "exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')",
-        Label = "LocalAppDataPlatform"
-      )
-      
+    for builder in node.project.builders_:
+        condition = condition_for(builder)
+        with xml.block('ImportGroup', Condition = condition, Label = 'PropertySheets'):
+            xml.tag('Import',
+                    Project = "$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props",
+                    Condition = "exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')",
+                    Label = "LocalAppDataPlatform")
+
 def export_configuration_paths(node, xml):
-  for builder in node.project.builders_:
-    condition = condition_for(builder)
-    xml.tag('OutDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
-    xml.tag('IntDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
-    if '/INCREMENTAL:NO' not in builder.compiler.linkflags and '/INCREMENTAL:NO' not in builder.compiler.postlink:
-      xml.tag('LinkIncremental', 'true', Condition = condition)
-    xml.tag('TargetName', builder.name_, Condition = condition)
+    for builder in node.project.builders_:
+        condition = condition_for(builder)
+        xml.tag('OutDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
+        xml.tag('IntDir', "$(ProjectName) - $(Configuration)\\", Condition = condition)
+        if '/INCREMENTAL:NO' not in builder.compiler.linkflags and '/INCREMENTAL:NO' not in builder.compiler.postlink:
+            xml.tag('LinkIncremental', 'true', Condition = condition)
+        xml.tag('TargetName', builder.name_, Condition = condition)
 
 def sanitize_val_defines(defines):
-  new_defines = []
-  for option in defines:
-    index = option.find('=')
-    if index == -1:
-      new_defines.append(option)
-      continue
+    new_defines = []
+    for option in defines:
+        index = option.find('=')
+        if index == -1:
+            new_defines.append(option)
+            continue
 
-    key = option[0:index]
-    val = option[index + 1:]
-    if val[0] == '"' and val[-1] == '"':
-      val = '\\"{0}\\"'.format(val)
-    new_defines.append('{0}={1}'.format(key, val))
-  return new_defines
+        key = option[0:index]
+        val = option[index + 1:]
+        if val[0] == '"' and val[-1] == '"':
+            val = '\\"{0}\\"'.format(val)
+        new_defines.append('{0}={1}'.format(key, val))
+    return new_defines
 
 def export_configuration_options(node, xml, builder):
-  compiler = builder.compiler
+    compiler = builder.compiler
 
-  includes = ['%(AdditionalIncludeDirectories)'] + compiler.includes + compiler.cxxincludes
-  all_defines = compiler.defines + compiler.cxxdefines
-  simple_defines = ['%(PreprocessorDefinitions)'] + [option for option in all_defines if '=' not in option]
-  val_defines = ['/D{0}'.format(option) for option in all_defines if '=' in option]
+    includes = ['%(AdditionalIncludeDirectories)'] + compiler.includes + compiler.cxxincludes
+    all_defines = compiler.defines + compiler.cxxdefines
+    simple_defines = ['%(PreprocessorDefinitions)'
+                     ] + [option for option in all_defines if '=' not in option]
+    val_defines = ['/D{0}'.format(option) for option in all_defines if '=' in option]
 
-  with xml.block('ClCompile'):
-    flags = compiler.cflags + compiler.cxxflags
+    with xml.block('ClCompile'):
+        flags = compiler.cflags + compiler.cxxflags
 
-    # Filter out options we handle specially.
-    other_flags = val_defines + flags
-    other_flags = [flag for flag in other_flags if not flag.startswith('/O')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/RTC')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/EH')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/MT')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/MD')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/W')]
-    other_flags = [flag for flag in other_flags if not flag.startswith('/GR')]
+        # Filter out options we handle specially.
+        other_flags = val_defines + flags
+        other_flags = [flag for flag in other_flags if not flag.startswith('/O')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/RTC')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/EH')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/MT')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/MD')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/W')]
+        other_flags = [flag for flag in other_flags if not flag.startswith('/GR')]
 
-    if len(other_flags):
-      xml.tag('AdditionalOptions', ' '.join(other_flags))
+        if len(other_flags):
+            xml.tag('AdditionalOptions', ' '.join(other_flags))
 
-    xml.tag('AdditionalIncludeDirectories', ';'.join(includes))
-    xml.tag('PreprocessorDefinitions', ';'.join(simple_defines))
+        xml.tag('AdditionalIncludeDirectories', ';'.join(includes))
+        xml.tag('PreprocessorDefinitions', ';'.join(simple_defines))
 
-    if '/Ox' in flags:
-      xml.tag('Optimization', 'Full')
-    elif '/O2' in flags:
-      xml.tag('Optimization', 'MaxSpeed')
-    elif '/O1' in flags:
-      xml.tag('Optimization', 'MinSpace')
-    else:
-      xml.tag('Optimization', 'Disabled')
+        if '/Ox' in flags:
+            xml.tag('Optimization', 'Full')
+        elif '/O2' in flags:
+            xml.tag('Optimization', 'MaxSpeed')
+        elif '/O1' in flags:
+            xml.tag('Optimization', 'MinSpace')
+        else:
+            xml.tag('Optimization', 'Disabled')
 
-    if '/Os' in flags:
-      xml.tag('FavorSizeOrSpeed', 'Size')
-    elif '/Ot' in flags:
-      xml.tag('FavorSizeOrSpeed', 'Speed')
+        if '/Os' in flags:
+            xml.tag('FavorSizeOrSpeed', 'Size')
+        elif '/Ot' in flags:
+            xml.tag('FavorSizeOrSpeed', 'Speed')
 
-    xml.tag('MinimalRebuild', 'true')
+        xml.tag('MinimalRebuild', 'true')
 
-    if '/RTC1' in flags or '/RTCsu' in flags:
-      xml.tag('BasicRuntimeChecks', 'EnableFastChecks')
-    elif '/RTCs' in flags:
-      xml.tag('BasicRuntimeChecks', 'StackFrame')
-    elif '/RTCu' in flags:
-      xml.tag('BasicRuntimeChecks', 'UninitVariables')
+        if '/RTC1' in flags or '/RTCsu' in flags:
+            xml.tag('BasicRuntimeChecks', 'EnableFastChecks')
+        elif '/RTCs' in flags:
+            xml.tag('BasicRuntimeChecks', 'StackFrame')
+        elif '/RTCu' in flags:
+            xml.tag('BasicRuntimeChecks', 'UninitVariables')
 
-    if '/Oy-' in flags:
-      xml.tag('OmitFramePointer', 'true')
-    if '/EHsc' in flags:
-      xml.tag('ExceptionHandling', 'Sync')
+        if '/Oy-' in flags:
+            xml.tag('OmitFramePointer', 'true')
+        if '/EHsc' in flags:
+            xml.tag('ExceptionHandling', 'Sync')
 
-    if '/MT' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreaded')
-    elif '/MTd' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreadedDebug')
-    elif '/MD' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreadedDLL')
-    elif '/MDd' in flags:
-      xml.tag('RuntimeLibrary', 'MultiThreadedDebugDLL')
+        if '/MT' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreaded')
+        elif '/MTd' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreadedDebug')
+        elif '/MD' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreadedDLL')
+        elif '/MDd' in flags:
+            xml.tag('RuntimeLibrary', 'MultiThreadedDebugDLL')
 
-    if '/W0' in flags:
-      xml.tag('WarningLevel', 'Level0')
-    elif '/W1' in flags:
-      xml.tag('WarningLevel', 'Level1')
-    elif '/W2' in flags:
-      xml.tag('WarningLevel', 'Level2')
-    elif '/W3' in flags:
-      xml.tag('WarningLevel', 'Level3')
-    elif '/W4' in flags:
-      xml.tag('WarningLevel', 'Level4')
+        if '/W0' in flags:
+            xml.tag('WarningLevel', 'Level0')
+        elif '/W1' in flags:
+            xml.tag('WarningLevel', 'Level1')
+        elif '/W2' in flags:
+            xml.tag('WarningLevel', 'Level2')
+        elif '/W3' in flags:
+            xml.tag('WarningLevel', 'Level3')
+        elif '/W4' in flags:
+            xml.tag('WarningLevel', 'Level4')
 
-    if '/WX' in flags:
-      xml.tag('TreatWarningAsError', 'true')
+        if '/WX' in flags:
+            xml.tag('TreatWarningAsError', 'true')
 
-    if '/Od' in flags:
-      xml.tag('DebugInformationFormat', 'EditAndContinue')
-    else:
-      xml.tag('DebugInformationFormat', 'ProgramDatabase')
+        if '/Od' in flags:
+            xml.tag('DebugInformationFormat', 'EditAndContinue')
+        else:
+            xml.tag('DebugInformationFormat', 'ProgramDatabase')
 
-    if '/GR-' in flags:
-      xml.tag('RuntimeTypeInfo', 'false')
-    elif '/GR' in flags:
-      xml.tag('RuntimeTypeInfo', 'true')
+        if '/GR-' in flags:
+            xml.tag('RuntimeTypeInfo', 'false')
+        elif '/GR' in flags:
+            xml.tag('RuntimeTypeInfo', 'true')
 
-    with xml.block('PrecompiledHeader'):
-      pass
-    xml.tag('MultiProcessorCompilation', 'true')
+        with xml.block('PrecompiledHeader'):
+            pass
+        xml.tag('MultiProcessorCompilation', 'true')
 
-  with xml.block('ResourceCompile'):
-    defines = ['%(PreprocessorDefinitions)'] + compiler.defines + compiler.cxxdefines + compiler.rcdefines
-    defines = sanitize_val_defines(defines)
-    xml.tag('PreprocessorDefinitions', ';'.join(defines))
-    xml.tag('AdditionalIncludeDirectories', ';'.join(includes[1:] + includes[0:1]))
+    with xml.block('ResourceCompile'):
+        defines = ['%(PreprocessorDefinitions)'
+                  ] + compiler.defines + compiler.cxxdefines + compiler.rcdefines
+        defines = sanitize_val_defines(defines)
+        xml.tag('PreprocessorDefinitions', ';'.join(defines))
+        xml.tag('AdditionalIncludeDirectories', ';'.join(includes[1:] + includes[0:1]))
 
-  with xml.block('Link'):
-    link_flags = compiler.linkflags + compiler.postlink
+    with xml.block('Link'):
+        link_flags = compiler.linkflags + compiler.postlink
 
-    # Parse link flags.
-    libs = ['%(AdditionalDependencies)']
-    ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
-    machine = 'X86'
-    subsystem = 'Windows'
-    for flag in link_flags:
-      if util.IsString(flag):
-        if flag == '/SUBSYSTEM:CONSOLE':
-          subsystem = 'Console'
-          continue
+        # Parse link flags.
+        libs = ['%(AdditionalDependencies)']
+        ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
+        machine = 'X86'
+        subsystem = 'Windows'
+        for flag in link_flags:
+            if util.IsString(flag):
+                if flag == '/SUBSYSTEM:CONSOLE':
+                    subsystem = 'Console'
+                    continue
 
-        if '.lib' in flag:
-          libs.append(flag)
-          continue
+                if '.lib' in flag:
+                    libs.append(flag)
+                    continue
 
-        m = re.match('/NODEFAULTLIB:(.+)', flag)
-        if m is not None:
-          ignore_libs.append(m.group(1))
-          continue
+                m = re.match('/NODEFAULTLIB:(.+)', flag)
+                if m is not None:
+                    ignore_libs.append(m.group(1))
+                    continue
 
-        m = re.match('/MACHINE:(.+)', flag)
-        if m is not None:
-          machine = m.group(1)
-      else:
-        libs.append(Dep.resolve(node.context, builder, flag))
+                m = re.match('/MACHINE:(.+)', flag)
+                if m is not None:
+                    machine = m.group(1)
+            else:
+                libs.append(Dep.resolve(node.context, builder, flag))
 
-    if '/WX' in link_flags:
-      xml.tag('TreatLinkerWarningAsErrors', 'true')
+        if '/WX' in link_flags:
+            xml.tag('TreatLinkerWarningAsErrors', 'true')
 
-    xml.tag('AdditionalDependencies', ';'.join(libs))
-    xml.tag('OutputFile', '$(OutDir)$(TargetFileName)')
-    xml.tag('IgnoreSpecificDefaultLibraries', ';'.join(ignore_libs))
-    if compiler.symbol_files is None:
-      xml.tag('GenerateDebugInformation', 'false')
-    else:
-      xml.tag('GenerateDebugInformation', 'true')
-    if '/OPT:REF' in link_flags:
-      xml.tag('OptimizeReferences', 'true')
-    elif '/OPT:NOREF' in link_flags:
-      xml.tag('OptimizeReferences', 'false')
-    if '/OPT:ICF' in link_flags:
-      xml.tag('EnableCOMDATFolding', 'true')
-    elif '/OPT:NOICF' in link_flags:
-      xml.tag('EnableCOMDATFolding', 'true')
-    xml.tag('TargetMachine', 'Machine{0}'.format(machine))
+        xml.tag('AdditionalDependencies', ';'.join(libs))
+        xml.tag('OutputFile', '$(OutDir)$(TargetFileName)')
+        xml.tag('IgnoreSpecificDefaultLibraries', ';'.join(ignore_libs))
+        if compiler.symbol_files is None:
+            xml.tag('GenerateDebugInformation', 'false')
+        else:
+            xml.tag('GenerateDebugInformation', 'true')
+        if '/OPT:REF' in link_flags:
+            xml.tag('OptimizeReferences', 'true')
+        elif '/OPT:NOREF' in link_flags:
+            xml.tag('OptimizeReferences', 'false')
+        if '/OPT:ICF' in link_flags:
+            xml.tag('EnableCOMDATFolding', 'true')
+        elif '/OPT:NOICF' in link_flags:
+            xml.tag('EnableCOMDATFolding', 'true')
+        xml.tag('TargetMachine', 'Machine{0}'.format(machine))
 
 def export_source_files(node, xml):
-  files = {}
-  all_builders = set()
-  for builder in node.project.builders_:
-    for source in builder.sources:
-      file = os.path.join(node.context.currentSourcePath, source)
-      builders = files.setdefault(file, set())
-      builders.add(builder)
-    all_builders.add(builder)
+    files = {}
+    all_builders = set()
+    for builder in node.project.builders_:
+        for source in builder.sources:
+            file = os.path.join(node.context.currentSourcePath, source)
+            builders = files.setdefault(file, set())
+            builders.add(builder)
+        all_builders.add(builder)
 
-  def emit(file, kind):
-    builders = files[file]
-    excluded = all_builders - builders
+    def emit(file, kind):
+        builders = files[file]
+        excluded = all_builders - builders
 
-    if len(excluded) == 0:
-      xml.tag(kind, Include = file)
-      return
+        if len(excluded) == 0:
+            xml.tag(kind, Include = file)
+            return
 
-    with xml.block(kind, Include = file):
-      for builder in excluded:
-        xml.tag('ExcludedFromBuild', 'true', Condition = condition_for(builder))
+        with xml.block(kind, Include = file):
+            for builder in excluded:
+                xml.tag('ExcludedFromBuild', 'true', Condition = condition_for(builder))
 
+    with xml.block('ItemGroup'):
+        for file in files:
+            _, ext = os.path.splitext(file)
+            if ext != '.rc':
+                emit(file, 'ClCompile')
 
-  with xml.block('ItemGroup'):
-    for file in files:
-      _, ext = os.path.splitext(file)
-      if ext != '.rc':
-        emit(file, 'ClCompile')
-
-  with xml.block('ItemGroup'):
-    for file in files:
-      _, ext = os.path.splitext(file)
-      if ext == '.rc':
-        emit(file, 'ResourceCompile')
+    with xml.block('ItemGroup'):
+        for file in files:
+            _, ext = os.path.splitext(file)
+            if ext == '.rc':
+                emit(file, 'ResourceCompile')

--- a/ambuild2/frontend/v2_1/vs/gen.py
+++ b/ambuild2/frontend/v2_1/vs/gen.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os, errno
@@ -25,150 +25,156 @@ from ambuild2.frontend.v2_1.base import BaseGenerator
 
 SupportedVersions = ['10', '11', '12', '14', '15', '16']
 YearMap = {
-  '2010': 10,
-  '2012': 11,
-  '2013': 12,
-  '2015': 14,
-  '2017': 15,
-  '2019': 16,
+    '2010': 10,
+    '2012': 11,
+    '2013': 12,
+    '2015': 14,
+    '2017': 15,
+    '2019': 16,
 }
 
 class Generator(BaseGenerator):
-  def __init__(self, sourcePath, buildPath, originalCwd, options, args):
-    super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
-    self.compiler = None
-    self.vs_version = None
-    self.files_ = {}
-    self.projects_ = set()
+    def __init__(self, sourcePath, buildPath, originalCwd, options, args):
+        super(Generator, self).__init__(sourcePath, buildPath, originalCwd, options, args)
+        self.compiler = None
+        self.vs_version = None
+        self.files_ = {}
+        self.projects_ = set()
 
-    if self.options.vs_version in SupportedVersions:
-      self.vs_version = int(self.options.vs_version)
-    else:
-      if self.options.vs_version not in YearMap:
-        util.con_err(
-          util.ConsoleRed,
-          'Unsupported Visual Studio version: {0}'.format(self.options.vs_version),
-          util.ConsoleNormal
-        )
-        raise Exception('Unsupported Visual Studio version: {0}'.format(self.options.vs_version)) 
-      self.vs_version = YearMap[self.options.vs_version]
+        if self.options.vs_version in SupportedVersions:
+            self.vs_version = int(self.options.vs_version)
+        else:
+            if self.options.vs_version not in YearMap:
+                util.con_err(
+                    util.ConsoleRed,
+                    'Unsupported Visual Studio version: {0}'.format(self.options.vs_version),
+                    util.ConsoleNormal)
+                raise Exception('Unsupported Visual Studio version: {0}'.format(
+                    self.options.vs_version))
+            self.vs_version = YearMap[self.options.vs_version]
 
-    self.cacheFile = os.path.join(self.buildPath, '.cache')
-    try:
-      with open(self.cacheFile, 'rb') as fp:
-        self.vars_ = util.pickle.load(fp)
-    except:
-      self.vars_ = {}
+        self.cacheFile = os.path.join(self.buildPath, '.cache')
+        try:
+            with open(self.cacheFile, 'rb') as fp:
+                self.vars_ = util.pickle.load(fp)
+        except:
+            self.vars_ = {}
 
-    if 'uuids' not in self.vars_:
-      self.vars_['uuids'] = {}
+        if 'uuids' not in self.vars_:
+            self.vars_['uuids'] = {}
 
-    self.target_platform = 'windows'
+        self.target_platform = 'windows'
 
-  # Overridden.
-  @property
-  def backend(self):
-    return 'vs'
+    # Overridden.
+    @property
+    def backend(self):
+        return 'vs'
 
-  # Overridden.
-  def preGenerate(self):
-    pass
+    # Overridden.
+    def preGenerate(self):
+        pass
 
-  # Overriden.
-  def postGenerate(self):
-    self.generateProjects()
-    with open(self.cacheFile, 'wb') as fp:
-      util.DiskPickle(self.vars_, fp)
+    # Overriden.
+    def postGenerate(self):
+        self.generateProjects()
+        with open(self.cacheFile, 'wb') as fp:
+            util.DiskPickle(self.vars_, fp)
 
-  def generateProjects(self):
-    for node in self.projects_:
-      # We cache uuids across runs to keep them consistent.
-      node.uuid = self.vars_['uuids'].get(node.path)
-      if node.uuid is None:
-        node.uuid = str(uuids.uuid1()).upper()
-        self.vars_['uuids'][node.path] = node.uuid
-      node.project.export(node)
+    def generateProjects(self):
+        for node in self.projects_:
+            # We cache uuids across runs to keep them consistent.
+            node.uuid = self.vars_['uuids'].get(node.path)
+            if node.uuid is None:
+                node.uuid = str(uuids.uuid1()).upper()
+                self.vars_['uuids'][node.path] = node.uuid
+            node.project.export(node)
 
-  # Overridden.
-  #
-  # We don't support reconfiguring in this frontend.
-  def addConfigureFile(self, cx, path):
-    pass
+    # Overridden.
+    #
+    # We don't support reconfiguring in this frontend.
+    def addConfigureFile(self, cx, path):
+        pass
 
-  # Overridden.
-  def detectCompilers(self, options):
-    if not self.compiler:
-      version = cxx.Compiler.GetVersionFromVS(self.vs_version)
-      vendor = cxx.VisualStudio(version)
-      self.base_compiler = cxx.Compiler(vendor)
-      self.compiler = self.base_compiler.clone()
-    return self.compiler
+    # Overridden.
+    def detectCompilers(self, options):
+        if not self.compiler:
+            version = cxx.Compiler.GetVersionFromVS(self.vs_version)
+            vendor = cxx.VisualStudio(version)
+            self.base_compiler = cxx.Compiler(vendor)
+            self.compiler = self.base_compiler.clone()
+        return self.compiler
 
-  # Overridden.
-  def enterContext(self, cx):
-    cx.vs_nodes = []
+    # Overridden.
+    def enterContext(self, cx):
+        cx.vs_nodes = []
 
-  # Overridden.
-  def leaveContext(self, cx):
-    pass
+    # Overridden.
+    def leaveContext(self, cx):
+        pass
 
-  def ensureUnique(self, path):
-    if path in self.files_:
-      entry = self.files_[path]
-      util.con_err(
-        util.ConsoleRed, 'Path {0} already exists as: {1}'.format(path, entry.kind),
-        util.ConsoleNormal
-      )
-      raise Exception('Path {0} already exists as: {1}'.format(path, entry.kind))
+    def ensureUnique(self, path):
+        if path in self.files_:
+            entry = self.files_[path]
+            util.con_err(util.ConsoleRed,
+                         'Path {0} already exists as: {1}'.format(path,
+                                                                  entry.kind), util.ConsoleNormal)
+            raise Exception('Path {0} already exists as: {1}'.format(path, entry.kind))
 
-  # Overridden.
-  def getLocalFolder(self, context):
-    if type(context.localFolder_) is nodes.FolderNode or context.localFolder_ is None:
-      return context.localFolder_
+    # Overridden.
+    def getLocalFolder(self, context):
+        if type(context.localFolder_) is nodes.FolderNode or context.localFolder_ is None:
+            return context.localFolder_
 
-    if not len(context.buildFolder):
-      context.localFolder_ = None
-    else:
-      context.localFolder_ = self.addFolder(context.parent, context.buildFolder)
+        if not len(context.buildFolder):
+            context.localFolder_ = None
+        else:
+            context.localFolder_ = self.addFolder(context.parent, context.buildFolder)
 
-    return context.localFolder_
+        return context.localFolder_
 
-  # Overridden.
-  def addFolder(self, cx, folder):
-    parentFolderNode = None
-    if cx is not None:
-      parentFolderNode = cx.localFolder
+    # Overridden.
+    def addFolder(self, cx, folder):
+        parentFolderNode = None
+        if cx is not None:
+            parentFolderNode = cx.localFolder
 
-    _, path = paths.ResolveFolder(parentFolderNode, folder)
-    if path in self.files_:
-      entry = self.files_[path]
-      if type(entry) is not nodes.FolderNode:
-        self.ensureUnique(path) # Will always throw.
-      return entry
+        _, path = paths.ResolveFolder(parentFolderNode, folder)
+        if path in self.files_:
+            entry = self.files_[path]
+            if type(entry) is not nodes.FolderNode:
+                self.ensureUnique(path)  # Will always throw.
+            return entry
 
-    try:
-      os.makedirs(path)
-    except OSError as exn:
-      if not (exn.errno == errno.EEXIST and os.path.isdir(path)):
-        raise
+        try:
+            os.makedirs(path)
+        except OSError as exn:
+            if not (exn.errno == errno.EEXIST and os.path.isdir(path)):
+                raise
 
-    obj = nodes.FolderNode(path)
-    self.files_[path] = obj
-    return obj
+        obj = nodes.FolderNode(path)
+        self.files_[path] = obj
+        return obj
 
-  # Overridden.
-  def addShellCommand(self, context, inputs, argv, outputs, folder=-1, dep_type=None,
-                      weak_inputs=[], shared_outputs=[]):
-    print(inputs, argv, outputs, folder, dep_type, weak_inputs, shared_outputs)
+    # Overridden.
+    def addShellCommand(self,
+                        context,
+                        inputs,
+                        argv,
+                        outputs,
+                        folder = -1,
+                        dep_type = None,
+                        weak_inputs = [],
+                        shared_outputs = []):
+        print(inputs, argv, outputs, folder, dep_type, weak_inputs, shared_outputs)
 
-  def addOutput(self, context, path, parent):
-    self.ensureUnique(path)
+    def addOutput(self, context, path, parent):
+        self.ensureUnique(path)
 
-    node = nodes.OutputNode(context, path, parent)
-    self.files_[path] = node
-    return node
+        node = nodes.OutputNode(context, path, parent)
+        self.files_[path] = node
+        return node
 
-  def addProjectNode(self, context, project):
-    self.ensureUnique(project.path)
-    self.projects_.add(project)
-    self.files_[project.path] = project
+    def addProjectNode(self, context, project):
+        self.ensureUnique(project.path)
+        self.projects_.add(project)
+        self.files_[project.path] = project

--- a/ambuild2/frontend/v2_1/vs/graph.py
+++ b/ambuild2/frontend/v2_1/vs/graph.py
@@ -1,17 +1,16 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
-

--- a/ambuild2/frontend/v2_1/vs/nodes.py
+++ b/ambuild2/frontend/v2_1/vs/nodes.py
@@ -1,63 +1,63 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
 class Node(object):
-  def __init__(self, context, path):
-    super(Node, self).__init__()
-    self.context = context
-    self.path = path
-    self.children = set()
-    self.parents = set()
+    def __init__(self, context, path):
+        super(Node, self).__init__()
+        self.context = context
+        self.path = path
+        self.children = set()
+        self.parents = set()
 
-  def addParent(self, parent):
-    self.parents.add(parent)
-    parent.children.add(self)
+    def addParent(self, parent):
+        self.parents.add(parent)
+        parent.children.add(self)
 
 class FolderNode(Node):
-  def __init__(self, path):
-    super(FolderNode, self).__init__(None, path)
+    def __init__(self, path):
+        super(FolderNode, self).__init__(None, path)
 
-  @property
-  def kind(self):
-    return 'folder'
+    @property
+    def kind(self):
+        return 'folder'
 
 class ContainerNode(Node):
-  def __init__(self, cx):
-    super(ContainerNode, self).__init__(cx, None)
+    def __init__(self, cx):
+        super(ContainerNode, self).__init__(cx, None)
 
-  @property
-  def kind(self):
-    return 'container'
+    @property
+    def kind(self):
+        return 'container'
 
 class OutputNode(Node):
-  def __init__(self, context, path, parent):
-    super(OutputNode, self).__init__(context, path)
-    self.addParent(parent)
+    def __init__(self, context, path, parent):
+        super(OutputNode, self).__init__(context, path)
+        self.addParent(parent)
 
-  @property
-  def kind(self):
-    return 'output'
+    @property
+    def kind(self):
+        return 'output'
 
 class ProjectNode(Node):
-  def __init__(self, context, path, project):
-    super(ProjectNode, self).__init__(context, path)
-    self.project = project
-    self.uuid = None
+    def __init__(self, context, path, project):
+        super(ProjectNode, self).__init__(context, path)
+        self.project = project
+        self.uuid = None
 
-  @property
-  def kind(self):
-    return 'project'
+    @property
+    def kind(self):
+        return 'project'

--- a/ambuild2/frontend/v2_1/vs/xmlbuilder.py
+++ b/ambuild2/frontend/v2_1/vs/xmlbuilder.py
@@ -1,70 +1,70 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
 class XmlScope(object):
-  def __init__(self, builder, tag, **kwargs):
-    self.builder_ = builder
-    self.tag_ = tag
-    self.kwargs_ = kwargs
+    def __init__(self, builder, tag, **kwargs):
+        self.builder_ = builder
+        self.tag_ = tag
+        self.kwargs_ = kwargs
 
-  def __enter__(self):
-    self.builder_.enter(self.tag_, **self.kwargs_)
+    def __enter__(self):
+        self.builder_.enter(self.tag_, **self.kwargs_)
 
-  def __exit__(self, type, value, traceback):
-    self.builder_.leave(self.tag_)
+    def __exit__(self, type, value, traceback):
+        self.builder_.leave(self.tag_)
 
 class XmlBuilder(object):
-  def __init__(self, fp, version="1.0", encoding="utf-8"):
-    super(XmlBuilder, self).__init__()
-    self.fp_ = fp
-    self.indent_ = 0
-    self.write('<?xml version="{0}" encoding="{1}"?>'.format(version, encoding))
+    def __init__(self, fp, version = "1.0", encoding = "utf-8"):
+        super(XmlBuilder, self).__init__()
+        self.fp_ = fp
+        self.indent_ = 0
+        self.write('<?xml version="{0}" encoding="{1}"?>'.format(version, encoding))
 
-  def block(self, tag, **kwargs):
-    return XmlScope(self, tag, **kwargs)
+    def block(self, tag, **kwargs):
+        return XmlScope(self, tag, **kwargs)
 
-  def tag(self, tag, contents = None, **kwargs):
-    open = self.build_element(tag, **kwargs)
-    if contents is None:
-      self.write('<{0} />'.format(open))
-    else:
-      self.write('<{0}>{1}</{2}>'.format(open, contents, tag))
+    def tag(self, tag, contents = None, **kwargs):
+        open = self.build_element(tag, **kwargs)
+        if contents is None:
+            self.write('<{0} />'.format(open))
+        else:
+            self.write('<{0}>{1}</{2}>'.format(open, contents, tag))
 
-  # Internal.
-  def enter(self, tag, **kwargs):
-    elt = self.build_element(tag, **kwargs)
-    self.write('<{0}>'.format(elt))
-    self.indent_ += 1
+    # Internal.
+    def enter(self, tag, **kwargs):
+        elt = self.build_element(tag, **kwargs)
+        self.write('<{0}>'.format(elt))
+        self.indent_ += 1
 
-  def leave(self, tag):
-    self.indent_ -= 1
-    self.write('</{0}>'.format(tag))
+    def leave(self, tag):
+        self.indent_ -= 1
+        self.write('</{0}>'.format(tag))
 
-  def build_element(self, tag, **kwargs):
-    if len(kwargs) == 0:
-      return '{0}'.format(tag)
+    def build_element(self, tag, **kwargs):
+        if len(kwargs) == 0:
+            return '{0}'.format(tag)
 
-    props = []
-    for key in kwargs:
-      props.append('{0}="{1}"'.format(key, kwargs[key]))
-    attrs = ' '.join(props)
-    return '{0} {1}'.format(tag, attrs)
+        props = []
+        for key in kwargs:
+            props.append('{0}="{1}"'.format(key, kwargs[key]))
+        attrs = ' '.join(props)
+        return '{0} {1}'.format(tag, attrs)
 
-  def write(self, line):
-    self.fp_.write('  ' * self.indent_)
-    self.fp_.write(line)
-    self.fp_.write('\n')
+    def write(self, line):
+        self.fp_.write('  ' * self.indent_)
+        self.fp_.write(line)
+        self.fp_.write('\n')

--- a/ambuild2/frontend/version.py
+++ b/ambuild2/frontend/version.py
@@ -1,87 +1,87 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from ambuild2 import util
 
 class Version(object):
-  def __init__(self, string):
-    super(Version, self).__init__()
-    if type(string) is int:
-      self.string = str(string)
-      self.vendor_name = None
-      self.components = [string]
-    else:
-      self.string = string
-      self.vendor_name, self.components = Version.split(string)
+    def __init__(self, string):
+        super(Version, self).__init__()
+        if type(string) is int:
+            self.string = str(string)
+            self.vendor_name = None
+            self.components = [string]
+        else:
+            self.string = string
+            self.vendor_name, self.components = Version.split(string)
 
-  def __str__(self):
-    return self.string
+    def __str__(self):
+        return self.string
 
-  @staticmethod
-  def split(string):
-    vendor_pos = string.rfind('-')
-    if vendor_pos != -1:
-      vendor_name = string[:vendor_pos]
-      version = string[vendor_pos+1:]
-    else:
-      vendor_name = None
-      version = string
-    return vendor_name, [int(part) for part in version.split('.')]
+    @staticmethod
+    def split(string):
+        vendor_pos = string.rfind('-')
+        if vendor_pos != -1:
+            vendor_name = string[:vendor_pos]
+            version = string[vendor_pos + 1:]
+        else:
+            vendor_name = None
+            version = string
+        return vendor_name, [int(part) for part in version.split('.')]
 
-  def __eq__(self, other):
-    result = self.cmp_base(other)
-    return result is not None and result == 0
+    def __eq__(self, other):
+        result = self.cmp_base(other)
+        return result is not None and result == 0
 
-  def __ne__(self, other):
-    result = self.cmp_base(other)
-    return result is None or result != 0
+    def __ne__(self, other):
+        result = self.cmp_base(other)
+        return result is None or result != 0
 
-  def __le__(self, other):
-    result = self.cmp_base(other)
-    return result is not None and result <= 0
+    def __le__(self, other):
+        result = self.cmp_base(other)
+        return result is not None and result <= 0
 
-  def __lt__(self, other):
-    result = self.cmp_base(other)
-    return result is not None and result < 0
+    def __lt__(self, other):
+        result = self.cmp_base(other)
+        return result is not None and result < 0
 
-  def __gt__(self, other):
-    result = self.cmp_base(other)
-    return result is not None and result > 0
+    def __gt__(self, other):
+        result = self.cmp_base(other)
+        return result is not None and result > 0
 
-  def __ge__(self, other):
-    result = self.cmp_base(other)
-    return result is not None and result >= 0
+    def __ge__(self, other):
+        result = self.cmp_base(other)
+        return result is not None and result >= 0
 
-  @staticmethod
-  def parse(other):
-    if hasattr(other, 'components'):
-      components = other.components
-      return getattr(other, 'vendor', None), other.components
-    if type(other) is int:
-      components = [other]
-      return None, components
-    return Version.split(str(other))
+    @staticmethod
+    def parse(other):
+        if hasattr(other, 'components'):
+            components = other.components
+            return getattr(other, 'vendor', None), other.components
+        if type(other) is int:
+            components = [other]
+            return None, components
+        return Version.split(str(other))
 
-  def cmp_base(self, other):
-    vendor_name, components = Version.parse(other)
+    def cmp_base(self, other):
+        vendor_name, components = Version.parse(other)
 
-    # If this version or the other version doesn't care about the vendor name,
-    # then return an ok comparison for compatibility. Otherwise, the vendor
-    # names must match.
-    if vendor_name is not None and self.vendor_name is not None:
-      if vendor_name != self.vendor_name:
-        return None
-    return util.compare(self.components, components)
+        # If this version or the other version doesn't care about the vendor name,
+        # then return an ok comparison for compatibility. Otherwise, the vendor
+        # names must match.
+        if vendor_name is not None and self.vendor_name is not None:
+            if vendor_name != self.vendor_name:
+                return None
+        return util.compare(self.components, components)

--- a/ambuild2/graph.py
+++ b/ambuild2/graph.py
@@ -1,142 +1,142 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from ambuild2 import nodetypes
 
 class GraphNode(object):
-  def __init__(self, entry):
-    self.entry = entry
-    self.incoming = set()
-    self.outgoing = set()
-    self.outputs = set()
-    self.is_command = entry.isCommand()
+    def __init__(self, entry):
+        self.entry = entry
+        self.incoming = set()
+        self.outgoing = set()
+        self.outputs = set()
+        self.is_command = entry.isCommand()
 
-  @property
-  def type(self):
-    return self.entry.type
+    @property
+    def type(self):
+        return self.entry.type
 
-  def isCommand(self):
-    return self.is_command
+    def isCommand(self):
+        return self.is_command
 
 class Graph(object):
-  def __init__(self, database):
-    self.db = database
-    self.node_map = {}
-    self.node_list = []
-    self.worklist = []
-    self.create = []
+    def __init__(self, database):
+        self.db = database
+        self.node_map = {}
+        self.node_list = []
+        self.worklist = []
+        self.create = []
 
-  def importEntry(self, entry):
-    assert entry not in self.node_map
+    def importEntry(self, entry):
+        assert entry not in self.node_map
 
-    graph_node = GraphNode(entry)
-    self.node_map[entry] = graph_node
-    self.node_list.append(graph_node)
-    self.worklist.append(graph_node)
-    return graph_node
+        graph_node = GraphNode(entry)
+        self.node_map[entry] = graph_node
+        self.node_list.append(graph_node)
+        self.worklist.append(graph_node)
+        return graph_node
 
-  def addEntry(self, entry):
-    if entry in self.node_map:
-      return self.node_map[entry]
+    def addEntry(self, entry):
+        if entry in self.node_map:
+            return self.node_map[entry]
 
-    return self.importEntry(entry)
+        return self.importEntry(entry)
 
-  def addEdge(self, from_node, to_node):
-    from_node.outgoing.add(to_node)
-    to_node.incoming.add(from_node)
+    def addEdge(self, from_node, to_node):
+        from_node.outgoing.add(to_node)
+        to_node.incoming.add(from_node)
 
-  def addEdgeToEntry(self, from_node, to_entry):
-    if to_entry not in self.node_map:
-      to_node = self.importEntry(to_entry)
-    else:
-      to_node = self.node_map[to_entry]
-    self.addEdge(from_node, to_node)
+    def addEdgeToEntry(self, from_node, to_entry):
+        if to_entry not in self.node_map:
+            to_node = self.importEntry(to_entry)
+        else:
+            to_node = self.node_map[to_entry]
+        self.addEdge(from_node, to_node)
 
-  def integrate(self):
-    while len(self.worklist):
-      node = self.worklist.pop()
+    def integrate(self):
+        while len(self.worklist):
+            node = self.worklist.pop()
 
-      for child_entry in self.db.query_outgoing(node.entry):
-        self.addEdgeToEntry(node, child_entry)
+            for child_entry in self.db.query_outgoing(node.entry):
+                self.addEdgeToEntry(node, child_entry)
 
-  def complete_ordering(self):
-    for node in self.node_list:
-      if not node.isCommand():
-        continue
+    def complete_ordering(self):
+        for node in self.node_list:
+            if not node.isCommand():
+                continue
 
-      for weak_input in self.db.query_weak_inputs(node.entry):
-        if weak_input not in self.node_map:
-          continue
-        dep = self.node_map[weak_input]
-        dep.outgoing.add(node)
-        node.incoming.add(dep)
+            for weak_input in self.db.query_weak_inputs(node.entry):
+                if weak_input not in self.node_map:
+                    continue
+                dep = self.node_map[weak_input]
+                dep.outgoing.add(node)
+                node.incoming.add(dep)
 
-  # We should try to get rid of this algorithm; it's very expensive and not
-  # really needed if we just include non-command nodes in the compressed
-  # version of the graph.
-  def filter_commands(self):
-    worklist = [node for node in self.node_list if not node.isCommand()]
-    for node in worklist:
-      for output in node.outgoing:
-        output.incoming.remove(node)
-        output_delta = node.incoming - output.incoming
-        output.incoming |= output_delta
-        for x in output_delta:
-          x.outgoing.add(output)
+    # We should try to get rid of this algorithm; it's very expensive and not
+    # really needed if we just include non-command nodes in the compressed
+    # version of the graph.
+    def filter_commands(self):
+        worklist = [node for node in self.node_list if not node.isCommand()]
+        for node in worklist:
+            for output in node.outgoing:
+                output.incoming.remove(node)
+                output_delta = node.incoming - output.incoming
+                output.incoming |= output_delta
+                for x in output_delta:
+                    x.outgoing.add(output)
 
-      for input in node.incoming:
-        input.outgoing.remove(node)
-        input_delta = node.outgoing - input.outgoing
-        input.outgoing |= input_delta
-        for x in input_delta:
-          x.incoming.add(input)
+            for input in node.incoming:
+                input.outgoing.remove(node)
+                input_delta = node.outgoing - input.outgoing
+                input.outgoing |= input_delta
+                for x in input_delta:
+                    x.incoming.add(input)
 
-    self.node_list = [node for node in self.node_list if node.isCommand()]
+        self.node_list = [node for node in self.node_list if node.isCommand()]
 
-  def finish(self):
-    self.integrate()
-    self.complete_ordering()
-    self.node_map = None
+    def finish(self):
+        self.integrate()
+        self.complete_ordering()
+        self.node_map = None
 
-  @property
-  def leafs(self):
-    return [node for node in self.node_list if not len(node.incoming)]
+    @property
+    def leafs(self):
+        return [node for node in self.node_list if not len(node.incoming)]
 
-  def for_each_child_of(self, node, callback):
-    for outgoing in node.outgoing:
-      if outgoing.isCommand():
-        callback(outgoing.entry)
-      else:
-        self.for_each_child_of(outgoing, callback)
+    def for_each_child_of(self, node, callback):
+        for outgoing in node.outgoing:
+            if outgoing.isCommand():
+                callback(outgoing.entry)
+            else:
+                self.for_each_child_of(outgoing, callback)
 
-  def for_each_leaf_command(self, callback):
-    for node in self.leafs:
-      if node.isCommand():
-        callback(node.entry)
-      else:
-        self.for_each_child_of(node, callback)
+    def for_each_leaf_command(self, callback):
+        for node in self.leafs:
+            if node.isCommand():
+                callback(node.entry)
+            else:
+                self.for_each_child_of(node, callback)
 
-  def printGraph(self):
-    for entry in self.create:
-      print(' : ' + entry.format())
+    def printGraph(self):
+        for entry in self.create:
+            print(' : ' + entry.format())
 
-    def printNode(node, indent):
-      print((' ' * indent) + ' - ' + node.entry.format())
-      for incoming in node.incoming:
-        printNode(incoming, indent + 1)
+        def printNode(node, indent):
+            print((' ' * indent) + ' - ' + node.entry.format())
+            for incoming in node.incoming:
+                printNode(incoming, indent + 1)
 
-    for node in [node for node in self.node_list if not len(node.incoming)]:
-      printNode(node, 0)
+        for node in [node for node in self.node_list if not len(node.incoming)]:
+            printNode(node, 0)

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import os
@@ -65,26 +65,26 @@ Cxx = 'cxx'
 Rc = 'rc'
 
 NodeNames = {
-  Source: 'source',
-  Command: 'command',
-  Output: 'output',
-  SharedOutput: 'output',
-  Mkdir: 'mkdir',
-  Copy: 'copy',
-  CopyFolder: 'copy -R',
-  Symlink: 'symlink',
-  Cxx: 'c++',
-  Rc: 'rc'
+    Source: 'source',
+    Command: 'command',
+    Output: 'output',
+    SharedOutput: 'output',
+    Mkdir: 'mkdir',
+    Copy: 'copy',
+    CopyFolder: 'copy -R',
+    Symlink: 'symlink',
+    Cxx: 'c++',
+    Rc: 'rc'
 }
 
 def IsFile(type):
-  return type == Output or type == Source
+    return type == Output or type == Source
 
 def IsCommand(type):
-  return type != Output and type != Source
+    return type != Output and type != Source
 
 def HasAutoDependencies(type):
-  return type == CopyFolder or type == Cxx
+    return type == CopyFolder or type == Cxx
 
 NOT_DIRTY = 0
 DIRTY = 1
@@ -92,118 +92,122 @@ ALWAYS_DIRTY = 2
 
 # The basic properties of a node as it exists in the database.
 class Entry(object):
-  def __init__(self, id, type, path, blob, folder, stamp, dirty):
-    # Unique node ID (integer)
-    self.id = id
+    def __init__(self, id, type, path, blob, folder, stamp, dirty):
+        # Unique node ID (integer)
+        self.id = id
 
-    # Node type, from above.
-    self.type = type
+        # Node type, from above.
+        self.type = type
 
-    # For source nodes, this is an absolute path to the source file.
-    # For output nodes, this is a path relative to the build folder.
-    # For command nodes, it is available as an arbitrary string, which is
-    # included in testing node equivalency when merging graphs.
-    #
-    # It is expected that when paths are not NULL, they are unique.
-    self.path = path
+        # For source nodes, this is an absolute path to the source file.
+        # For output nodes, this is a path relative to the build folder.
+        # For command nodes, it is available as an arbitrary string, which is
+        # included in testing node equivalency when merging graphs.
+        #
+        # It is expected that when paths are not NULL, they are unique.
+        self.path = path
 
-    # Command nodes may have extra data associated with them; this is
-    # usually an argv serialized by Python.
-    self.blob = blob
+        # Command nodes may have extra data associated with them; this is
+        # usually an argv serialized by Python.
+        self.blob = blob
 
-    # For command nodes, this is a link to a 'Mkdir' node describing its
-    # working directory.
-    self.folder = folder
+        # For command nodes, this is a link to a 'Mkdir' node describing its
+        # working directory.
+        self.folder = folder
 
-    # Last modification time.
-    self.stamp = stamp
+        # Last modification time.
+        self.stamp = stamp
 
-    # See the DIRTY values above.
-    self.dirty = dirty
+        # See the DIRTY values above.
+        self.dirty = dirty
 
-    # If not None, a ToolsEnv that has environment information for running
-    # commands.
-    self.tools_env = None
+        # If not None, a ToolsEnv that has environment information for running
+        # commands.
+        self.tools_env = None
 
-    #########################################
-    # Remaining fields are lazily computed. #
-    #########################################
+        #########################################
+        # Remaining fields are lazily computed. #
+        #########################################
 
-    # Strong inputs are used to force updates. Dynamic inputs force updates,
-    # but are added and removed as dependencies change. Weak updates do not
-    # force updates, but only ordering.
-    self.strong_inputs = None
-    self.dynamic_inputs = None
-    self.weak_inputs = None
+        # Strong inputs are used to force updates. Dynamic inputs force updates,
+        # but are added and removed as dependencies change. Weak updates do not
+        # force updates, but only ordering.
+        self.strong_inputs = None
+        self.dynamic_inputs = None
+        self.weak_inputs = None
 
-    self.outgoing = None
+        self.outgoing = None
 
-  def isCommand(self):
-    return IsCommand(self.type)
+    def isCommand(self):
+        return IsCommand(self.type)
 
-  def isFile(self):
-    return IsFile(self.type)
+    def isFile(self):
+        return IsFile(self.type)
 
-  @property
-  def folder_name(self):
-    if not self.folder:
-      return ''
-    return self.folder.path
+    @property
+    def folder_name(self):
+        if not self.folder:
+            return ''
+        return self.folder.path
 
-  def format(self):
-    if self.type == Source or self.type == Output or self.type == SharedOutput:
-      return self.path
-    text = ''
-    if self.type == Mkdir:
-      return 'mkdir -p ' + self.path
-    if self.type == Symlink:
-      return 'ln -s "{0}" "{1}"'.format(self.blob[0], os.path.join(self.folder_name, self.blob[1]))
-    if self.type == Copy:
-      return 'cp "{0}" "{1}"'.format(self.blob[0], os.path.join(self.folder_name, self.blob[1]))
-    if self.type == Cxx:
-      return '[' + self.blob['type'] + ']' + ' -> ' + (' '.join([arg for arg in self.blob['argv']]))
-    if self.type == Rc:
-      return ' '.join([arg for arg in self.blob['cl_argv']]) + ' && ' + ' '.join([arg for arg in self.blob['rc_argv']])
-    return (' '.join([arg for arg in self.blob]))
+    def format(self):
+        if self.type == Source or self.type == Output or self.type == SharedOutput:
+            return self.path
+        text = ''
+        if self.type == Mkdir:
+            return 'mkdir -p ' + self.path
+        if self.type == Symlink:
+            return 'ln -s "{0}" "{1}"'.format(self.blob[0],
+                                              os.path.join(self.folder_name, self.blob[1]))
+        if self.type == Copy:
+            return 'cp "{0}" "{1}"'.format(self.blob[0], os.path.join(self.folder_name,
+                                                                      self.blob[1]))
+        if self.type == Cxx:
+            return '[' + self.blob['type'] + ']' + ' -> ' + (' '.join(
+                [arg for arg in self.blob['argv']]))
+        if self.type == Rc:
+            return ' '.join([arg for arg in self.blob['cl_argv']]) + ' && ' + ' '.join(
+                [arg for arg in self.blob['rc_argv']])
+        return (' '.join([arg for arg in self.blob]))
 
 def combine(a, b):
-  if type(a) is Entry:
-    text_a = a.path
-  else:
-    text_a = a
-  if type(b) is Entry:
-    text_b = b.path
-  else:
-    if not len(b):
-      return text_a
-    text_b = b
-  if not text_a:
-    return text_b
-  return os.path.join(text_a, text_b)
+    if type(a) is Entry:
+        text_a = a.path
+    else:
+        text_a = a
+    if type(b) is Entry:
+        text_b = b.path
+    else:
+        if not len(b):
+            return text_a
+        text_b = b
+    if not text_a:
+        return text_b
+    return os.path.join(text_a, text_b)
 
 # Helper class for reading env_data objects in the database. This cannot modify
 # the underlying environment data.
 class ToolsEnv(object):
-  def __init__(self, env_id, env_data):
-    self.env_id = env_id
-    self.env_data = env_data # Source of truth for equality testing.
-    self.env_cmds = None
-    self.tools = {}
+    def __init__(self, env_id, env_data):
+        self.env_id = env_id
+        self.env_data = env_data  # Source of truth for equality testing.
+        self.env_cmds = None
+        self.tools = {}
 
-    for name, data in env_data:
-      if name == 'env_cmds':
-        self.env_cmds = data
-      elif name == 'tools':
-        for tool_name, tool_path in data:
-          self.tools[tool_name] = tool_path
+        for name, data in env_data:
+            if name == 'env_cmds':
+                self.env_cmds = data
+            elif name == 'tools':
+                for tool_name, tool_path in data:
+                    self.tools[tool_name] = tool_path
 
 # This compares a ToolsEnv to an env_data tuple. Any other combination is not
 # a legal comparison.
 def IsSameEnvData(tools_env, env_data):
-  if tools_env is None:
-    return env_data is None
-  if env_data is None:
-    return tools_env is None
-  if id(tools_env.env_data) == id(env_data):
-    return True
-  return tools_env.env_data == env_data
+    if tools_env is None:
+        return env_data is None
+    if env_data is None:
+        return tools_env is None
+    if id(tools_env.env_data) == id(env_data):
+        return True
+    return tools_env.env_data == env_data

--- a/ambuild2/process_manager.py
+++ b/ambuild2/process_manager.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import errno
@@ -21,234 +21,236 @@ import platform
 import select
 import sys
 try:
-  import _winapi
+    import _winapi
 except:
-  _winapi = None
+    _winapi = None
 
 # Inherit this to make a child process's main function.
 class MessageReceiver(object):
-  def __init__(self, channel):
-    self.channel = channel
-    self.active_ = True
+    def __init__(self, channel):
+        self.channel = channel
+        self.active_ = True
 
-  def pump(self):
-    try:
-      self.pump_impl()
-    except KeyboardInterrupt:
-      sys.exit(1)
+    def pump(self):
+        try:
+            self.pump_impl()
+        except KeyboardInterrupt:
+            sys.exit(1)
 
-  def pump_impl(self):
-    while self.active_:
-      obj = self.channel.recv()
-      if obj['id'] == 'stop':
-        self.onShutdown()
-        return True
+    def pump_impl(self):
+        while self.active_:
+            obj = self.channel.recv()
+            if obj['id'] == 'stop':
+                self.onShutdown()
+                return True
 
-      if obj['id'] not in self.messageMap:
-        raise Exception('Unhandled message: {}'.format(obj['id']))
-      self.messageMap[obj['id']](self, obj)
+            if obj['id'] not in self.messageMap:
+                raise Exception('Unhandled message: {}'.format(obj['id']))
+            self.messageMap[obj['id']](self, obj)
 
-  def halt_pump(self):
-    self.active_ = False
+    def halt_pump(self):
+        self.active_ = False
 
 class Channel(object):
-  def __init__(self, sender, receiver):
-    self.sender_ = sender
-    self.receiver_ = receiver
+    def __init__(self, sender, receiver):
+        self.sender_ = sender
+        self.receiver_ = receiver
 
-  def send(self, obj):
-    return self.sender_.send(obj)
+    def send(self, obj):
+        return self.sender_.send(obj)
 
-  def recv(self):
-    return self.receiver_.recv()
+    def recv(self):
+        return self.receiver_.recv()
 
-  def close(self):
-    self.sender_.close()
-    self.receiver_.close()
+    def close(self):
+        self.sender_.close()
+        self.receiver_.close()
 
-  @property
-  def poll_handle(self):
-    return self.receiver_.fileno()
+    @property
+    def poll_handle(self):
+        return self.receiver_.fileno()
 
-  @property
-  def poll_pipe(self):
-    return self.receiver_
+    @property
+    def poll_pipe(self):
+        return self.receiver_
 
 # Universal main for child processes.
 def child_main(target, channel, *args):
-  obj = target(channel, *args)
-  if obj.pump():
-    sys.exit(0)
-  else:
-    sys.exit(1)
+    obj = target(channel, *args)
+    if obj.pump():
+        sys.exit(0)
+    else:
+        sys.exit(1)
 
 # Wrapper around the parent process's view of a child.
 class ProcessHost(object):
-  def __init__(self):
-    self.proc = None
-    self.channel = None
+    def __init__(self):
+        self.proc = None
+        self.channel = None
 
-  def spawn(self, target, args):
-    parent_send, child_recv = mp.Pipe()
-    parent_recv, child_send = mp.Pipe()
+    def spawn(self, target, args):
+        parent_send, child_recv = mp.Pipe()
+        parent_recv, child_send = mp.Pipe()
 
-    self.channel = Channel(parent_send, parent_recv)
-    child_channel = Channel(child_send, child_recv)
+        self.channel = Channel(parent_send, parent_recv)
+        child_channel = Channel(child_send, child_recv)
 
-    full_args = (target, child_channel) + args
-    self.proc = mp.Process(target = child_main, args = full_args)
-    self.proc.start()
+        full_args = (target, child_channel) + args
+        self.proc = mp.Process(target = child_main, args = full_args)
+        self.proc.start()
 
-  @property
-  def pid(self):
-    return self.proc.pid
+    @property
+    def pid(self):
+        return self.proc.pid
 
 class ProcessManager(object):
-  def __init__(self):
-    self.tasks_ = mp.Queue()
-    self.children_ = []
+    def __init__(self):
+        self.tasks_ = mp.Queue()
+        self.children_ = []
 
-  def spawn(self, target, args):
-    child = ProcessHost()
-    child.spawn(target, args)
-    self.children_.append(child)
-    return child
+    def spawn(self, target, args):
+        child = ProcessHost()
+        child.spawn(target, args)
+        self.children_.append(child)
+        return child
 
-  def shutdown(self):
-    self.close_all_children()
+    def shutdown(self):
+        self.close_all_children()
 
-  def close_all_children(self):
-    for child in self.children_:
-      try:
-        child.channel.send({
-          'id': 'stop',
-        })
-        child.channel.close()
-      except:
-        pass
+    def close_all_children(self):
+        for child in self.children_:
+            try:
+                child.channel.send({
+                    'id': 'stop',
+                })
+                child.channel.close()
+            except:
+                pass
 
-    for child in self.children_:
-      child.proc.join()
-    self.children_ = []
+        for child in self.children_:
+            child.proc.join()
+        self.children_ = []
 
 class ChannelPollerBase(object):
-  def __init__(self, cx, procs):
-    self.cx_ = cx
-    self.procs_ = procs[:]
+    def __init__(self, cx, procs):
+        self.cx_ = cx
+        self.procs_ = procs[:]
 
 # If available, use native Python 3.3+ support for multiplexing.
 if hasattr(mp, 'connection') and hasattr(mp.connection, 'wait'):
-  class ChannelPoller(ChannelPollerBase):
-    def __init__(self, cx, procs):
-      super(ChannelPoller, self).__init__(cx, procs)
-      self.map_ = {}
-      self.pipes_ = None
 
-    def __enter__(self):
-      for proc in self.procs_:
-        self.map_[proc.channel.poll_pipe] = proc
-      self.pipes_ = [proc.channel.poll_pipe for proc in self.procs_]
-      return self
+    class ChannelPoller(ChannelPollerBase):
+        def __init__(self, cx, procs):
+            super(ChannelPoller, self).__init__(cx, procs)
+            self.map_ = {}
+            self.pipes_ = None
 
-    def poll(self):
-      ready = mp.connection.wait(self.pipes_)
-      proc = self.map_[ready[0]]
-      return proc, proc.channel.recv()
+        def __enter__(self):
+            for proc in self.procs_:
+                self.map_[proc.channel.poll_pipe] = proc
+            self.pipes_ = [proc.channel.poll_pipe for proc in self.procs_]
+            return self
 
-    def __exit__(self, type, value, traceback):
-      pass
+        def poll(self):
+            ready = mp.connection.wait(self.pipes_)
+            proc = self.map_[ready[0]]
+            return proc, proc.channel.recv()
+
+        def __exit__(self, type, value, traceback):
+            pass
 
 # Windows does not allow WaitForMultipleObjects on a pipe, we'd need to use
 # IO completion ports. I can't get ReOpenFile() to work, so we do something
 # extremely gross: spawn a bunch of threads.
 elif platform.system() == 'Windows':
-  import collections
-  import threading
+    import collections
+    import threading
 
-  def wait_on_pipe(poller, proc):
-    try:
-      while True:
-        obj = proc.channel.recv()
-        poller.on_receive(proc, obj)
-    except:
-      poller.on_receive(proc, None)
+    def wait_on_pipe(poller, proc):
+        try:
+            while True:
+                obj = proc.channel.recv()
+                poller.on_receive(proc, obj)
+        except:
+            poller.on_receive(proc, None)
 
-  class ChannelPoller(ChannelPollerBase):
-    def __init__(self, cx, procs):
-      super(ChannelPoller, self).__init__(cx, procs)
-      self.closing_ = False
-      self.threads_ = []
-      self.lock_ = threading.RLock()
-      self.cv_ = threading.Condition(self.lock_)
-      self.queue_ = collections.deque()
+    class ChannelPoller(ChannelPollerBase):
+        def __init__(self, cx, procs):
+            super(ChannelPoller, self).__init__(cx, procs)
+            self.closing_ = False
+            self.threads_ = []
+            self.lock_ = threading.RLock()
+            self.cv_ = threading.Condition(self.lock_)
+            self.queue_ = collections.deque()
 
-    def __enter__(self):
-      for proc in self.procs_:
-        thread = threading.Thread(target = wait_on_pipe,
-                                  name = "Pipe Waiter",
-                                  args = (self, proc))
-        self.threads_.append(thread)
-      for thread in self.threads_:
-        thread.start()
-      return self
+        def __enter__(self):
+            for proc in self.procs_:
+                thread = threading.Thread(target = wait_on_pipe,
+                                          name = "Pipe Waiter",
+                                          args = (self, proc))
+                self.threads_.append(thread)
+            for thread in self.threads_:
+                thread.start()
+            return self
 
-    def poll(self):
-      with self.cv_:
-        while len(self.queue_) == 0:
-          self.cv_.wait()
-          continue
-        proc, obj = self.queue_.popleft()
+        def poll(self):
+            with self.cv_:
+                while len(self.queue_) == 0:
+                    self.cv_.wait()
+                    continue
+                proc, obj = self.queue_.popleft()
 
-        if obj is None:
-          raise EOFError('Process {} pipe closed'.format(proc.pid))
+                if obj is None:
+                    raise EOFError('Process {} pipe closed'.format(proc.pid))
 
-      return proc, obj
+            return proc, obj
 
-    def on_receive(self, proc, obj):
-      with self.cv_:
-        if not self.closing_:
-          self.queue_.append((proc, obj))
-          self.cv_.notify_all()
+        def on_receive(self, proc, obj):
+            with self.cv_:
+                if not self.closing_:
+                    self.queue_.append((proc, obj))
+                    self.cv_.notify_all()
 
-    def __exit__(self, type, value, traceback):
-      with self.cv_:
-        self.closing_ = True
+        def __exit__(self, type, value, traceback):
+            with self.cv_:
+                self.closing_ = True
 
-      # This is a hack, but it's the easiest way to ensure that worker
-      # processes won't throw a broken pipe exception.
-      self.cx_.procman.close_all_children()
+            # This is a hack, but it's the easiest way to ensure that worker
+            # processes won't throw a broken pipe exception.
+            self.cx_.procman.close_all_children()
 
-      # Force pipes to close to terminate threads
-      for proc in self.procs_:
-        proc.channel.close()
-      for thread in self.threads_:
-        thread.join()
+            # Force pipes to close to terminate threads
+            for proc in self.procs_:
+                proc.channel.close()
+            for thread in self.threads_:
+                thread.join()
 
 # And everywhere else use select().
 else:
-  class ChannelPoller(ChannelPollerBase):
-    def __init__(self, cx, procs):
-      super(ChannelPoller, self).__init__(cx, procs)
-      self.map_ = {}
-      self.rdlist_ = []
 
-    def __enter__(self):
-      for proc in self.procs_:
-        self.map_[proc.channel.poll_handle] = proc
-        self.rdlist_ = [key for key in self.map_]
-      return self
+    class ChannelPoller(ChannelPollerBase):
+        def __init__(self, cx, procs):
+            super(ChannelPoller, self).__init__(cx, procs)
+            self.map_ = {}
+            self.rdlist_ = []
 
-    def poll(self):
-      while True:
-        try:
-          ready, _, _ = select.select(self.rdlist_, [], [])
-          if ready:
-            proc = self.map_[ready[0]]
-            return proc, proc.channel.recv()
-        except select.error as e:
-          if e.args[0] == errno.EINTR:
-            continue
-          raise
+        def __enter__(self):
+            for proc in self.procs_:
+                self.map_[proc.channel.poll_handle] = proc
+                self.rdlist_ = [key for key in self.map_]
+            return self
 
-    def __exit__(self, type, value, traceback):
-      pass
+        def poll(self):
+            while True:
+                try:
+                    ready, _, _ = select.select(self.rdlist_, [], [])
+                    if ready:
+                        proc = self.map_[ready[0]]
+                        return proc, proc.channel.recv()
+                except select.error as e:
+                    if e.args[0] == errno.EINTR:
+                        continue
+                    raise
+
+        def __exit__(self, type, value, traceback):
+            pass

--- a/ambuild2/run.py
+++ b/ambuild2/run.py
@@ -1,17 +1,17 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et:
 #
 # This file is part of AMBuild.
-# 
+#
 # AMBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # AMBuild is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
@@ -54,100 +54,129 @@ builder.Configure()
 """.format(DEFAULT_API = DEFAULT_API)
 
 def BuildOptions():
-  parser = OptionParser("usage: %prog [options] [path]")
-  parser.add_option("--no-color", dest="no_color", action="store_true", default=False,
-                    help="Disable console colors.")
-  parser.add_option("--show-graph", dest="show_graph", action="store_true", default=False,
-                    help="Show the dependency graph and then exit.")
-  parser.add_option("--show-changed", dest="show_changed", action="store_true", default=False,
-                    help="Show the list of dirty nodes and then exit.")
-  parser.add_option("--show-damage", dest="show_damage", action="store_true", default=False,
-                    help="Show the computed change graph and then exit.")
-  parser.add_option("--show-commands", dest="show_commands", action="store_true", default=False,
-                    help="Show the computed command graph and then exit.")
-  parser.add_option("--show-steps", dest="show_steps", action="store_true", default=False,
-                    help="Show the computed build steps and then exit.")
-  parser.add_option("-j", "--jobs", dest="jobs", type="int", default=0,
-                    help="Number of worker processes. Minimum number is 1; default is #cores * 1.25.")
-  parser.add_option('--refactor', dest="refactor", action="store_true", default=False,
-                    help="Abort the build if the dependency graph would change.")
-  parser.add_option('--new-project', dest="new_project", action="store_true", default=False,
-                    help="Export a sample AMBuildScript in the current folder.")
+    parser = OptionParser("usage: %prog [options] [path]")
+    parser.add_option("--no-color",
+                      dest = "no_color",
+                      action = "store_true",
+                      default = False,
+                      help = "Disable console colors.")
+    parser.add_option("--show-graph",
+                      dest = "show_graph",
+                      action = "store_true",
+                      default = False,
+                      help = "Show the dependency graph and then exit.")
+    parser.add_option("--show-changed",
+                      dest = "show_changed",
+                      action = "store_true",
+                      default = False,
+                      help = "Show the list of dirty nodes and then exit.")
+    parser.add_option("--show-damage",
+                      dest = "show_damage",
+                      action = "store_true",
+                      default = False,
+                      help = "Show the computed change graph and then exit.")
+    parser.add_option("--show-commands",
+                      dest = "show_commands",
+                      action = "store_true",
+                      default = False,
+                      help = "Show the computed command graph and then exit.")
+    parser.add_option("--show-steps",
+                      dest = "show_steps",
+                      action = "store_true",
+                      default = False,
+                      help = "Show the computed build steps and then exit.")
+    parser.add_option(
+        "-j",
+        "--jobs",
+        dest = "jobs",
+        type = "int",
+        default = 0,
+        help = "Number of worker processes. Minimum number is 1; default is #cores * 1.25.")
+    parser.add_option('--refactor',
+                      dest = "refactor",
+                      action = "store_true",
+                      default = False,
+                      help = "Abort the build if the dependency graph would change.")
+    parser.add_option('--new-project',
+                      dest = "new_project",
+                      action = "store_true",
+                      default = False,
+                      help = "Export a sample AMBuildScript in the current folder.")
 
-  options, argv = parser.parse_args()
+    options, argv = parser.parse_args()
 
-  if len(argv) > 1:
-    parser.error("expected path, found extra arguments")
+    if len(argv) > 1:
+        parser.error("expected path, found extra arguments")
 
-  if options.new_project:
-    if os.path.exists('AMBuildScript'):
-      sys.stderr.write('An AMBuildScript file already exists here; aborting.\n')
-      sys.exit(1)
-    if os.path.exists('configure.py'):
-      sys.stderr.write('A configure.py file already exists here; aborting.\n')
-      sys.exit(1)
+    if options.new_project:
+        if os.path.exists('AMBuildScript'):
+            sys.stderr.write('An AMBuildScript file already exists here; aborting.\n')
+            sys.exit(1)
+        if os.path.exists('configure.py'):
+            sys.stderr.write('A configure.py file already exists here; aborting.\n')
+            sys.exit(1)
 
-    with open('AMBuildScript', 'w') as fp:
-      fp.write(SampleScript)
-    with open('configure.py', 'w') as fp:
-      fp.write(SampleConfigure)
+        with open('AMBuildScript', 'w') as fp:
+            fp.write(SampleScript)
+        with open('configure.py', 'w') as fp:
+            fp.write(SampleConfigure)
 
-    sys.stdout.write('Sample AMBuildScript and configure.py scripts generated.\n')
-    sys.exit(0)
+        sys.stdout.write('Sample AMBuildScript and configure.py scripts generated.\n')
+        sys.exit(0)
 
-  return options, argv
+    return options, argv
 
 def Build(buildPath, options, argv):
-  with util.FolderChanger(buildPath):
-    with Context(buildPath, options, argv) as cx:
-      return cx.Build()
+    with util.FolderChanger(buildPath):
+        with Context(buildPath, options, argv) as cx:
+            return cx.Build()
 
 def CompatBuild(buildPath):
-  options, argv = BuildOptions()
-  return Build(buildPath, options, argv)
+    options, argv = BuildOptions()
+    return Build(buildPath, options, argv)
 
-def PrepareBuild(sourcePath, buildPath=None):
-  return BuildParser(sourcePath, '2.0', buildPath)
+def PrepareBuild(sourcePath, buildPath = None):
+    return BuildParser(sourcePath, '2.0', buildPath)
 
 def PreparerForAPI(api):
-  if api == '2.0':
-    from ambuild2.frontend.v2_0.prep import Preparer
-  elif api == '2.1' or api.startswith('2.1.'):
-    from ambuild2.frontend.v2_1 import Preparer
-  else:
-    raise Exception('API version {0} not found'.format(api))
-  return Preparer
+    if api == '2.0':
+        from ambuild2.frontend.v2_0.prep import Preparer
+    elif api == '2.1' or api.startswith('2.1.'):
+        from ambuild2.frontend.v2_1 import Preparer
+    else:
+        raise Exception('API version {0} not found'.format(api))
+    return Preparer
 
 def HasAPI(api):
-  try:
-    if PreparerForAPI(api) is not None:
-      return True
-  except:
-    pass
-  return False
+    try:
+        if PreparerForAPI(api) is not None:
+            return True
+    except:
+        pass
+    return False
 
-def BuildParser(sourcePath, api, buildPath=None):
-  if buildPath == None:
-    buildPath = os.path.abspath(os.getcwd())
+def BuildParser(sourcePath, api, buildPath = None):
+    if buildPath == None:
+        buildPath = os.path.abspath(os.getcwd())
 
-  Preparer = PreparerForAPI(api)
-  return Preparer(sourcePath=sourcePath, buildPath=buildPath)
+    Preparer = PreparerForAPI(api)
+    return Preparer(sourcePath = sourcePath, buildPath = buildPath)
 
 def cli_run():
-  options, argv = BuildOptions()
+    options, argv = BuildOptions()
 
-  if not len(argv):
-    folder = '.'
-  else:
-    folder = argv[0]
-    if not os.path.exists(folder):
-      sys.stderr.write('Error: path does not exist: {0}\n'.format(folder))
-      sys.exit(1)
+    if not len(argv):
+        folder = '.'
+    else:
+        folder = argv[0]
+        if not os.path.exists(folder):
+            sys.stderr.write('Error: path does not exist: {0}\n'.format(folder))
+            sys.exit(1)
 
-  cache_path = os.path.join(folder, '.ambuild2', 'graph')
-  if not os.path.exists(cache_path):
-    sys.stderr.write('Error: folder was not configured for AMBuild.\n')
-    sys.exit(1)
+    cache_path = os.path.join(folder, '.ambuild2', 'graph')
+    if not os.path.exists(cache_path):
+        sys.stderr.write('Error: folder was not configured for AMBuild.\n')
+        sys.exit(1)
 
-  if not Build(os.path.abspath(folder), options, argv):
-    sys.exit(1)
+    if not Build(os.path.abspath(folder), options, argv):
+        sys.exit(1)

--- a/ambuild2/task.py
+++ b/ambuild2/task.py
@@ -9,485 +9,478 @@ from ambuild2 import nodetypes
 from ambuild2 import process_manager
 
 class Task(object):
-  def __init__(self, id, entry, outputs):
-    self.id = id
-    self.type = entry.type
-    self.data = entry.blob
-    if entry.folder:
-      self.folder = entry.folder.path
-    else:
-      self.folder = None
-    self.outputs = outputs
-    self.outgoing = []
-    self.incoming = set()
-    self.tools_env = entry.tools_env
+    def __init__(self, id, entry, outputs):
+        self.id = id
+        self.type = entry.type
+        self.data = entry.blob
+        if entry.folder:
+            self.folder = entry.folder.path
+        else:
+            self.folder = None
+        self.outputs = outputs
+        self.outgoing = []
+        self.incoming = set()
+        self.tools_env = entry.tools_env
 
-  def addOutgoing(self, task):
-    self.outgoing.append(task)
-    task.incoming.add(self)
+    def addOutgoing(self, task):
+        self.outgoing.append(task)
+        task.incoming.add(self)
 
-  @property
-  def folder_name(self):
-    if not self.folder:
-      return ''
-    return self.folder
+    @property
+    def folder_name(self):
+        if not self.folder:
+            return ''
+        return self.folder
 
-  def format(self):
-    text = ''
-    if self.type == nodetypes.Cxx:
-      return '[' + self.data['type'] + ']' + ' -> ' + (' '.join([arg for arg in self.data['argv']]))
-    if self.type == nodetypes.Symlink:
-      return 'ln -s "{0}" "{1}"'.format(self.data[0], os.path.join(self.folder_name, self.data[1]))
-    if self.type == nodetypes.Copy:
-      return 'cp "{0}" "{1}"'.format(self.data[0], os.path.join(self.folder_name, self.data[1]))
-    return (' '.join([arg for arg in self.data]))
+    def format(self):
+        text = ''
+        if self.type == nodetypes.Cxx:
+            return '[' + self.data['type'] + ']' + ' -> ' + (' '.join(
+                [arg for arg in self.data['argv']]))
+        if self.type == nodetypes.Symlink:
+            return 'ln -s "{0}" "{1}"'.format(self.data[0],
+                                              os.path.join(self.folder_name, self.data[1]))
+        if self.type == nodetypes.Copy:
+            return 'cp "{0}" "{1}"'.format(self.data[0], os.path.join(self.folder_name,
+                                                                      self.data[1]))
+        return (' '.join([arg for arg in self.data]))
 
 class TaskWorker(process_manager.MessageReceiver):
-  def __init__(self, channel, vars):
-    super(TaskWorker, self).__init__(channel)
-    self.buildPath = vars['buildPath']
-    self.pid = os.getpid()
-    self.vars = vars
-    self.messageMap = {
-      'task': lambda channel, message: self.receive_task(channel, message)
-    }
-    self.taskMap = {
-      # When updating this, add to task_argv_debug().
-      'cxx': lambda message: self.doCompile(message),
-      'cmd': lambda message: self.doCommand(message),
-      'ln': lambda message: self.doSymlink(message),
-      'cp': lambda message: self.doCopy(message),
-      'rc': lambda message: self.doResource(message),
-      # When updating this, add to task_argv_debug().
-    }
-    self.try_send({'id': 'spawned'})
+    def __init__(self, channel, vars):
+        super(TaskWorker, self).__init__(channel)
+        self.buildPath = vars['buildPath']
+        self.pid = os.getpid()
+        self.vars = vars
+        self.messageMap = {'task': lambda channel, message: self.receive_task(channel, message)}
+        self.taskMap = {
+            # When updating this, add to task_argv_debug().
+            'cxx': lambda message: self.doCompile(message),
+            'cmd': lambda message: self.doCommand(message),
+            'ln': lambda message: self.doSymlink(message),
+            'cp': lambda message: self.doCopy(message),
+            'rc': lambda message: self.doResource(message),
+            # When updating this, add to task_argv_debug().
+        }
+        self.try_send({'id': 'spawned'})
 
-  def onShutdown(self):
-    pass
+    def onShutdown(self):
+        pass
 
-  def receive_task(self, channel, message):
-    try:
-      return self.process_task(channel, message)
-    except Exception as e:
-      response = {
-        'ok': False,
-        'cmdline': self.task_argv_debug(message),
-        'stdout': '',
-        'stderr': traceback.format_exc(),
-      }
-      return self.issueResponse(message, response)
-
-  def process_task(self, channel, message):
-    task_id = message['task_id']
-    task_type = message['task_type']
-    task_folder = message['task_folder']
-    if not task_folder:
-      task_folder = '.'
-
-    # Remove all outputs.
-    for output in message['task_outputs']:
-      try:
-        os.unlink(output)
-      except OSError as exn:
-        if exn.errno != errno.ENOENT:
-          response = {
-            'ok': False,
-            'cmdline': 'rm {0}'.format(output),
-            'stdout': '',
-            'stderr': '{0}'.format(exn)
-          }
-          return self.issueResponse(message, response)
-
-    if not message['task_folder']:
-      message['task_folder'] = '.'
-
-    # Do the task.
-    response = self.taskMap[task_type](message)
-    return self.issueResponse(message, response)
-
-  def issueResponse(self, message, response):
-    # Compute new timestamps for all command outputs.
-    new_timestamps = []
-    if response['ok']:
-      for output in message['task_outputs']:
+    def receive_task(self, channel, message):
         try:
-          new_timestamps.append((output, os.path.getmtime(output)))
-        except:
-          response['ok'] = False
-          response['stderr'] += 'Expected output file, but not found: {0}'.format(output)
-          break
+            return self.process_task(channel, message)
+        except Exception as e:
+            response = {
+                'ok': False,
+                'cmdline': self.task_argv_debug(message),
+                'stdout': '',
+                'stderr': traceback.format_exc(),
+            }
+            return self.issueResponse(message, response)
 
-    # Send a message back to the master process to update the DAG and spew
-    # stdout/stderr if needed.
-    response['id'] = 'results'
-    response['task_id'] = message['task_id']
-    response['updates'] = new_timestamps
-    self.try_send(response)
+    def process_task(self, channel, message):
+        task_id = message['task_id']
+        task_type = message['task_type']
+        task_folder = message['task_folder']
+        if not task_folder:
+            task_folder = '.'
 
-  def try_send(self, message):
-    try:
-      self.channel.send(message)
-    except OSError as e:
-      if getattr(e, 'winerror', 0) == 232:
-        # Parent is dead, so ignore the error.
-        return
-      raise
+        # Remove all outputs.
+        for output in message['task_outputs']:
+            try:
+                os.unlink(output)
+            except OSError as exn:
+                if exn.errno != errno.ENOENT:
+                    response = {
+                        'ok': False,
+                        'cmdline': 'rm {0}'.format(output),
+                        'stdout': '',
+                        'stderr': '{0}'.format(exn)
+                    }
+                    return self.issueResponse(message, response)
 
-  def doCommand(self, message):
-    task_folder = message['task_folder']
-    tools_env = message['task_tools_env']
-    argv = message['task_data']
+        if not message['task_folder']:
+            message['task_folder'] = '.'
 
-    env = None
-    if tools_env is not None:
-      if tools_env.env_cmds is not None:
-        env = util.BuildEnv(tools_env.env_cmds)
-      if argv[0] in tools_env.tools:
-        argv[0] = tools_env.tools[argv[0]]
+        # Do the task.
+        response = self.taskMap[task_type](message)
+        return self.issueResponse(message, response)
 
-    with util.FolderChanger(task_folder):
-      try:
-        p, stdout, stderr = util.Execute(argv, env = env)
-        status = p.returncode == 0
-      except Exception as exn:
-        status = False
-        stdout = ''
-        stderr = '{0}'.format(exn)
+    def issueResponse(self, message, response):
+        # Compute new timestamps for all command outputs.
+        new_timestamps = []
+        if response['ok']:
+            for output in message['task_outputs']:
+                try:
+                    new_timestamps.append((output, os.path.getmtime(output)))
+                except:
+                    response['ok'] = False
+                    response['stderr'] += 'Expected output file, but not found: {0}'.format(output)
+                    break
 
-    reply = {
-      'ok': status,
-      'cmdline': self.task_argv_debug(message),
-      'stdout': stdout,
-      'stderr': stderr,
-    }
-    return reply
+        # Send a message back to the master process to update the DAG and spew
+        # stdout/stderr if needed.
+        response['id'] = 'results'
+        response['task_id'] = message['task_id']
+        response['updates'] = new_timestamps
+        self.try_send(response)
 
-  def doSymlink(self, message):
-    task_folder = message['task_folder']
-    source_path, output_path = message['task_data']
+    def try_send(self, message):
+        try:
+            self.channel.send(message)
+        except OSError as e:
+            if getattr(e, 'winerror', 0) == 232:
+                # Parent is dead, so ignore the error.
+                return
+            raise
 
-    with util.FolderChanger(task_folder):
-      rcode, stdout, stderr = util.symlink(source_path, output_path)
+    def doCommand(self, message):
+        task_folder = message['task_folder']
+        tools_env = message['task_tools_env']
+        argv = message['task_data']
 
-    reply = {
-      'ok': rcode == 0,
-      'cmdline': self.task_argv_debug(message),
-      'stdout': stdout,
-      'stderr': stderr,
-    }
-    return reply
+        env = None
+        if tools_env is not None:
+            if tools_env.env_cmds is not None:
+                env = util.BuildEnv(tools_env.env_cmds)
+            if argv[0] in tools_env.tools:
+                argv[0] = tools_env.tools[argv[0]]
 
-  def doCopy(self, message):
-    task_folder = message['task_folder']
-    source_path, output_path = message['task_data']
+        with util.FolderChanger(task_folder):
+            try:
+                p, stdout, stderr = util.Execute(argv, env = env)
+                status = p.returncode == 0
+            except Exception as exn:
+                status = False
+                stdout = ''
+                stderr = '{0}'.format(exn)
 
-    with util.FolderChanger(task_folder):
-      if os.path.exists(source_path):
-        shutil.copy(source_path, output_path)
-        ok = True
-        stderr = ''
-      else:
-        ok = False
-        stderr = 'File not found: {0}'.format(source_path)
+        reply = {
+            'ok': status,
+            'cmdline': self.task_argv_debug(message),
+            'stdout': stdout,
+            'stderr': stderr,
+        }
+        return reply
 
-    reply = {
-      'ok': ok,
-      'cmdline': self.task_argv_debug(message),
-      'stdout': '',
-      'stderr': stderr,
-    }
-    return reply
+    def doSymlink(self, message):
+        task_folder = message['task_folder']
+        source_path, output_path = message['task_data']
 
-  # Adjusts any dependencies relative to the current folder, to be relative to
-  # the output folder instead.
-  def rewriteDeps(self, deps):
-    paths = []
-    for inc_path in deps:
-      if not os.path.isabs(inc_path):
-        inc_path = os.path.abspath(inc_path)
+        with util.FolderChanger(task_folder):
+            rcode, stdout, stderr = util.symlink(source_path, output_path)
 
-      # Detect whether the include is within the build folder or not.
-      build_path = self.buildPath
-      if build_path[-1] != os.path.sep:
-        build_path += os.path.sep
-      prefix = os.path.commonprefix([build_path, inc_path])
-      if prefix == build_path:
-        # The include is not a system include, i.e. it was generated, so
-        # rewrite the path to be relative to the build folder.
-        inc_path = os.path.relpath(inc_path, self.buildPath)
+        reply = {
+            'ok': rcode == 0,
+            'cmdline': self.task_argv_debug(message),
+            'stdout': stdout,
+            'stderr': stderr,
+        }
+        return reply
 
-      paths.append(inc_path)
-    return paths
+    def doCopy(self, message):
+        task_folder = message['task_folder']
+        source_path, output_path = message['task_data']
 
-  def doCompile(self, message):
-    task_folder = message['task_folder']
-    task_data = message['task_data']
-    tools_env = message['task_tools_env']
-    cc_type = task_data['type']
-    argv = task_data['argv']
+        with util.FolderChanger(task_folder):
+            if os.path.exists(source_path):
+                shutil.copy(source_path, output_path)
+                ok = True
+                stderr = ''
+            else:
+                ok = False
+                stderr = 'File not found: {0}'.format(source_path)
 
-    env = None
-    if tools_env is not None:
-      if tools_env.env_cmds is not None:
-        env = util.BuildEnv(tools_env.env_cmds)
-      if 'cl' in tools_env.tools:
-        argv[0] = tools_env.tools['cl']
+        reply = {
+            'ok': ok,
+            'cmdline': self.task_argv_debug(message),
+            'stdout': '',
+            'stderr': stderr,
+        }
+        return reply
 
-    with util.FolderChanger(task_folder):
-      p, out, err = util.Execute(argv, env = env)
-      if cc_type == 'gcc':
-        err, deps = util.ParseGCCDeps(err)
-      elif cc_type == 'msvc':
-        out, deps = util.ParseMSVCDeps(self.vars, out)
-      elif cc_type == 'sun':
-        err, deps = util.ParseSunDeps(err)
-      elif cc_type == 'fxc':
-        out, deps = util.ParseFXCDeps(out)
-      else:
-        raise Exception('unknown compiler type')
+    # Adjusts any dependencies relative to the current folder, to be relative to
+    # the output folder instead.
+    def rewriteDeps(self, deps):
+        paths = []
+        for inc_path in deps:
+            if not os.path.isabs(inc_path):
+                inc_path = os.path.abspath(inc_path)
 
-      paths = self.rewriteDeps(deps)
+            # Detect whether the include is within the build folder or not.
+            build_path = self.buildPath
+            if build_path[-1] != os.path.sep:
+                build_path += os.path.sep
+            prefix = os.path.commonprefix([build_path, inc_path])
+            if prefix == build_path:
+                # The include is not a system include, i.e. it was generated, so
+                # rewrite the path to be relative to the build folder.
+                inc_path = os.path.relpath(inc_path, self.buildPath)
 
-    reply = {
-      'ok': p.returncode == 0,
-      'cmdline': self.task_argv_debug(message),
-      'stdout': out,
-      'stderr': err,
-      'deps': paths,
-    }
-    return reply
+            paths.append(inc_path)
+        return paths
 
-  def doResource(self, message):
-    task_folder = message['task_folder']
-    task_data = message['task_data']
-    tools_env = message['task_tools_env']
-    cl_argv = task_data['cl_argv']
-    rc_argv = task_data['rc_argv']
+    def doCompile(self, message):
+        task_folder = message['task_folder']
+        task_data = message['task_data']
+        tools_env = message['task_tools_env']
+        cc_type = task_data['type']
+        argv = task_data['argv']
 
-    env = None
-    if tools_env is not None:
-      if tools_env.env_cmds is not None:
-        env = util.BuildEnv(tools_env.env_cmds)
-      if 'cl' in tools_env.tools:
-        cl_argv[0] = tools_env.tools['cl']
-      if 'rc' in tools_env.tools:
-        rc_argv[0] = tools_env.tools['rc']
+        env = None
+        if tools_env is not None:
+            if tools_env.env_cmds is not None:
+                env = util.BuildEnv(tools_env.env_cmds)
+            if 'cl' in tools_env.tools:
+                argv[0] = tools_env.tools['cl']
 
-    with util.FolderChanger(task_folder):
-      # Includes go to stderr when we preprocess to stdout.
-      p, out, err = util.Execute(cl_argv, env = env)
-      out, deps = util.ParseMSVCDeps(self.vars, err)
-      paths = self.rewriteDeps(deps)
+        with util.FolderChanger(task_folder):
+            p, out, err = util.Execute(argv, env = env)
+            if cc_type == 'gcc':
+                err, deps = util.ParseGCCDeps(err)
+            elif cc_type == 'msvc':
+                out, deps = util.ParseMSVCDeps(self.vars, out)
+            elif cc_type == 'sun':
+                err, deps = util.ParseSunDeps(err)
+            elif cc_type == 'fxc':
+                out, deps = util.ParseFXCDeps(out)
+            else:
+                raise Exception('unknown compiler type')
 
-      if p.returncode == 0:
-        p, out, err = util.Execute(rc_argv, env = env)
-        
-    reply = {
-      'ok': p.returncode == 0,
-      'cmdline': self.task_argv_debug(message),
-      'stdout': out,
-      'stderr': err,
-      'deps': paths,
-    }
-    return reply
+            paths = self.rewriteDeps(deps)
 
-  def task_argv_debug(self, message):
-    task_data = message.get('task_data', None)
-    if message['task_type'] == 'rc':
-      cl_argv = task_data['cl_argv']
-      rc_argv = task_data['rc_argv']
-      return ' '.join([arg for arg in cl_argv]) + ' && ' + ' '.join([arg for arg in rc_argv])
-    elif message['task_type'] == 'cxx':
-      return ' '.join([arg for arg in task_data['argv']])
-    elif message['task_type'] == 'cmd':
-      return ' '.join([arg for arg in task_data])
-    elif message['task_type'] in ['cp', 'ln']:
-      task_folder = message['task_folder']
-      if message['task_type'] == 'cp':
-        cmd = 'cp'
-      elif message['task_type'] == 'ln':
-        cmd = 'ln -s'
-      return '{} "{}" "{}"'.format(cmd, task_data[0], os.path.join(task_folder, task_data[1]))
+        reply = {
+            'ok': p.returncode == 0,
+            'cmdline': self.task_argv_debug(message),
+            'stdout': out,
+            'stderr': err,
+            'deps': paths,
+        }
+        return reply
+
+    def doResource(self, message):
+        task_folder = message['task_folder']
+        task_data = message['task_data']
+        tools_env = message['task_tools_env']
+        cl_argv = task_data['cl_argv']
+        rc_argv = task_data['rc_argv']
+
+        env = None
+        if tools_env is not None:
+            if tools_env.env_cmds is not None:
+                env = util.BuildEnv(tools_env.env_cmds)
+            if 'cl' in tools_env.tools:
+                cl_argv[0] = tools_env.tools['cl']
+            if 'rc' in tools_env.tools:
+                rc_argv[0] = tools_env.tools['rc']
+
+        with util.FolderChanger(task_folder):
+            # Includes go to stderr when we preprocess to stdout.
+            p, out, err = util.Execute(cl_argv, env = env)
+            out, deps = util.ParseMSVCDeps(self.vars, err)
+            paths = self.rewriteDeps(deps)
+
+            if p.returncode == 0:
+                p, out, err = util.Execute(rc_argv, env = env)
+
+        reply = {
+            'ok': p.returncode == 0,
+            'cmdline': self.task_argv_debug(message),
+            'stdout': out,
+            'stderr': err,
+            'deps': paths,
+        }
+        return reply
+
+    def task_argv_debug(self, message):
+        task_data = message.get('task_data', None)
+        if message['task_type'] == 'rc':
+            cl_argv = task_data['cl_argv']
+            rc_argv = task_data['rc_argv']
+            return ' '.join([arg for arg in cl_argv]) + ' && ' + ' '.join([arg for arg in rc_argv])
+        elif message['task_type'] == 'cxx':
+            return ' '.join([arg for arg in task_data['argv']])
+        elif message['task_type'] == 'cmd':
+            return ' '.join([arg for arg in task_data])
+        elif message['task_type'] in ['cp', 'ln']:
+            task_folder = message['task_folder']
+            if message['task_type'] == 'cp':
+                cmd = 'cp'
+            elif message['task_type'] == 'ln':
+                cmd = 'ln -s'
+            return '{} "{}" "{}"'.format(cmd, task_data[0], os.path.join(task_folder, task_data[1]))
 
 class TaskMaster(object):
-  BUILD_IN_PROGRESS = 0
-  BUILD_SUCCEEDED = 1
-  BUILD_NO_CHANGES = 2
-  BUILD_FAILED = 3
-  BUILD_INTERRUPTED = 4
+    BUILD_IN_PROGRESS = 0
+    BUILD_SUCCEEDED = 1
+    BUILD_NO_CHANGES = 2
+    BUILD_FAILED = 3
+    BUILD_INTERRUPTED = 4
 
-  def __init__(self, cx, builder, task_graph, max_parallel):
-    self.cx = cx
-    self.builder = builder
-    self.status_ = TaskMaster.BUILD_IN_PROGRESS
-    self.messageMap = {
-      'completed': lambda child, message: self.receiveCompleted(child, message),
-      'spawned': lambda child, message: self.recvSpawned(child, message),
-      'results': lambda child, message: self.recvTaskComplete(child, message),
-      'done': lambda child, message: self.receiveDone(child, message),
-    }
-    self.errors_ = []
-    self.task_graph = task_graph
-    self.workers_ = []
-    self.pending_ = {}
-    self.idle_ = set()
-    self.build_completed_ = False
+    def __init__(self, cx, builder, task_graph, max_parallel):
+        self.cx = cx
+        self.builder = builder
+        self.status_ = TaskMaster.BUILD_IN_PROGRESS
+        self.messageMap = {
+            'completed': lambda child, message: self.receiveCompleted(child, message),
+            'spawned': lambda child, message: self.recvSpawned(child, message),
+            'results': lambda child, message: self.recvTaskComplete(child, message),
+            'done': lambda child, message: self.receiveDone(child, message),
+        }
+        self.errors_ = []
+        self.task_graph = task_graph
+        self.workers_ = []
+        self.pending_ = {}
+        self.idle_ = set()
+        self.build_completed_ = False
 
-    # Figure out how many tasks to create.
-    if cx.options.jobs == 0:
-      # Using 1 process will be strictly worse than an in-process build,
-      # since we incur the additional overhead of message passing. Instead,
-      # we use two processes as the minimal number. If that turns out to be
-      # bad we can create an in-process TaskMaster later.
-      if mp.cpu_count() == 1:
-        num_processes = 2
-      else:
-        num_processes = int(mp.cpu_count() * 1.25)
-    else:
-      num_processes = cx.options.jobs
+        # Figure out how many tasks to create.
+        if cx.options.jobs == 0:
+            # Using 1 process will be strictly worse than an in-process build,
+            # since we incur the additional overhead of message passing. Instead,
+            # we use two processes as the minimal number. If that turns out to be
+            # bad we can create an in-process TaskMaster later.
+            if mp.cpu_count() == 1:
+                num_processes = 2
+            else:
+                num_processes = int(mp.cpu_count() * 1.25)
+        else:
+            num_processes = cx.options.jobs
 
-    # Don't create more processes than we'll need.
-    if num_processes > max_parallel:
-      num_processes = max_parallel
+        # Don't create more processes than we'll need.
+        if num_processes > max_parallel:
+            num_processes = max_parallel
 
-    for _ in range(num_processes):
-      self.startWorker()
+        for _ in range(num_processes):
+            self.startWorker()
 
-  def spewResult(self, worker, message):
-    if message['ok']:
-      color = util.ConsoleGreen
-    else:
-      color = util.ConsoleRed
-    util.con_out(
-      util.ConsoleBlue,
-      '[{0}]'.format(message['pid']),
-      util.ConsoleNormal,
-      ' ',
-      color,
-      message['cmdline'],
-      util.ConsoleNormal)
-    sys.stdout.flush()
+    def spewResult(self, worker, message):
+        if message['ok']:
+            color = util.ConsoleGreen
+        else:
+            color = util.ConsoleRed
+        util.con_out(util.ConsoleBlue, '[{0}]'.format(message['pid']), util.ConsoleNormal, ' ',
+                     color, message['cmdline'], util.ConsoleNormal)
+        sys.stdout.flush()
 
-    if len(message['stdout']):
-      util.WriteEncodedText(sys.stdout, message['stdout'])
-      if message['stdout'][-1] != '\n':
-        sys.stdout.write('\n')
-      sys.stdout.flush()
-          
-    if len(message['stderr']):
-      util.WriteEncodedText(sys.stderr, message['stderr'])
-      if message['stderr'][-1] != '\n':
-        sys.stderr.write('\n')
-      sys.stderr.flush()
+        if len(message['stdout']):
+            util.WriteEncodedText(sys.stdout, message['stdout'])
+            if message['stdout'][-1] != '\n':
+                sys.stdout.write('\n')
+            sys.stdout.flush()
 
-  def recvTaskComplete(self, worker, message):
-    message['pid'] = worker.pid
-    if not message['ok']:
-      self.errors_.append((worker, message))
-      self.terminateBuild(TaskMaster.BUILD_FAILED)
-      return
+        if len(message['stderr']):
+            util.WriteEncodedText(sys.stderr, message['stderr'])
+            if message['stderr'][-1] != '\n':
+                sys.stderr.write('\n')
+            sys.stderr.flush()
 
-    self.spewResult(worker, message)
+    def recvTaskComplete(self, worker, message):
+        message['pid'] = worker.pid
+        if not message['ok']:
+            self.errors_.append((worker, message))
+            self.terminateBuild(TaskMaster.BUILD_FAILED)
+            return
 
-    task = self.pending_[worker.pid]
-    del self.pending_[worker.pid]
-    if message['task_id'] != task.id:
-      raise Exception('Worker {} returned wrong task id (got {}, expected {})'.format(
-                      worker.pid, task_id, task.id))
+        self.spewResult(worker, message)
 
-    updates = message['updates']
-    if not self.builder.updateGraph(task.id, updates, message):
-      util.con_out(util.ConsoleRed, 'Failed to update node!', util.ConsoleNormal)
-      self.terminateBuild(TaskMaster.BUILD_FAILED)
+        task = self.pending_[worker.pid]
+        del self.pending_[worker.pid]
+        if message['task_id'] != task.id:
+            raise Exception('Worker {} returned wrong task id (got {}, expected {})'.format(
+                worker.pid, task_id, task.id))
 
-    # Enqueue any tasks that can be run if this was their last outstanding
-    # dependency.
-    for outgoing in task.outgoing:
-      outgoing.incoming.remove(task)
-      if len(outgoing.incoming) == 0:
-        self.task_graph.append(outgoing)
+        updates = message['updates']
+        if not self.builder.updateGraph(task.id, updates, message):
+            util.con_out(util.ConsoleRed, 'Failed to update node!', util.ConsoleNormal)
+            self.terminateBuild(TaskMaster.BUILD_FAILED)
 
-    if not len(self.task_graph) and not len(self.pending_):
-      # There are no tasks remaining.
-      self.status_ = TaskMaster.BUILD_SUCCEEDED
+        # Enqueue any tasks that can be run if this was their last outstanding
+        # dependency.
+        for outgoing in task.outgoing:
+            outgoing.incoming.remove(task)
+            if len(outgoing.incoming) == 0:
+                self.task_graph.append(outgoing)
 
-    # Add this process to the idle set.
-    self.idle_.add(worker)
+        if not len(self.task_graph) and not len(self.pending_):
+            # There are no tasks remaining.
+            self.status_ = TaskMaster.BUILD_SUCCEEDED
 
-    # If more stuff was queued, and we have idle processes, use them.
-    while len(self.task_graph) and len(self.idle_):
-      worker = self.idle_.pop()
-      self.issue_next_task(worker)
+        # Add this process to the idle set.
+        self.idle_.add(worker)
 
-  def terminateBuild(self, status):
-    self.status_ = status
+        # If more stuff was queued, and we have idle processes, use them.
+        while len(self.task_graph) and len(self.idle_):
+            worker = self.idle_.pop()
+            self.issue_next_task(worker)
 
-  def startWorker(self):
-    args = (self.cx.vars,)
-    child = self.cx.procman.spawn(TaskWorker, args)
-    self.workers_.append(child)
+    def terminateBuild(self, status):
+        self.status_ = status
 
-    util.con_out(
-      util.ConsoleHeader,
-      'Spawned {0} (pid: {1})'.format('worker', child.proc.pid),
-      util.ConsoleNormal)
+    def startWorker(self):
+        args = (self.cx.vars,)
+        child = self.cx.procman.spawn(TaskWorker, args)
+        self.workers_.append(child)
 
-  def run(self):
-    try:
-      self.pump()
-    except KeyboardInterrupt: # :TODO: TEST!
-      self.terminateBuild(TaskMaster.BUILD_INTERRUPTED)
-    for worker, message in self.errors_:
-      self.spewResult(worker, message)
-    return self.status_
+        util.con_out(util.ConsoleHeader, 'Spawned {0} (pid: {1})'.format('worker', child.proc.pid),
+                     util.ConsoleNormal)
 
-  def onShutdown(self):
-    return False
-
-  def recvSpawned(self, worker, message):
-    if self.status_ != TaskMaster.BUILD_IN_PROGRESS:
-      return
-
-    if not len(self.task_graph):
-      # If there are still tasks left to complete, they're waiting on others
-      # to finish. Mark this process as ready and just ignore the status
-      # change for now.
-      self.idle_.add(worker)
-      return
-
-    self.issue_next_task(worker)
-
-  def issue_next_task(self, worker):
-    task = self.task_graph.pop()
-    message = {
-      'id': 'task',
-      'task_id': task.id,
-      'task_type': task.type,
-      'task_data': task.data,
-      'task_folder': task.folder,
-      'task_outputs': task.outputs,
-      'task_tools_env': task.tools_env,
-    }
-    worker.channel.send(message)
-    self.pending_[worker.pid] = task
-
-  def pump(self):
-    with process_manager.ChannelPoller(self.cx, self.workers_) as poller:
-      while self.status_ == TaskMaster.BUILD_IN_PROGRESS:
+    def run(self):
         try:
-          proc, obj = poller.poll()
-          if obj['id'] not in self.messageMap:
-            raise Exception('Unhandled message type: {}'.format(obj['id']))
-          self.messageMap[obj['id']](proc, obj)
-        except EOFError:
-          # The process died. Very sad. Clean up and fail the build.
-          util.con_err(util.ConsoleBlue, '[{0}]'.format(proc.pid), util.ConsoleNormal, ' ',
-                       util.ConsoleRed, 'Worker unexpectedly exited.')
-          self.terminateBuild(TaskMaster.BUILD_FAILED)
-          break
+            self.pump()
+        except KeyboardInterrupt:  # :TODO: TEST!
+            self.terminateBuild(TaskMaster.BUILD_INTERRUPTED)
+        for worker, message in self.errors_:
+            self.spewResult(worker, message)
+        return self.status_
 
-  def status(self):
-    return self.status_
+    def onShutdown(self):
+        return False
 
-  def succeeded(self):
-    return self.status_ == TaskMaster.BUILD_SUCCEEDED
+    def recvSpawned(self, worker, message):
+        if self.status_ != TaskMaster.BUILD_IN_PROGRESS:
+            return
+
+        if not len(self.task_graph):
+            # If there are still tasks left to complete, they're waiting on others
+            # to finish. Mark this process as ready and just ignore the status
+            # change for now.
+            self.idle_.add(worker)
+            return
+
+        self.issue_next_task(worker)
+
+    def issue_next_task(self, worker):
+        task = self.task_graph.pop()
+        message = {
+            'id': 'task',
+            'task_id': task.id,
+            'task_type': task.type,
+            'task_data': task.data,
+            'task_folder': task.folder,
+            'task_outputs': task.outputs,
+            'task_tools_env': task.tools_env,
+        }
+        worker.channel.send(message)
+        self.pending_[worker.pid] = task
+
+    def pump(self):
+        with process_manager.ChannelPoller(self.cx, self.workers_) as poller:
+            while self.status_ == TaskMaster.BUILD_IN_PROGRESS:
+                try:
+                    proc, obj = poller.poll()
+                    if obj['id'] not in self.messageMap:
+                        raise Exception('Unhandled message type: {}'.format(obj['id']))
+                    self.messageMap[obj['id']](proc, obj)
+                except EOFError:
+                    # The process died. Very sad. Clean up and fail the build.
+                    util.con_err(util.ConsoleBlue, '[{0}]'.format(proc.pid), util.ConsoleNormal,
+                                 ' ', util.ConsoleRed, 'Worker unexpectedly exited.')
+                    self.terminateBuild(TaskMaster.BUILD_FAILED)
+                    break
+
+    def status(self):
+        return self.status_
+
+    def succeeded(self):
+        return self.status_ == TaskMaster.BUILD_SUCCEEDED

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -1,4 +1,4 @@
-# vim: set sts=2 ts=8 sw=2 tw=99 et: 
+# vim: set sts=2 ts=8 sw=2 tw=99 et:
 import errno
 import subprocess
 import re, os, sys, locale
@@ -7,527 +7,525 @@ import platform
 from tempfile import NamedTemporaryFile
 
 try:
-  import __builtin__ as builtins
+    import __builtin__ as builtins
 except ImportError:
-  import builtins
+    import builtins
 try:
-  import cPickle as pickle
+    import cPickle as pickle
 except ImportError:
-  import pickle
+    import pickle
 
 # When present, we know this was not installed with distutils, because
 # distutils is no longer supported.
 INSTALLED_BY_PIP_OR_SETUPTOOLS = True
 
 def NormalizeArchString(arch):
-  # We normalize platforms across different operating systems.
-  if arch in ['x86_64', 'AMD64', 'x64', 'amd64']:
-    return 'x86_64'
-  if arch in ['x86', 'i386', 'i686', 'x32', 'ia32']:
-    return 'x86'
-  if arch.startswith('arm64') or arch.startswith('armv8') or arch.startswith('aarch64'):
-    return 'arm64'
-  if not arch:
-    return 'unknown'
-  return arch
+    # We normalize platforms across different operating systems.
+    if arch in ['x86_64', 'AMD64', 'x64', 'amd64']:
+        return 'x86_64'
+    if arch in ['x86', 'i386', 'i686', 'x32', 'ia32']:
+        return 'x86'
+    if arch.startswith('arm64') or arch.startswith('armv8') or arch.startswith('aarch64'):
+        return 'arm64'
+    if not arch:
+        return 'unknown'
+    return arch
 
 Architecture = NormalizeArchString(platform.machine())
 
 def Platform():
-  if IsWindows():
-    return 'windows'
-  if IsMac():
-    return 'mac'
-  if IsLinux():
-    return 'linux'
-  if IsFreeBSD():
-    return 'freebsd'
-  if IsOpenBSD():
-    return 'openbsd'
-  if IsNetBSD():
-    return 'netbsd'
-  if IsSolaris():
-    return 'solaris'
-  if IsCygwin():
-    return 'cygwin'
-  return 'unknown'
+    if IsWindows():
+        return 'windows'
+    if IsMac():
+        return 'mac'
+    if IsLinux():
+        return 'linux'
+    if IsFreeBSD():
+        return 'freebsd'
+    if IsOpenBSD():
+        return 'openbsd'
+    if IsNetBSD():
+        return 'netbsd'
+    if IsSolaris():
+        return 'solaris'
+    if IsCygwin():
+        return 'cygwin'
+    return 'unknown'
 
 def IsLinux():
-  return sys.platform[0:5] == 'linux'
+    return sys.platform[0:5] == 'linux'
 
 def IsFreeBSD():
-  return sys.platform[0:7] == 'freebsd'
+    return sys.platform[0:7] == 'freebsd'
 
 def IsNetBSD():
-  return sys.platform[0:6] == 'netbsd'
+    return sys.platform[0:6] == 'netbsd'
 
 def IsOpenBSD():
-  return sys.platform[0:7] == 'openbsd'
+    return sys.platform[0:7] == 'openbsd'
 
 def IsWindows():
-  return sys.platform == 'win32'
+    return sys.platform == 'win32'
 
 def IsCygwin():
-  return sys.platform == 'cygwin'
+    return sys.platform == 'cygwin'
 
 def IsMac():
-  return sys.platform == 'darwin' or sys.platform[0:6] == 'Darwin'
+    return sys.platform == 'darwin' or sys.platform[0:6] == 'Darwin'
 
 def IsSolaris():
-  return sys.platform[0:5] == 'sunos'
+    return sys.platform[0:5] == 'sunos'
 
 def IsUnixy():
-  return not IsWindows()
+    return not IsWindows()
 
 def IsBSD():
-  return IsMac() or IsFreeBSD() or IsOpenBSD() or IsNetBSD()
+    return IsMac() or IsFreeBSD() or IsOpenBSD() or IsNetBSD()
 
 if IsWindows():
-  ExecutableSuffix = '.exe'
+    ExecutableSuffix = '.exe'
 else:
-  ExecutableSuffix = ''
+    ExecutableSuffix = ''
 
 if IsWindows():
-  SharedLibSuffix = '.dll'
+    SharedLibSuffix = '.dll'
 elif sys.platform == 'darwin':
-  SharedLibSuffix = '.dylib'
+    SharedLibSuffix = '.dylib'
 else:
-  SharedLibSuffix = '.so'
+    SharedLibSuffix = '.so'
 
 if IsUnixy():
-  StaticLibSuffix = '.a'
+    StaticLibSuffix = '.a'
 else:
-  StaticLibSuffix = '.lib'
+    StaticLibSuffix = '.lib'
 
 if IsWindows():
-  StaticLibPrefix = ''
+    StaticLibPrefix = ''
 else:
-  StaticLibPrefix = 'lib'
+    StaticLibPrefix = 'lib'
 
 def WaitForProcess(process):
-  out, err = process.communicate()
-  process.stdoutText = DecodeConsoleText(sys.stdout, out)
-  process.stderrText = DecodeConsoleText(sys.stderr, err)
-  return process.returncode
+    out, err = process.communicate()
+    process.stdoutText = DecodeConsoleText(sys.stdout, out)
+    process.stderrText = DecodeConsoleText(sys.stderr, err)
+    return process.returncode
 
 def CreateProcess(argv, executable = None, env = None):
-  pargs = { 'args': argv }
-  pargs['stdout'] = subprocess.PIPE
-  pargs['stderr'] = subprocess.PIPE
-  if executable != None:
-    pargs['executable'] = executable
-  if env != None:
-    pargs['env'] = env
-  try:
-    process = subprocess.Popen(**pargs)
-  except:
-    return None
-  return process
+    pargs = {'args': argv}
+    pargs['stdout'] = subprocess.PIPE
+    pargs['stderr'] = subprocess.PIPE
+    if executable != None:
+        pargs['executable'] = executable
+    if env != None:
+        pargs['env'] = env
+    try:
+        process = subprocess.Popen(**pargs)
+    except:
+        return None
+    return process
 
 def MakePath(*list):
-  path = os.path.join(*list)
-  if IsWindows():
-    path = path.replace('\\\\', '\\')
-  return path
+    path = os.path.join(*list)
+    if IsWindows():
+        path = path.replace('\\\\', '\\')
+    return path
 
 def RemoveFolderAndContents(path):
-  for file in os.listdir(path):
-    subpath = os.path.join(path, file)
-    try:
-      if os.path.isfile(subpath) or os.path.islink(subpath):
-        os.unlink(subpath)
-      elif os.path.isdir(subpath):
-        RemoveFolderAndContents(subpath)
-    except:
-      pass
-  os.rmdir(path)
+    for file in os.listdir(path):
+        subpath = os.path.join(path, file)
+        try:
+            if os.path.isfile(subpath) or os.path.islink(subpath):
+                os.unlink(subpath)
+            elif os.path.isdir(subpath):
+                RemoveFolderAndContents(subpath)
+        except:
+            pass
+    os.rmdir(path)
 
 class FolderChanger:
-  def __init__(self, folder):
-    self.old = os.getcwd()
-    self.new = folder
+    def __init__(self, folder):
+        self.old = os.getcwd()
+        self.new = folder
 
-  def __enter__(self):
-    if self.new:
-      os.chdir(self.new)
+    def __enter__(self):
+        if self.new:
+            os.chdir(self.new)
 
-  def __exit__(self, type, value, traceback):
-    os.chdir(self.old)
+    def __exit__(self, type, value, traceback):
+        os.chdir(self.old)
 
 class Guard:
-  def __init__(self, obj):
-    self.obj = obj
+    def __init__(self, obj):
+        self.obj = obj
 
-  def __enter__(self):
-    return self.obj
+    def __enter__(self):
+        return self.obj
 
-  def __exit__(self, type, value, traceback):
-    self.obj.close()
+    def __exit__(self, type, value, traceback):
+        self.obj.close()
 
 def Execute(argv, shell = False, env = None):
-  p = subprocess.Popen(
-      args=argv,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.PIPE,
-      shell=shell,
-      env=env
-  )
-  stdout, stderr = p.communicate()
-  out = DecodeConsoleText(sys.stdout, stdout)
-  err = DecodeConsoleText(sys.stderr, stderr)
-  return p, out, err
+    p = subprocess.Popen(args = argv,
+                         stdout = subprocess.PIPE,
+                         stderr = subprocess.PIPE,
+                         shell = shell,
+                         env = env)
+    stdout, stderr = p.communicate()
+    out = DecodeConsoleText(sys.stdout, stdout)
+    err = DecodeConsoleText(sys.stderr, stderr)
+    return p, out, err
 
 def typeof(x):
-  return builtins.type(x)
+    return builtins.type(x)
 
 if str == bytes:
-  # Python 2.7. sqlite blob is buffer
-  BlobType = buffer
+    # Python 2.7. sqlite blob is buffer
+    BlobType = buffer
 else:
-  BlobType = bytes
+    BlobType = bytes
 
 def Unpickle(blob):
-  if type(blob) != bytes:
-    blob = bytes(blob)
-  return pickle.loads(blob)
+    if type(blob) != bytes:
+        blob = bytes(blob)
+    return pickle.loads(blob)
 
 # We don't want to dump Python 3 pickle format since then ambuild couldn't
 # run it if you using Python 2.
 PICKLE_PROTOCOL = min(2, pickle.HIGHEST_PROTOCOL)
 
 def DiskPickle(obj, fp):
-  return pickle.dump(obj, fp, PICKLE_PROTOCOL)
+    return pickle.dump(obj, fp, PICKLE_PROTOCOL)
 
 def CompatPickle(obj):
-  return pickle.dumps(obj, PICKLE_PROTOCOL)
+    return pickle.dumps(obj, PICKLE_PROTOCOL)
 
 def str2b(s):
-  if bytes is str:
-    return s
-  return bytes(s, 'utf8')
+    if bytes is str:
+        return s
+    return bytes(s, 'utf8')
 
 sReadIncludes = 0
 sLookForIncludeGuard = 1
 sFoundIncludeGuard = 2
 sIgnoring = 3
-def ParseGCCDeps(text):
-  deps = set()
-  strip = False
-  new_text = ''
 
-  state = sReadIncludes
-  for line in re.split('\n+', text):
-    line = line.replace('\r', '')
-    if state == sReadIncludes:
-      m = re.match('[\.!x]\.*\s+(.+)\s*$', line)
-      if m == None:
-        state = sLookForIncludeGuard
-      else:
-        name = m.groups()[0]
-        if os.path.exists(name):
-          strip = True
-          deps.add(name)
-        else:
-          state = sLookForIncludeGuard
-    if state == sLookForIncludeGuard:
-      if line.startswith('Multiple include guards may be useful for:'):
-        state = sFoundIncludeGuard
-        strip = True
-      else:
-        state = sReadIncludes
-        strip = False
-    elif state == sFoundIncludeGuard:
-      if not line in deps:
-        strip = False
-        state = sIgnoring
-    if not strip and len(line):
-      new_text += line + '\n'
-  return new_text, deps
+def ParseGCCDeps(text):
+    deps = set()
+    strip = False
+    new_text = ''
+
+    state = sReadIncludes
+    for line in re.split('\n+', text):
+        line = line.replace('\r', '')
+        if state == sReadIncludes:
+            m = re.match('[\.!x]\.*\s+(.+)\s*$', line)
+            if m == None:
+                state = sLookForIncludeGuard
+            else:
+                name = m.groups()[0]
+                if os.path.exists(name):
+                    strip = True
+                    deps.add(name)
+                else:
+                    state = sLookForIncludeGuard
+        if state == sLookForIncludeGuard:
+            if line.startswith('Multiple include guards may be useful for:'):
+                state = sFoundIncludeGuard
+                strip = True
+            else:
+                state = sReadIncludes
+                strip = False
+        elif state == sFoundIncludeGuard:
+            if not line in deps:
+                strip = False
+                state = sIgnoring
+        if not strip and len(line):
+            new_text += line + '\n'
+    return new_text, deps
 
 def ParseMSVCDeps(vars, out):
-  if 'cc_inclusion_pattern' in vars:
-    pattern = vars['cc_inclusion_pattern']
-  elif 'cxx_inclusion_pattern' in vars:
-    pattern = vars['cxx_inclusion_pattern']
-  elif 'msvc_inclusion_pattern' in vars:
-    pattern = vars['msvc_inclusion_pattern']
-  else:
-    pattern = 'Note: including file:\s+(.+)$'
-
-  deps = []
-  new_text = ''
-  out = out.replace('\r\n', '\n')
-  out = out.replace('\r', '\n')
-  for line in out.split('\n'):
-    m = re.search(pattern, line)
-    if m != None:
-      file = m.group(1).strip()
-      deps.append(file)
+    if 'cc_inclusion_pattern' in vars:
+        pattern = vars['cc_inclusion_pattern']
+    elif 'cxx_inclusion_pattern' in vars:
+        pattern = vars['cxx_inclusion_pattern']
+    elif 'msvc_inclusion_pattern' in vars:
+        pattern = vars['msvc_inclusion_pattern']
     else:
-      new_text += line + '\n'
-  return new_text, deps
+        pattern = 'Note: including file:\s+(.+)$'
+
+    deps = []
+    new_text = ''
+    out = out.replace('\r\n', '\n')
+    out = out.replace('\r', '\n')
+    for line in out.split('\n'):
+        m = re.search(pattern, line)
+        if m != None:
+            file = m.group(1).strip()
+            deps.append(file)
+        else:
+            new_text += line + '\n'
+    return new_text, deps
 
 def ParseFXCDeps(out):
-  out = out.replace('\r\n', '\n')
-  out = out.replace('\r', '\n')
+    out = out.replace('\r\n', '\n')
+    out = out.replace('\r', '\n')
 
-  deps = []
-  new_text = ''
-  for line in out.split('\n'):
-    # The inclusion pattern is probably translated, but for now we ignore this possibilty.
-    m = re.match('Opening file \[.*\], stack top \[.*\]', line)
-    if m is not None:
-      continue
-    m = re.match('Current working dir \[.*\]', line)
-    if m is not None:
-      continue
-    m = re.match('Resolved to \[(.+)\]', line)
-    if m is not None:
-      deps.append(m.group(1).strip())
-      continue
-    new_text += line + '\n'
+    deps = []
+    new_text = ''
+    for line in out.split('\n'):
+        # The inclusion pattern is probably translated, but for now we ignore this possibilty.
+        m = re.match('Opening file \[.*\], stack top \[.*\]', line)
+        if m is not None:
+            continue
+        m = re.match('Current working dir \[.*\]', line)
+        if m is not None:
+            continue
+        m = re.match('Resolved to \[(.+)\]', line)
+        if m is not None:
+            deps.append(m.group(1).strip())
+            continue
+        new_text += line + '\n'
 
-  return new_text, deps
+    return new_text, deps
 
 def ParseSunDeps(text):
-  deps = set()
-  new_text = ''
+    deps = set()
+    new_text = ''
 
-  for line in re.split('\n+', text):
-    name = line.lstrip()
-    if os.path.isfile(name):
-      deps.add(name)
-    else:
-      new_text += line + '\n'
-  return new_text.strip(), deps
+    for line in re.split('\n+', text):
+        name = line.lstrip()
+        if os.path.isfile(name):
+            deps.add(name)
+        else:
+            new_text += line + '\n'
+    return new_text.strip(), deps
 
 if hasattr(os, 'symlink'):
-  def symlink(target, link):
-    os.symlink(target, link)
-    return 0, '', ''
+
+    def symlink(target, link):
+        os.symlink(target, link)
+        return 0, '', ''
 elif IsWindows():
-  def symlink(target, link):
-    argv = [
-      'mklink',
-      '"{0}"'.format(link),
-      '"{0}"'.format(target)
-    ]
-    p, out, err = Execute(argv, shell=True)
-    return p.returncode, out, err
+
+    def symlink(target, link):
+        argv = ['mklink', '"{0}"'.format(link), '"{0}"'.format(target)]
+        p, out, err = Execute(argv, shell = True)
+        return p.returncode, out, err
 
 # Detect whether the filesystem supports symlinks. This is a conservative
 # test. It can fail if, for example, the current working directly is not
 # writable. This creates local temporary files; it's intended to be called
 # inside temporary folders or cache folders.
 def DetectSymlinkSupport():
-  if not hasattr(os, 'symlink'):
-    return False
+    if not hasattr(os, 'symlink'):
+        return False
 
-  with NamedTemporaryFile() as fp:
-    try:
-      random_name = str(uuid.uuid4())
-      os.symlink(fp.name, random_name)
-      os.unlink(random_name)
-    except:
-      return False
+    with NamedTemporaryFile() as fp:
+        try:
+            random_name = str(uuid.uuid4())
+            os.symlink(fp.name, random_name)
+            os.unlink(random_name)
+        except:
+            return False
 
-  return True
-
+    return True
 
 if IsUnixy():
-  ConsoleGreen = lambda fp: fp.write('\033[92m')
-  ConsoleRed = lambda fp: fp.write('\033[91m')
-  ConsoleNormal = lambda fp: fp.write('\033[0m')
-  ConsoleBlue = lambda fp: fp.write('\033[94m')
-  ConsoleHeader = lambda fp: fp.write('\033[95m')
+    ConsoleGreen = lambda fp: fp.write('\033[92m')
+    ConsoleRed = lambda fp: fp.write('\033[91m')
+    ConsoleNormal = lambda fp: fp.write('\033[0m')
+    ConsoleBlue = lambda fp: fp.write('\033[94m')
+    ConsoleHeader = lambda fp: fp.write('\033[95m')
 elif IsWindows():
-  def SwitchColor(fp, color):
-    import ctypes
 
-    STD_OUTPUT_HANDLE = -11
-    STD_ERROR_HANDLE = -12
-    
-    # Ensure previously colored text is flushed before changing colors again. Otherwise text may
-    # not be colored as expected
-    fp.flush()
+    def SwitchColor(fp, color):
+        import ctypes
 
-    std = None
-    if fp == sys.stdout:
-      std = STD_OUTPUT_HANDLE
-    elif fp == sys.stdin:
-      std = STD_ERROR_HANDLE
-    if std is None:
-      return
+        STD_OUTPUT_HANDLE = -11
+        STD_ERROR_HANDLE = -12
 
-    handle = ctypes.windll.kernel32.GetStdHandle(std)
-    ctypes.windll.kernel32.SetConsoleTextAttribute(handle, color)
+        # Ensure previously colored text is flushed before changing colors again. Otherwise text may
+        # not be colored as expected
+        fp.flush()
 
-  ConsoleGreen = lambda fp: SwitchColor(fp, 0xA)
-  ConsoleRed = lambda fp: SwitchColor(fp, 0xC)
-  ConsoleNormal = lambda fp: SwitchColor(fp, 0x7)
-  ConsoleBlue = lambda fp: SwitchColor(fp, 0x9)
-  ConsoleHeader = lambda fp: SwitchColor(fp, 0xD)
+        std = None
+        if fp == sys.stdout:
+            std = STD_OUTPUT_HANDLE
+        elif fp == sys.stdin:
+            std = STD_ERROR_HANDLE
+        if std is None:
+            return
+
+        handle = ctypes.windll.kernel32.GetStdHandle(std)
+        ctypes.windll.kernel32.SetConsoleTextAttribute(handle, color)
+
+    ConsoleGreen = lambda fp: SwitchColor(fp, 0xA)
+    ConsoleRed = lambda fp: SwitchColor(fp, 0xC)
+    ConsoleNormal = lambda fp: SwitchColor(fp, 0x7)
+    ConsoleBlue = lambda fp: SwitchColor(fp, 0x9)
+    ConsoleHeader = lambda fp: SwitchColor(fp, 0xD)
 else:
-  ConsoleGreen = ''
-  ConsoleRed = ''
-  ConsoleNormal = ''
-  ConsoleBlue = ''
-  ConsoleHeader = ''
+    ConsoleGreen = ''
+    ConsoleRed = ''
+    ConsoleNormal = ''
+    ConsoleBlue = ''
+    ConsoleHeader = ''
 
 def IsColor(text):
-  return IsLambda(text)
+    return IsLambda(text)
 
 sConsoleColorsEnabled = True
+
 def DisableConsoleColors():
-  global sConsoleColorsEnabled
-  sConsoleColorsEnabled = False
+    global sConsoleColorsEnabled
+    sConsoleColorsEnabled = False
 
 def con_print(fp, args):
-  for arg in args:
-    if IsColor(arg):
-      arg(fp)
-    else:
-      fp.write(arg)
-  fp.write('\n')
+    for arg in args:
+        if IsColor(arg):
+            arg(fp)
+        else:
+            fp.write(arg)
+    fp.write('\n')
 
 def con_print_simple(fp, args):
-  for arg in args:
-    if IsColor(arg):
-      continue
-    fp.write(arg)
-  fp.write('\n')
+    for arg in args:
+        if IsColor(arg):
+            continue
+        fp.write(arg)
+    fp.write('\n')
 
 def con_out(*args):
-  if sys.stdout.isatty():
-    con_print(sys.stdout, args)
-  else:
-    con_print_simple(sys.stdout, args)
+    if sys.stdout.isatty():
+        con_print(sys.stdout, args)
+    else:
+        con_print_simple(sys.stdout, args)
 
 def con_err(*args):
-  if sys.stderr.isatty():
-    con_print(sys.stderr, args)
-  else:
-    con_print_simple(sys.stderr, args)
+    if sys.stderr.isatty():
+        con_print(sys.stderr, args)
+    else:
+        con_print_simple(sys.stderr, args)
 
 LambdaType = type(lambda: None)
 
 def IsLambda(v):
-  return type(v) == LambdaType
+    return type(v) == LambdaType
 
 # In Python 3, basestring causes a NameError
 def StringType():
-  try:
-    return basestring
-  except NameError:
-    return str
+    try:
+        return basestring
+    except NameError:
+        return str
 
 def IsString(v):
-  return isinstance(v, StringType())
+    return isinstance(v, StringType())
 
 class Expando(object):
-  pass
+    pass
 
 def rm_path(path):
-  assert not os.path.isabs(path)
+    assert not os.path.isabs(path)
 
-  if os.path.exists(path):
-    con_out(ConsoleHeader, 'Removing old output: ',
-            ConsoleBlue, '{0}'.format(path),
-            ConsoleNormal)
+    if os.path.exists(path):
+        con_out(ConsoleHeader, 'Removing old output: ', ConsoleBlue, '{0}'.format(path),
+                ConsoleNormal)
 
-  try:
-    os.unlink(path)
-  except OSError as exn:
-    if exn.errno != errno.ENOENT:
-      con_err(ConsoleRed, 'Could not remove file: ',
-              ConsoleBlue, '{0}'.format(path),
-              ConsoleNormal, '\n',
-              ConsoleRed, '{0}'.format(exn),
-              ConsoleNormal)
-      raise
+    try:
+        os.unlink(path)
+    except OSError as exn:
+        if exn.errno != errno.ENOENT:
+            con_err(ConsoleRed, 'Could not remove file: ', ConsoleBlue, '{0}'.format(path),
+                    ConsoleNormal, '\n', ConsoleRed, '{0}'.format(exn), ConsoleNormal)
+            raise
 
 def DecodeConsoleText(origin, text):
-  try:
-    if origin.encoding:
-      return text.decode(origin.encoding, 'replace')
-  except:
-    pass
+    try:
+        if origin.encoding:
+            return text.decode(origin.encoding, 'replace')
+    except:
+        pass
 
-  try:
-    return text.decode(locale.getpreferredencoding(), 'replace')
-  except:
-    pass
+    try:
+        return text.decode(locale.getpreferredencoding(), 'replace')
+    except:
+        pass
 
-  return text.decode('utf8', 'replace')
+    return text.decode('utf8', 'replace')
 
 def WriteEncodedText(fd, text):
-  if not hasattr(fd, 'encoding') or fd.encoding == None:
-    text = text.encode(locale.getpreferredencoding(), 'replace')
-  fd.write(text)
+    if not hasattr(fd, 'encoding') or fd.encoding == None:
+        text = text.encode(locale.getpreferredencoding(), 'replace')
+    fd.write(text)
 
 class CmpOrderable(object):
-  def __init__(self):
-    super(CmpOrderable, self).__init__()
+    def __init__(self):
+        super(CmpOrderable, self).__init__()
 
-  def __lt__(self, other):
-    return self.__cmp__(other) < 0
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0
 
-  def __le__(self, other):
-    return self.__cmp__(other) <= 0
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
 
-  def __eq__(self, other):
-    return self.__cmp__(other) == 0
+    def __eq__(self, other):
+        return self.__cmp__(other) == 0
 
-  def __ne__(self, other):
-    return self.__cmp__(other) != 0
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
 
-  def __gt__(self, other):
-    return self.__cmp__(other) > 0
+    def __gt__(self, other):
+        return self.__cmp__(other) > 0
 
-  def __ge__(self, other):
-    return self.__cmp__(other) >= 0
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
 
 if str == bytes:
-  class Orderable(object):
-    pass
-  compare = cmp
+
+    class Orderable(object):
+        pass
+
+    compare = cmp
 else:
-  class Orderable(CmpOrderable):
-    pass
-  compare = lambda a, b: (a > b) - (a < b)
+
+    class Orderable(CmpOrderable):
+        pass
+
+    compare = lambda a, b: (a > b) - (a < b)
 
 # Return the relative path from prefix_path to search_path, if search_path
 # begins with prefix_path.
 def RelPathIfCommon(search_path, prefix_path):
-  search_path = os.path.normpath(search_path)
-  prefix_path = os.path.normpath(prefix_path)
+    search_path = os.path.normpath(search_path)
+    prefix_path = os.path.normpath(prefix_path)
 
-  # relpath will assert on Windows if the drives don't match.
-  search_drive = os.path.splitdrive(search_path)[0]
-  prefix_drive = os.path.splitdrive(prefix_path)[0]
-  if search_drive.lower() != prefix_drive.lower():
-    # Different drives, can't possibly be in the same path.
-    return None
+    # relpath will assert on Windows if the drives don't match.
+    search_drive = os.path.splitdrive(search_path)[0]
+    prefix_drive = os.path.splitdrive(prefix_path)[0]
+    if search_drive.lower() != prefix_drive.lower():
+        # Different drives, can't possibly be in the same path.
+        return None
 
-  # If the relative path from prefix to search starts with a .., then we know
-  # there is no common folder because we had to leave the prefix path.
-  rel_path = os.path.relpath(search_path, prefix_path)
-  if rel_path.startswith('..'):
-    return None
+    # If the relative path from prefix to search starts with a .., then we know
+    # there is no common folder because we had to leave the prefix path.
+    rel_path = os.path.relpath(search_path, prefix_path)
+    if rel_path.startswith('..'):
+        return None
 
-  assert not os.path.isabs(rel_path)
-  return rel_path
+    assert not os.path.isabs(rel_path)
+    return rel_path
 
 # Build an environment from an iterable of environment commands.
 def BuildEnv(cmds, env = None):
-  if env is None:
-    env = os.environ.copy()
-  for cmd, key, value in cmds:
-    if cmd == 'replace':
-      env[key] = value
-    elif cmd == 'add':
-      if key in env:
-        env[key] += value
-      else:
-        env[key] = value
-  return env
+    if env is None:
+        env = os.environ.copy()
+    for cmd, key, value in cmds:
+        if cmd == 'replace':
+            env[key] = value
+        elif cmd == 'add':
+            if key in env:
+                env[key] += value
+            else:
+                env[key] = value
+    return env

--- a/setup.py
+++ b/setup.py
@@ -4,73 +4,67 @@
 import sys
 
 def detect_distutils():
-  sys.path.pop(0)
-  try:
-    import ambuild2.util
+    sys.path.pop(0)
     try:
-      val = getattr(ambuild2.util, 'INSTALLED_BY_PIP_OR_SETUPTOOLS')
-    except AttributeError:
-      sys.exit(1)
-  except ImportError:
-    pass
+        import ambuild2.util
+        try:
+            val = getattr(ambuild2.util, 'INSTALLED_BY_PIP_OR_SETUPTOOLS')
+        except AttributeError:
+            sys.exit(1)
+    except ImportError:
+        pass
 
-  sys.exit(0)
+    sys.exit(0)
 
 # This if statement is supposedly required by multiprocessing.
 if __name__ == '__main__':
-  import os
-  import multiprocessing as mp
+    import os
+    import multiprocessing as mp
 
-  mp.freeze_support()
-  proc = mp.Process(target=detect_distutils)
-  proc.start()
-  proc.join()
+    mp.freeze_support()
+    proc = mp.Process(target = detect_distutils)
+    proc.start()
+    proc.join()
 
-  if proc.exitcode != 0:
-    sys.stderr.write('''You have an older installation of AMBuild. AMBuild must
+    if proc.exitcode != 0:
+        sys.stderr.write('''You have an older installation of AMBuild. AMBuild must
 now be installed using pip (see README.md). To prevent
 conflicts, please remove the old distutils version. You can
 do this by inspecting the following paths and removing
 any ambuild folders:
 \n''')
 
-    for path in sys.path[1:]:
-      for subdir in ['ambuild', 'ambuild2']:
-        subpath = os.path.join(path, subdir)
-        if os.path.exists(subpath):
-          sys.stderr.write('\t{}\n'.format(subpath))
+        for path in sys.path[1:]:
+            for subdir in ['ambuild', 'ambuild2']:
+                subpath = os.path.join(path, subdir)
+                if os.path.exists(subpath):
+                    sys.stderr.write('\t{}\n'.format(subpath))
 
-    sys.stderr.write('Aborting installation.\n')
-    sys.stderr.flush()
-    sys.exit(1)
+        sys.stderr.write('Aborting installation.\n')
+        sys.stderr.flush()
+        sys.exit(1)
 
-  from setuptools import setup, find_packages
-  try:
-    import sqlite3
-  except:
-    raise SystemError('py-sqlite3 must be installed')
+    from setuptools import setup, find_packages
+    try:
+        import sqlite3
+    except:
+        raise SystemError('py-sqlite3 must be installed')
 
-  amb_scripts = []
-  if sys.platform != 'win32':
-    if sys.platform == 'darwin':
-      amb_scripts.append('scripts/ambuild_dsymutil_wrapper.sh')
-    else:
-      amb_scripts.append('scripts/ambuild_objcopy_wrapper.sh')
+    amb_scripts = []
+    if sys.platform != 'win32':
+        if sys.platform == 'darwin':
+            amb_scripts.append('scripts/ambuild_dsymutil_wrapper.sh')
+        else:
+            amb_scripts.append('scripts/ambuild_objcopy_wrapper.sh')
 
-  setup(
-    name = 'AMBuild',
-    version = '2.0',
-    description = 'AlliedModders Build System',
-    author = 'David Anderson',
-    author_email = 'dvander@alliedmods.net',
-    url = 'http://www.alliedmods.net/ambuild',
-    packages = find_packages(),
-    python_requires='>=2.6',
-    entry_points = {
-      'console_scripts': [
-        'ambuild = ambuild2.run:cli_run'
-      ]
-    },
-    scripts=amb_scripts,
-    zip_safe=False
-  )
+    setup(name = 'AMBuild',
+          version = '2.0',
+          description = 'AlliedModders Build System',
+          author = 'David Anderson',
+          author_email = 'dvander@alliedmods.net',
+          url = 'http://www.alliedmods.net/ambuild',
+          packages = find_packages(),
+          python_requires = '>=2.6',
+          entry_points = {'console_scripts': ['ambuild = ambuild2.run:cli_run']},
+          scripts = amb_scripts,
+          zip_safe = False)

--- a/tests/always_dirty/configure.py
+++ b/tests/always_dirty/configure.py
@@ -3,13 +3,13 @@ API_VERSION = '2.1'
 
 import sys
 try:
-  from ambuild2 import run
-  if not run.HasAPI(API_VERSION):
-    raise Exception()
+    from ambuild2 import run
+    if not run.HasAPI(API_VERSION):
+        raise Exception()
 except:
-  sys.stderr.write('AMBuild {0} must be installed to build this project.\n'.format(API_VERSION))
-  sys.stderr.write('http://www.alliedmods.net/ambuild\n')
-  sys.exit(1)
+    sys.stderr.write('AMBuild {0} must be installed to build this project.\n'.format(API_VERSION))
+    sys.stderr.write('http://www.alliedmods.net/ambuild\n')
+    sys.exit(1)
 
-builder = run.BuildParser(sourcePath = sys.path[0], api=API_VERSION)
+builder = run.BuildParser(sourcePath = sys.path[0], api = API_VERSION)
 builder.Configure()

--- a/tests/always_dirty/generate.py
+++ b/tests/always_dirty/generate.py
@@ -2,8 +2,8 @@
 import datetime
 
 def main():
-  with open('sample.h', 'w') as fp:
-    fp.write("const char* DATE = {0};\n".format(datetime.datetime.now()))
+    with open('sample.h', 'w') as fp:
+        fp.write("const char* DATE = {0};\n".format(datetime.datetime.now()))
 
 if __name__ == '__main__':
     main()

--- a/tests/autoinclude/configure.py
+++ b/tests/autoinclude/configure.py
@@ -2,5 +2,5 @@
 import sys
 from ambuild2 import run
 
-builder = run.BuildParser(sourcePath = sys.path[0], api='2.1')
+builder = run.BuildParser(sourcePath = sys.path[0], api = '2.1')
 builder.Configure()

--- a/tests/autoinclude/generate_header.py
+++ b/tests/autoinclude/generate_header.py
@@ -2,7 +2,7 @@
 import sys
 
 with open(sys.argv[1], 'w') as fp:
-  fp.write("""
+    fp.write("""
 #ifndef HELLO_STRING
 # define HELLO_STRING "HELLO!"
 #endif

--- a/tests/cx_paths/configure.py
+++ b/tests/cx_paths/configure.py
@@ -2,5 +2,5 @@
 import sys
 from ambuild2 import run
 
-builder = run.BuildParser(sourcePath = sys.path[0], api="2.1")
+builder = run.BuildParser(sourcePath = sys.path[0], api = "2.1")
 builder.Configure()

--- a/tests/modules/configure.py
+++ b/tests/modules/configure.py
@@ -2,5 +2,5 @@
 import sys
 from ambuild2 import run
 
-builder = run.BuildParser(sourcePath = sys.path[0], api="2.1")
+builder = run.BuildParser(sourcePath = sys.path[0], api = "2.1")
 builder.Configure()

--- a/tests/shaders/configure.py
+++ b/tests/shaders/configure.py
@@ -3,13 +3,13 @@ API_VERSION = '2.1'
 
 import sys
 try:
-  from ambuild2 import run
-  if not run.HasAPI(API_VERSION):
-    raise Exception()
+    from ambuild2 import run
+    if not run.HasAPI(API_VERSION):
+        raise Exception()
 except:
-  sys.stderr.write('AMBuild {0} must be installed to build this project.\n'.format(API_VERSION))
-  sys.stderr.write('http://www.alliedmods.net/ambuild\n')
-  sys.exit(1)
+    sys.stderr.write('AMBuild {0} must be installed to build this project.\n'.format(API_VERSION))
+    sys.stderr.write('http://www.alliedmods.net/ambuild\n')
+    sys.exit(1)
 
-builder = run.BuildParser(sourcePath = sys.path[0], api=API_VERSION)
+builder = run.BuildParser(sourcePath = sys.path[0], api = API_VERSION)
 builder.Configure()

--- a/tests/shared_outputs/basic/generate_header.py
+++ b/tests/shared_outputs/basic/generate_header.py
@@ -2,7 +2,7 @@
 import sys
 
 with open(sys.argv[1], 'w') as fp:
-  fp.write("""
+    fp.write("""
 #ifndef HELLO_STRING
 # define HELLO_STRING "HELLO!"
 #endif

--- a/tests/shared_outputs/duplicates/generate_header.py
+++ b/tests/shared_outputs/duplicates/generate_header.py
@@ -2,7 +2,7 @@
 import sys
 
 with open(sys.argv[1], 'w') as fp:
-  fp.write("""
+    fp.write("""
 #ifndef HELLO_STRING
 # define HELLO_STRING "HELLO!"
 #endif

--- a/tests/shared_outputs/mixup/generate_header.py
+++ b/tests/shared_outputs/mixup/generate_header.py
@@ -2,7 +2,7 @@
 import sys
 
 with open(sys.argv[1], 'w') as fp:
-  fp.write("""
+    fp.write("""
 #ifndef HELLO_STRING
 # define HELLO_STRING "HELLO!"
 #endif

--- a/tests/shared_outputs/multiples/generate_header.py
+++ b/tests/shared_outputs/multiples/generate_header.py
@@ -2,7 +2,7 @@
 import sys
 
 with open(sys.argv[1], 'w') as fp:
-  fp.write("""
+    fp.write("""
 #ifndef HELLO_STRING
 # define HELLO_STRING "HELLO!"
 #endif


### PR DESCRIPTION
Two-space indents are particularly hard to read for Python code, so
this restyles everything using YAPF. I've picked the Google style, and
made a few changes for further readability:
 - 100 column limit, because we're in the year 2020.
 - Spaces around = in function calls, since AMBuild has a *lot* of
 these, and it looks dense otherwise.
 - No blank lines around class declarations.

Note: database.py is heavy on string literals, and YAPF did not do a good
job styling these (I'm not even sure what *would* be a good style). For
now, style rules don't apply there. I've also omitted restyling AMBuild 1
code because it's ancient.

Style is now checked as a GitHub action.