### PR TITLE
Refactor the Projects API.

### DIFF
--- a/ambuild2/frontend/base_generator.py
+++ b/ambuild2/frontend/base_generator.py
@@ -45,3 +45,13 @@ class BaseGenerator(object):
 
     def addConfigureFile(self, context, path):
         raise Exception('Must be implemented!')
+
+    # The following methods are only needed to implement v2.2 generators.
+    def newProgramProject(self, name):
+        raise NotImplementedError()
+
+    def newLibraryProject(self, name):
+        raise NotImplementedError()
+
+    def newStaticLibraryProject(self, name):
+        raise NotImplementedError()

--- a/ambuild2/frontend/v2_2/amb2_gen.py
+++ b/ambuild2/frontend/v2_2/amb2_gen.py
@@ -17,6 +17,7 @@
 import os
 from ambuild2 import util
 from ambuild2.frontend import amb2
+from ambuild2.frontend.v2_2.cpp import builders
 from ambuild2.frontend.v2_2.cpp import detect
 
 class Generator(amb2.Generator):
@@ -26,3 +27,12 @@ class Generator(amb2.Generator):
     def detectCompilers(self, **kwargs):
         with util.FolderChanger(self.cacheFolder):
             return detect.AutoDetectCxx(self.cm.host, self.cm.options, **kwargs)
+
+    def newProgramProject(self, context, name):
+        return builders.Project(builders.Program, context, name)
+
+    def newLibraryProject(self, context, name):
+        return builders.Project(builders.Library, context, name)
+
+    def newStaticLibraryProject(self, context, name):
+        return builders.Project(builders.StaticLibrary, context, name)

--- a/ambuild2/frontend/v2_2/context.py
+++ b/ambuild2/frontend/v2_2/context.py
@@ -211,6 +211,15 @@ class BuildContext(BaseContext):
         else:
             self.buildFolder = os.path.normpath(folder)
 
+    def ProgramProject(self, name):
+        return self.generator_.newProgramProject(self, name)
+
+    def LibraryProject(self, name):
+        return self.generator_.newLibraryProject(self, name)
+
+    def StaticLibraryProject(self, name):
+        return self.generator_.newStaticLibraryProject(self, name)
+
 # Access to everything.
 class TopLevelBuildContext(BuildContext):
     def __init__(self, cm, parent, vars, script, sourceFolder, buildFolder):

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -71,10 +71,10 @@ class BuilderProxy(object):
         return Dep(text, node)
 
 class Project(object):
-    def __init__(self, constructor, compiler, name):
+    def __init__(self, constructor, context, name):
         super(Project, self).__init__()
         self.constructor_ = constructor
-        self.compiler = compiler
+        self.context_ = context
         self.name = name
         self.sources = []
         self.proxies_ = []
@@ -96,9 +96,8 @@ class Project(object):
             outputs += [builder.generate(generator, cx)]
         return outputs
 
-    def Configure(self, name, tag):
-        compiler = self.compiler.clone()
-        proxy = BuilderProxy(self, compiler, name)
+    def Configure(self, compiler, name, tag):
+        proxy = BuilderProxy(self, compiler.clone(), name)
         self.proxies_.append(proxy)
         return proxy
 

--- a/ambuild2/frontend/v2_2/cpp/compiler.py
+++ b/ambuild2/frontend/v2_2/cpp/compiler.py
@@ -125,15 +125,6 @@ class Compiler(Cloneable):
     def StaticLibrary(self, name):
         raise Exception('Must be implemented!')
 
-    def ProgramProject(self, name):
-        raise Exception('Must be implemented!')
-
-    def LibraryProject(self, name):
-        raise Exception('Must be implemented!')
-
-    def StaticLibraryProject(self, name):
-        raise Exception('Must be implemented!')
-
     @staticmethod
     def Dep(text, node = None):
         return builders.Dep(text, node)

--- a/tests/multiarch/core/AMBuild
+++ b/tests/multiarch/core/AMBuild
@@ -1,5 +1,10 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 
+project = builder.ProgramProject('sample')
+project.sources += [
+  'main.cpp',
+]
+
 for cxx in [builder.x86, builder.x64]:
     if cxx is None:
         continue
@@ -12,8 +17,6 @@ for cxx in [builder.x86, builder.x64]:
     elif cxx.like('msvc'):
         cxx.cflags += ['/WX']
 
-    program = cxx.Program('sample')
-    program.sources += [
-      'main.cpp',
-    ]
-    builder.Add(program)
+    project.Configure(cxx, 'sample', cxx.target.arch)
+
+builder.Add(project)


### PR DESCRIPTION
The Projects API was designed for multi-architecture use, back when we
had to hack support for that in each build script. Now, they need to be
decoupled from compilers to properly support multi-arch builds.

This patch removes the interface for projects off the C++ compiler and
into the build context, meaning, it will go through the generator. This
will also make vsgen support of the 2.2 API a little cleaner.