### PR TITLE
Remove the Dep API.

### DIFF
--- a/ambuild2/frontend/v2_2/context.py
+++ b/ambuild2/frontend/v2_2/context.py
@@ -175,13 +175,15 @@ class BuildContext(BaseContext):
         return self.generator_.addSource(self, source_path)
 
     def AddSymlink(self, source, output_path):
-        return self.generator_.addSymlink(self, source, output_path)
+        _, (entry,) = self.generator_.addSymlink(self, source, output_path)
+        return entry
 
     def AddFolder(self, folder):
         return self.generator_.addFolder(self, folder)
 
     def AddCopy(self, source, output_path):
-        return self.generator_.addCopy(self, source, output_path)
+        _, (entry,) = self.generator_.addCopy(self, source, output_path)
+        return entry
 
     def AddCommand(self,
                    inputs,
@@ -192,15 +194,16 @@ class BuildContext(BaseContext):
                    weak_inputs = [],
                    shared_outputs = [],
                    env_data = None):
-        return self.generator_.addShellCommand(self,
-                                               inputs,
-                                               argv,
-                                               outputs,
-                                               folder = folder,
-                                               dep_type = dep_type,
-                                               weak_inputs = weak_inputs,
-                                               shared_outputs = shared_outputs,
-                                               env_data = env_data)
+        _, entries = self.generator_.addShellCommand(self,
+                                                     inputs,
+                                                     argv,
+                                                     outputs,
+                                                     folder = folder,
+                                                     dep_type = dep_type,
+                                                     weak_inputs = weak_inputs,
+                                                     shared_outputs = shared_outputs,
+                                                     env_data = env_data)
+        return entries
 
     def Context(self, name):
         return self.cm.Context(name)


### PR DESCRIPTION
This was used by SourceMod to achieve special linkage rules for HL2SDK
shared libraries. Its functionality is easily replaced with Entry nodes
and weaklinkdeps.

Also, simplify AddSymlink and friends.