### PR TITLE
Added support for auto versioning of AMBuild.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ any ambuild folders:
           setup_requires = ['setuptools-git-versioning>=1.1.5'],
           version_config = {
               'template': '{tag}',
-              'dev_template': '{tag}.{ccount}-git.{sha}',
-              'dirty_template': '{tag}.{ccount}-git.{sha}.dirty',
+              'dev_template': '{tag}.{ccount}+git.{sha}',
+              'dirty_template': '{tag}.{ccount}+git.{sha}.dirty',
               'starting_version': '2.1.1'
           },
           entry_points = {'console_scripts': ['ambuild = ambuild2.run:cli_run']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,14 @@ any ambuild folders:
           author_email = 'dvander@alliedmods.net',
           url = 'http://www.alliedmods.net/ambuild',
           packages = find_packages(),
-          python_requires = '>=2.6',
+          python_requires = '>=2.7',
+          setup_requires = ['setuptools-git-versioning>=1.1.5'],
+          version_config = {
+              'template': '{tag}',
+              'dev_template': '{tag}.{ccount}-git.{sha}',
+              'dirty_template': '{tag}.{ccount}-git.{sha}.dirty',
+              'starting_version': '2.1.1'
+          },
           entry_points = {'console_scripts': ['ambuild = ambuild2.run:cli_run']},
           scripts = amb_scripts,
           zip_safe = False)


### PR DESCRIPTION
Note: The required plugin only supports Python 2.7+, pinned to minimum version of 1.1.5 (runtime issue/no Python 2.7 support on earlier versions)

Example output on my local machine: ```AMBuild-2.1.1.436+git.43ac8773```

Closes #82