### PR TITLE
Fix var propagation on lambda contexts.

### DIFF
--- a/ambuild2/frontend/v2_2/context_manager.py
+++ b/ambuild2/frontend/v2_2/context_manager.py
@@ -120,6 +120,9 @@ class ContextManager(context_manager.ContextManager):
         return scriptGlobals.get('rvalue', None)
 
     def callBuilder(self, parent, fun):
+        if parent is not self.contextStack_[-1]:
+            raise Exception('Can only create child build contexts of the currently active context')
+
         cx = BuildContext(cm = self,
                           parent = parent,
                           vars = copy.copy(parent.vars_),
@@ -129,7 +132,7 @@ class ContextManager(context_manager.ContextManager):
 
         self.pushContext(cx)
         try:
-            rvalue = fun(cx)
+            rvalue = fun(cx.proxy_)
         finally:
             self.popContext()
         return rvalue


### PR DESCRIPTION
The "builder" that gets exposed is a proxy object that supports magic
cloning when the builder is nested. We need to expose this proxy, not
the outer context object.