### PR TITLE
Improve failed build error messaging.

### DIFF
--- a/ambuild2/builder.py
+++ b/ambuild2/builder.py
@@ -117,7 +117,7 @@ class Builder(object):
                 util.con_err(util.ConsoleBlue, ' -> ', util.ConsoleRed,
                              '{0}'.format(task.entry.format()), util.ConsoleNormal)
 
-        return tm.status()
+        return tm.status(), tm.failed_task_message
 
     def lazyUpdateEntry(self, entry):
         if entry.type != nodetypes.Source:

--- a/ambuild2/context.py
+++ b/ambuild2/context.py
@@ -174,9 +174,13 @@ class Context(object):
             builder.printSteps()
             return True
 
-        status = builder.update()
+        status, message = builder.update()
         if status == TaskMaster.BUILD_FAILED:
-            util.con_err(util.ConsoleHeader, 'Build failed.', util.ConsoleNormal)
+            if message is None:
+                util.con_err(util.ConsoleHeader, 'Build failed.', util.ConsoleNormal)
+            else:
+                util.con_err(util.ConsoleHeader, 'Build failed: {}'.format(message),
+                             util.ConsoleNormal)
             return False
         if status == TaskMaster.BUILD_INTERRUPTED:
             util.con_err(util.ConsoleHeader, 'Build cancelled.', util.ConsoleNormal)


### PR DESCRIPTION
When a build fails, sometimes it's really hard to see what job it
actually fails on. For example, shared C++ files make this tricky. This
will make AMBuild print the name of the output that failed to generate.