### PR TITLE
Fix --vs-version selection by year

### DIFF
--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -43,14 +43,14 @@ class Generator(BaseGenerator):
         if self.cm.options.vs_version in SupportedVersions:
             self.vs_version = int(self.cm.options.vs_version)
         else:
-            if self.options.vs_version not in YearMap:
+            if self.cm.options.vs_version not in YearMap:
                 util.con_err(
                     util.ConsoleRed,
-                    'Unsupported Visual Studio version: {0}'.format(self.options.vs_version),
+                    'Unsupported Visual Studio version: {0}'.format(self.cm.options.vs_version),
                     util.ConsoleNormal)
                 raise Exception('Unsupported Visual Studio version: {0}'.format(
-                    self.options.vs_version))
-            self.vs_version = YearMap[self.options.vs_version]
+                    self.cm.options.vs_version))
+            self.vs_version = YearMap[self.cm.options.vs_version]
 
         self.cacheFile = os.path.join(self.cm.buildPath, '.cache')
         try:


### PR DESCRIPTION
Trying to generate Visual Studio project files and selecting the target version by --vs-version=2019 failed due to recent refactorings.