### PR TITLE
Add support for cross-compilation.

### DIFF
--- a/ambuild2/frontend/system.py
+++ b/ambuild2/frontend/system.py
@@ -40,4 +40,11 @@ class System(object):
     def abi(self):
         return self.abi_
 
+    @property
+    def triple(self):
+        suffix = ''
+        if self.abi:
+            suffix += '-' + self.abi
+        return '{}-{}{}{}'.format(self.platform, self.arch, self.subarch, suffix)
+
 System.Host = System(util.Platform(), util.Architecture, util.SubArch, util.DetectHostAbi())

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -47,6 +47,17 @@ def DecodeArchString(arch):
 
 Architecture, SubArch = DecodeArchString(platform.machine())
 
+ALL_PLATFORMS = [
+    'windows',
+    'mac',
+    'linux',
+    'freebsd',
+    'openbsd',
+    'netbsd',
+    'solaris',
+    'cygwin',
+]
+
 def Platform():
     if IsWindows():
         return 'windows'


### PR DESCRIPTION
This introduces a new "target" option to DetectCxx, which can be a
full platform triple (or partial identifier). Currently, this only
supports systems which are trivially configured, eg, do not have extra
include or ldflag requirements. However, support for more advanced
systems could be easily added.

AMBuild achieves this on Linux by looking for a compiler in the
following form:

        <arch>-<platform>-<abi>-[gcc|g++]

The "platform" is currently always Linux. The abi defaults to "gnu" if
no disambiguation is needed.

On Mac and Windows, both native compilers have first-class support for
cross-compilation. The only effective change here is how AMBuild tests
the compiler.

For cross-compilation targets, we still emit test C and C++ source
files. However, the linked executable is never ran - we only verify that
compilation succeeded. We also do an extra preprocess step to grab
critical information about the compiler.

Example of this working for SourcePawn:

        python3 configure.py --targets=arm-gnueabihf,x86_64,x86

        Warning: build is being configured in the source tree.
        Re-using build folder: objdir
        Checking CC compiler (vendor test gcc)... ['arm-linux-gnueabihf-gcc', '-E', 'test.c']
        found gcc version 9.3, arm
        Checking CXX compiler (vendor test gcc)... ['arm-linux-gnueabihf-g++', '-E', 'test.cpp']
        found gcc version 9.3, arm
        Checking CC compiler (vendor test gcc)... ['clang', '-m64', 'test.c', '-o', 'test-c']
        found clang version 10.0, x86_64
        Checking CXX compiler (vendor test gcc)... ['clang++', '-m64', 'test.cpp', '-o', 'test-cxx']
        found clang version 10.0, x86_64
        Checking CC compiler (vendor test gcc)... ['clang', '-m32', 'test.c', '-o', 'test-c']
        found clang version 10.0, x86
        Checking CXX compiler (vendor test gcc)... ['clang++', '-m32', 'test.cpp', '-o', 'test-cxx']
        found clang version 10.0, x86

And on Windows:

        Warning: build is being configured in the source tree.
        Re-using build folder: objdir
        Checking CC compiler (vendor test msvc)... ['C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.27.29110\\bin\\HostX64\\ARM\\cl.exe', '-E', 'test.c', '-nologo']
        found msvc version 1927, arm
        Checking CXX compiler (vendor test msvc)... ['C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.27.29110\\bin\\HostX64\\ARM\\cl.exe', '-E', 'test.cpp', '-nologo']
        found msvc version 1927, arm