### PR TITLE
Fix msvc detection on non-english installations

### DIFF
--- a/ambuild2/frontend/msvc_utils.py
+++ b/ambuild2/frontend/msvc_utils.py
@@ -75,6 +75,7 @@ class MSVCFinder(object):
             '*',
             '-requires',
             'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+            '-utf8',
         ]
         try:
             output = subprocess.check_output(argv)


### PR DESCRIPTION
`vswhere` encodes the output using the system's code page by default. Python tries to parse the output as utf8, so tell vswhere to output utf8 too.