### PR TITLE
Add a way to write files as part of the build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/*/obj-*/
 *.pyc
 *.*~
 objdir
+*.o

--- a/ambuild2/database.py
+++ b/ambuild2/database.py
@@ -715,7 +715,6 @@ class Database(object):
       node = self.import_node(row[0], row[1:])
       aggregate(node)
 
-  # Find the list of commands that generate this shared output.
   def query_commands(self, aggregate):
     query = """
       select id, type, stamp, dirty, path, folder, data, env_id

--- a/ambuild2/frontend/amb2_gen.py
+++ b/ambuild2/frontend/amb2_gen.py
@@ -201,6 +201,9 @@ class Generator(BaseGenerator):
                 break
             components.append(name)
 
+        if not len(components):
+            return parent
+
         path = parent_path
         while len(components):
             name = components.pop()
@@ -719,6 +722,25 @@ class Generator(BaseGenerator):
                                weak_inputs = weak_inputs,
                                shared_outputs = shared_outputs,
                                env_data = env_data)
+
+    def addOutputFile(self, context, path, contents):
+        folder, filename = os.path.split(path)
+        if not filename:
+            raise Exception('Must specify a file, {} is a folder'.format(path))
+
+        folder_node = self.generateFolder(context.localFolder, folder)
+        data = {
+            'path': paths.Join(folder_node, filename),
+            'contents': contents,
+        }
+
+        _, outputs = self.addCommand(context = context,
+                                     node_type = nodetypes.BinWrite,
+                                     folder = folder_node,
+                                     data = data,
+                                     inputs = [],
+                                     outputs = [filename])
+        return outputs[0]
 
     def addConfigureFile(self, context, path):
         if not os.path.isabs(path) and context is not None:

--- a/ambuild2/frontend/v2_2/context.py
+++ b/ambuild2/frontend/v2_2/context.py
@@ -228,6 +228,9 @@ class BuildContext(BaseContext):
     def StaticLibraryProject(self, name):
         return self.generator_.newStaticLibraryProject(self, name)
 
+    def AddOutputFile(self, path, contents):
+        return self.generator_.addOutputFile(self, path, contents)
+
 # Access to everything.
 class TopLevelBuildContext(BuildContext):
     def __init__(self, cm, parent, vars, script, sourceFolder, buildFolder):

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -1,4 +1,4 @@
-# vim: set ts=8 sts=2 sw=2 tw=99 et:
+# vim: set ts=8 sts=4 sw=4 tw=99 et:
 #
 # This file is part of AMBuild.
 #

--- a/ambuild2/frontend/v2_2/cpp/gcc.py
+++ b/ambuild2/frontend/v2_2/cpp/gcc.py
@@ -1,4 +1,4 @@
-# vim: set ts=8 sts=2 sw=2 tw=99 et:
+# vim: set ts=8 sts=4 sw=4 tw=99 et:
 #
 # This file is part of AMBuild.
 #

--- a/ambuild2/frontend/v2_2/cpp/msvc.py
+++ b/ambuild2/frontend/v2_2/cpp/msvc.py
@@ -1,4 +1,4 @@
-# vim: set ts=8 sts=2 sw=2 tw=99 et:
+# vim: set ts=8 sts=4 sw=4 tw=99 et:
 #
 # This file is part of AMBuild.
 #

--- a/ambuild2/frontend/v2_2/cpp/vendor.py
+++ b/ambuild2/frontend/v2_2/cpp/vendor.py
@@ -1,4 +1,4 @@
-# vim: set ts=8 sts=2 sw=2 tw=99 et:
+# vim: set ts=8 sts=4 sw=4 tw=99 et:
 #
 # This file is part of AMBuild.
 #

--- a/ambuild2/nodetypes.py
+++ b/ambuild2/nodetypes.py
@@ -43,14 +43,6 @@ Mkdir = 'mkd'
 # not have a command counterpart.
 Copy = 'cp'
 
-# FolderCopy nodes snapshot the contents of a folder - non-recursively - and
-# become dirty when files are added or removed. They automatically maintain
-# individual copy links for each file in the folder.
-#
-# To ensure proper ordering, any files in the folder that are dependent on a
-# build action, will have their copy node properly depending on that action.
-CopyFolder = 'cpa'
-
 # Link nodes are a special command node, representing a symlink, from a source
 # to a destination. On operating systems where symlinking is not available or
 # unreliable, copies may be performed instead.
@@ -65,6 +57,11 @@ Cxx = 'cxx'
 # rc.exe on Windows.
 Rc = 'rc'
 
+# Bin nodes are a helper node. They write an embedded byte sequence directly to
+# a file. They have no inputs. It is a command-like node, meaning, it has an
+# attached output node.
+BinWrite = 'bin'
+
 NodeNames = {
     Source: 'source',
     Command: 'command',
@@ -72,7 +69,6 @@ NodeNames = {
     SharedOutput: 'output',
     Mkdir: 'mkdir',
     Copy: 'copy',
-    CopyFolder: 'copy -R',
     Symlink: 'symlink',
     Cxx: 'c++',
     Rc: 'rc'
@@ -85,7 +81,7 @@ def IsCommand(type):
     return type != Output and type != Source
 
 def HasAutoDependencies(type):
-    return type == CopyFolder or type == Cxx
+    return type == Cxx
 
 NOT_DIRTY = 0
 DIRTY = 1
@@ -110,6 +106,9 @@ class Entry(object):
 
         # Command nodes may have extra data associated with them; this is
         # usually an argv serialized by Python.
+        #
+        # For binary nodes, it is a dictionary containing the file name and
+        # file contents.
         self.blob = blob
 
         # For command nodes, this is a link to a 'Mkdir' node describing its


### PR DESCRIPTION
Previously, the only way to do this was to add a bunch of boilerplate,
creating a command node around something like "echo", or a custom
script. Simply opening and writing an output file would not be properly
integrated into the dependency graph.

The new API, "AddOutputFile", allows build scripts to specify a file
namd and its binary contents. This creates a job in the build and
returns a node that can be used as a dependency.