### PR TITLE
Add sub-architecture and ABI to System objects.

### DIFF
--- a/ambuild2/frontend/system.py
+++ b/ambuild2/frontend/system.py
@@ -17,11 +17,12 @@
 from ambuild2 import util
 
 class System(object):
-    def __init__(self, platform, arch, subarch = ''):
+    def __init__(self, platform, arch, subarch = '', abi = ''):
         super(System, self).__init__()
         self.platform_ = platform
         self.arch_ = arch
         self.subarch_ = subarch
+        self.abi_ = abi
 
     @property
     def platform(self):
@@ -35,4 +36,8 @@ class System(object):
     def subarch(self):
         return self.subarch_
 
-System.Host = System(util.Platform(), util.Architecture, util.SubArch)
+    @property
+    def abi(self):
+        return self.abi_
+
+System.Host = System(util.Platform(), util.Architecture, util.SubArch, util.DetectHostAbi())

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -49,6 +49,12 @@ class Dep(object):
 
         return item
 
+def TargetSuffix(target):
+    base = '{}-{}{}'.format(target.platform, target.arch, target.subarch)
+    if target.abi:
+        return base + '-' + target.abi
+    return base
+
 class BuilderProxy(object):
     def __init__(self, builder, compiler, name):
         self.constructor_ = builder.constructor_
@@ -56,8 +62,7 @@ class BuilderProxy(object):
         self.custom = builder.custom[:]
         self.compiler = compiler
         self.name_ = name
-        self.localFolder = os.path.join(
-            name, '{}-{}'.format(compiler.target.platform, compiler.target.arch))
+        self.localFolder = os.path.join(name, TargetSuffix(compiler.target))
 
     @property
     def outputFile(self):
@@ -292,8 +297,7 @@ class BinaryBuilder(object):
         self.used_cxx_ = False
         self.linker_ = None
         self.modules_ = []
-        self.localFolder = os.path.join(
-            name, '{}-{}'.format(compiler.target.platform, compiler.target.arch))
+        self.localFolder = os.path.join(name, TargetSuffix(compiler.target))
         self.has_code_ = False
 
     @property


### PR DESCRIPTION
This doesn't affect x86/x86_64 which have no subarch or abi to care about. On ARMv7 however, the System object looks more complicated. For example, on an r-pi 3: `("linux", "arm", "v71", "gnueabihf")`