### PR TITLE
Add helpers for ld/link.exe and ar/lib.exe

### DIFF
--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -701,7 +701,7 @@ class StaticLibrary(BinaryBuilder):
         return 'static'
 
     def compute_link_argv(self, cx, files):
-        return self.linker_.staticLinkArgv(files, self.outputFile)
+        return self.compiler.archiver.makeArgv(self.compiler.archiver_argv, files, self.outputFile)
 
     def perform_symbol_steps(self, cx):
         pass

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -668,8 +668,9 @@ class Program(BinaryBuilder):
             outputFile = self.outputFile)
 
 class Library(BinaryBuilder):
-    def __init__(self, compiler, name):
+    def __init__(self, compiler, name, build_static = False):
         super(Library, self).__init__(compiler, name)
+        self.build_static = build_static
 
     @staticmethod
     def buildName(compiler, name):

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -600,20 +600,20 @@ class BinaryBuilder(BinaryBuilderBase):
         shared_outputs = []
         if self.linker_.behavior == 'msvc':
             if link_type != 'static' and '/INCREMENTAL:NO' not in step.argv:
-                shared_outputs += [step.name + '.ilk']
+                shared_outputs += [step.base_name + '.ilk']
 
         if self.linker_.behavior == 'msvc':
             if self.type == 'library' and self.has_code_:
                 # In theory, .dlls should have exports, so MSVC will generate these
                 # files. If this turns out not to be true, we may have to get fancier.
-                step.outputs += [step.name + '.lib']
-                step.outputs += [step.name + '.exp']
+                step.outputs += [step.base_name + '.lib']
+                step.outputs += [step.base_name + '.exp']
 
         if self.linker_.like('emscripten'):
             if isinstance(self, Program):
                 # This might not be correct if the user is actually still using asm.js,
                 # we would need to look for `-s WASM=0` in the linker args to check.
-                step.outputs += [step.name + '.wasm']
+                step.outputs += [step.base_name + '.wasm']
 
         if self.compiler.symbol_files == 'separate' and link_type != 'static':
             self.performSymbolSteps(cx, step)

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -41,7 +41,7 @@ class BuilderProxy(object):
 
     @property
     def outputFile(self):
-        return self.constructor_.buildName(self.compiler, self.name_)
+        return self.constructor_.outputFile
 
     @property
     def type(self):
@@ -393,6 +393,15 @@ class BinaryBuilderBase(object):
         buildPath = os.path.normpath(os.path.join(buildPath, subfolder))
         return localFolder, buildPath
 
+class LinkerStep(object):
+    def __init__(self, base_name, type):
+        self.base_name = base_name
+        self.type = type
+        self.argv = []
+        self.outputs = []
+        self.debug_entry = None
+        self.shared_outputs = []
+
 class BinaryBuilder(BinaryBuilderBase):
     def __init__(self, compiler, name):
         super(BinaryBuilder, self).__init__(compiler, name)
@@ -407,7 +416,7 @@ class BinaryBuilder(BinaryBuilderBase):
 
     @property
     def outputFile(self):
-        return self.buildName(self.compiler, self.name_)
+        return self.computeLinkerOutputFile(self.name_, self.type)
 
     def generate(self, generator, cx):
         # Find dependencies
@@ -427,14 +436,7 @@ class BinaryBuilder(BinaryBuilderBase):
             elif obj.type == 'resource':
                 inputs.append(generator.addCxxRcTask(cx, obj))
 
-        return self.generate_linker_output(generator, cx, inputs)
-
-    def generate_linker_output(self, generator, cx, inputs):
-        # Add the link step.
-        folder_node = generator.generateFolder(cx.localFolder, self.localFolder)
-        output_file, debug_file = self.link(context = cx, folder = folder_node, inputs = inputs)
-
-        return CppNodes(output_file, debug_file, self.type, self.compiler.target)
+        return self.link(generator, cx, inputs)
 
     # Create a sub-component of the binary.
     def Module(self, context, name):
@@ -577,34 +579,51 @@ class BinaryBuilder(BinaryBuilderBase):
             for entry in pch_objects:
                 files.append(os.path.relpath(entry.path, localBuildFolder))
 
-        self.compute_link_step(cx, files)
+        # Build static libraries for shared libraries.
+        self.static_link_step = None
+        if self.type == 'library':
+            static_name = self.name_
+            if self.type == 'library' and self.linker_.behavior == 'msvc':
+                # Need to decorate the name since MSVC generates a .lib for dlls.
+                output_file = self.name_ + '_static'
+            self.static_link_step = self.computeLinkStep(cx, files, static_name, 'static')
 
-    def compute_link_step(self, cx, files):
-        self.argv = self.compute_link_argv(cx, files)
+        self.link_step = self.computeLinkStep(cx, files, self.name_, self.type)
 
-        self.linker_outputs = [self.outputFile]
-        self.debug_entry = None
+    def computeLinkStep(self, cx, files, name, link_type):
+        step = LinkerStep(name, link_type)
+        step.argv = self.computeLinkerArgv(cx, files, name, link_type)
+        step.outputs = [self.computeLinkerOutputFile(name, link_type)]
+
+        # The existence of .ilk files on Windows does not seem reliable, so we
+        # treat it as "shared" which does not participate in the DAG (yet).
+        shared_outputs = []
+        if self.linker_.behavior == 'msvc':
+            if link_type != 'static' and '/INCREMENTAL:NO' not in step.argv:
+                shared_outputs += [step.name + '.ilk']
 
         if self.linker_.behavior == 'msvc':
-            if isinstance(self, Library) and self.has_code_:
+            if self.type == 'library' and self.has_code_:
                 # In theory, .dlls should have exports, so MSVC will generate these
                 # files. If this turns out not to be true, we may have to get fancier.
-                self.linker_outputs += [self.name_ + '.lib']
-                self.linker_outputs += [self.name_ + '.exp']
+                step.outputs += [step.name + '.lib']
+                step.outputs += [step.name + '.exp']
 
         if self.linker_.like('emscripten'):
             if isinstance(self, Program):
                 # This might not be correct if the user is actually still using asm.js,
                 # we would need to look for `-s WASM=0` in the linker args to check.
-                self.linker_outputs += [self.name_ + '.wasm']
+                step.outputs += [step.name + '.wasm']
 
-        if self.compiler.symbol_files == 'separate':
-            self.perform_symbol_steps(cx)
+        if self.compiler.symbol_files == 'separate' and link_type != 'static':
+            self.performSymbolSteps(cx, step)
 
-    def perform_symbol_steps(self, cx):
+        return step
+
+    def performSymbolSteps(self, cx, step):
         if self.linker_.family == 'msvc':
             # Note, pdb is last since we read the pdb as outputs[-1].
-            self.linker_outputs += [self.name_ + '.pdb']
+            step.outputs += [self.name_ + '.pdb']
         elif self.compiler.target.platform == 'mac':
             bundle_folder = os.path.join(self.localFolder, self.outputFile + '.dSYM')
             bundle_entry = cx.AddFolder(bundle_folder)
@@ -615,32 +634,65 @@ class BinaryBuilder(BinaryBuilderBase):
             ]
             for folder in bundle_layout:
                 cx.AddFolder(os.path.join(bundle_folder, folder))
-            self.linker_outputs += [
+            step.outputs += [
                 self.outputFile + '.dSYM/Contents/Info.plist',
                 self.outputFile + '.dSYM/Contents/Resources/DWARF/' + self.outputFile
             ]
-            self.debug_entry = bundle_entry
-            self.argv = ['ambuild_dsymutil_wrapper.sh', self.outputFile] + self.argv
+            step.debug_entry = bundle_entry
+            step.argv = ['ambuild_dsymutil_wrapper.sh', self.outputFile] + step.argv
         elif self.compiler.target.platform == 'linux':
-            self.linker_outputs += [self.outputFile + '.dbg']
-            self.argv = ['ambuild_objcopy_wrapper.sh', self.outputFile] + self.argv
+            step.outputs += [self.outputFile + '.dbg']
+            step.argv = ['ambuild_objcopy_wrapper.sh', self.outputFile] + self.argv
 
-    def link(self, context, folder, inputs):
-        # The existence of .ilk files on Windows does not seem reliable, so we
-        # treat it as "shared" which does not participate in the DAG (yet).
-        shared_outputs = []
-        if self.linker_.behavior == 'msvc':
-            if not isinstance(self, StaticLibrary) and '/INCREMENTAL:NO' not in self.argv:
-                shared_outputs += [self.name_ + '.ilk']
+    def computeLinkerOutputFile(self, name, link_type):
+        if link_type == 'program':
+            return self.compiler.vendor.nameForExecutable(name)
+        elif link_type == 'library':
+            return self.compiler.vendor.nameForSharedLibrary(name)
+        elif link_type == 'static':
+            return self.compiler.vendor.nameForStaticLibrary(name)
+        raise Exception('Unknown link type: {}'.format(link_type))
 
+    def computeLinkerArgv(self, cx, files, name, link_type):
+        output_file = self.computeLinkerOutputFile(name, link_type)
+        if link_type == 'program':
+            return self.compiler.vendor.programLinkArgv(
+                cmd_argv = self.linker_argv_,
+                files = files,
+                linkFlags = self.linkFlags(cx),
+                symbolFile = name if self.compiler.symbol_files else None,
+                outputFile = output_file)
+        elif link_type == 'library':
+            return self.compiler.vendor.libLinkArgv(
+                cmd_argv = self.linker_argv_,
+                files = files,
+                linkFlags = self.linkFlags(cx),
+                symbolFile = name if self.compiler.symbol_files else None,
+                outputFile = output_file)
+        elif link_type == 'static':
+            return self.compiler.archiver.makeArgv(self.compiler.archiver_argv, files, output_file)
+
+    def link(self, generator, cx, inputs):
+        folder_node = generator.generateFolder(cx.localFolder, self.localFolder)
+
+        static_output_file = None
+        if self.static_link_step is not None:
+            static_output_file = self.addLinkStep(cx, folder_node, inputs, self.static_link_step)
+
+        output_file, debug_file = self.addLinkStep(cx, folder_node, inputs, self.link_step)
+
+        return CppNodes(output_file, debug_file, self.type, self.compiler.target,
+                        static_output_file)
+
+    def addLinkStep(self, context, folder, inputs, step):
         outputs = context.AddCommand(inputs = inputs + self.compiler.linkdeps,
-                                     argv = self.argv,
-                                     outputs = self.linker_outputs,
+                                     argv = step.argv,
+                                     outputs = step.outputs,
                                      folder = folder,
                                      weak_inputs = self.compiler.weaklinkdeps,
-                                     shared_outputs = shared_outputs,
+                                     shared_outputs = step.shared_outputs,
                                      env_data = self.compiler.env_data)
-        if not self.debug_entry and self.compiler.symbol_files:
+        if not step.debug_entry and self.compiler.symbol_files:
             if self.linker_.behavior != 'msvc' and self.compiler.symbol_files == 'bundled':
                 self.debug_entry = outputs[0]
             else:
@@ -651,60 +703,25 @@ class Program(BinaryBuilder):
     def __init__(self, compiler, name):
         super(Program, self).__init__(compiler, name)
 
-    @staticmethod
-    def buildName(compiler, name):
-        return compiler.vendor.nameForExecutable(name)
-
     @property
     def type(self):
         return 'program'
 
-    def compute_link_argv(self, cx, files):
-        return self.compiler.vendor.programLinkArgv(
-            cmd_argv = self.linker_argv_,
-            files = files,
-            linkFlags = self.linkFlags(cx),
-            symbolFile = self.name_ if self.compiler.symbol_files else None,
-            outputFile = self.outputFile)
-
 class Library(BinaryBuilder):
-    def __init__(self, compiler, name, build_static = False):
+    def __init__(self, compiler, name):
         super(Library, self).__init__(compiler, name)
-        self.build_static = build_static
-
-    @staticmethod
-    def buildName(compiler, name):
-        return compiler.vendor.nameForSharedLibrary(name)
 
     @property
     def type(self):
         return 'library'
 
-    def compute_link_argv(self, cx, files):
-        return self.compiler.vendor.libLinkArgv(
-            cmd_argv = self.linker_argv_,
-            files = files,
-            linkFlags = self.linkFlags(cx),
-            symbolFile = self.name_ if self.compiler.symbol_files else None,
-            outputFile = self.outputFile)
-
 class StaticLibrary(BinaryBuilder):
     def __init__(self, compiler, name):
         super(StaticLibrary, self).__init__(compiler, name)
 
-    @staticmethod
-    def buildName(compiler, name):
-        return compiler.vendor.nameForStaticLibrary(name)
-
     @property
     def type(self):
         return 'static'
-
-    def compute_link_argv(self, cx, files):
-        return self.compiler.archiver.makeArgv(self.compiler.archiver_argv, files, self.outputFile)
-
-    def perform_symbol_steps(self, cx):
-        pass
 
 class PrecompiledHeaders(BinaryBuilderBase):
     def __init__(self, compiler, name, source_type):

--- a/ambuild2/frontend/v2_2/cpp/compiler.py
+++ b/ambuild2/frontend/v2_2/cpp/compiler.py
@@ -55,9 +55,17 @@ class Compiler(Cloneable):
         'linkdeps',
     ]
 
+    shallow_attrs_ = [
+        'linker',
+        'archiver',
+        'symbol_files_',
+    ]
+
     def __init__(self, vendor, target, options = None):
         self.vendor = vendor
         self.target = target
+        self.linker = None
+        self.archiver = None
         for attr in self.attrs_:
             setattr(self, attr, [])
         if getattr(options, 'symbol_files', False):
@@ -68,8 +76,8 @@ class Compiler(Cloneable):
     def inherit(self, other):
         for attr in self.attrs_:
             setattr(self, attr, copy.copy(getattr(other, attr)))
-
-        self.symbol_files_ = other.symbol_files_
+        for attr in self.shallow_attrs_:
+            setattr(self, attr, getattr(other, attr))
 
     def clone(self):
         raise Exception('Must be implemented!')
@@ -143,6 +151,8 @@ class CliCompiler(Compiler):
         self.cxx_argv = cxx_argv
         self.found_pkg_config_ = False
         self.env_data = env_data
+        self.linker_argv = None
+        self.archiver_argv = None
 
     def clone(self):
         cc = CliCompiler(self.vendor, self.target, self.cc_argv, self.cxx_argv)
@@ -151,6 +161,8 @@ class CliCompiler(Compiler):
 
     def inherit(self, other):
         super(CliCompiler, self).inherit(other)
+        self.linker_argv = other.linker_argv
+        self.archiver_argv = other.archiver_argv
         self.env_data = other.env_data
 
     def __deepcopy__(self, memo):

--- a/ambuild2/frontend/v2_2/cpp/deptypes.py
+++ b/ambuild2/frontend/v2_2/cpp/deptypes.py
@@ -16,11 +16,12 @@
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 
 class CppNodes(object):
-    def __init__(self, output, debug_outputs, type, target):
+    def __init__(self, output, debug_outputs, type, target, static_binary = None):
         self.binary = output
         self.debug = debug_outputs
         self.type = type
         self.target = target
+        self.static_binary = static_binary
 
 class PchNodes(object):
     def __init__(self, folder, header_file, pch_file, object_file, source_type):

--- a/ambuild2/frontend/v2_2/cpp/detect.py
+++ b/ambuild2/frontend/v2_2/cpp/detect.py
@@ -26,7 +26,7 @@ from ambuild2.frontend.cpp.verify import Verifier
 from ambuild2.frontend.system import System
 from ambuild2.frontend.v2_2.cpp import vendor, compiler
 from ambuild2.frontend.v2_2.cpp.gcc import GCC, Clang, Emscripten, GccLinker, GccArchiver
-from ambuild2.frontend.v2_2.cpp.msvc import MSVC
+from ambuild2.frontend.v2_2.cpp.msvc import MSVC, MsvcLinker, MsvcArchiver
 
 class CommandAndVendor(object):
     def __init__(self, argv, vendor, arch):
@@ -174,16 +174,19 @@ class CompilerLocator(object):
         cli.linker = MsvcLinker()
         cli.archiver = MsvcArchiver()
 
-        if cli.env_data and 'tools' in cli.env_data:
-            tools = {'{}.exe'.format(k): v for k, v in cli.env_data['tools']}
-        else:
+        tools = None
+        if cli.env_data:
+            kv = {k: v for k, v in cli.env_data}
+            if 'tools' in kv:
+                tools = {'{}.exe'.format(k): v for k, v in kv['tools']}
+        if tools is None:
             tools = FindToolsInEnv(os.environ, ['lib.exe', 'link.exe'])
         if 'lib.exe' not in tools:
             raise CompilerNotFoundException('Unable to find LIB.EXE')
         if 'link.exe' not in tools:
             raise CompilerNotFoundException('Unable to find LINK.EXE')
-        cli.linker_argv = tools['link.exe']
-        cli.archiver_argv = tools['lib.exe']
+        cli.linker_argv = [tools['link.exe']]
+        cli.archiver_argv = [tools['lib.exe']]
 
     def detect_gcc_tools(self, cli):
         cli.linker = GccLinker()

--- a/ambuild2/frontend/v2_2/cpp/detect.py
+++ b/ambuild2/frontend/v2_2/cpp/detect.py
@@ -216,10 +216,10 @@ class CompilerLocator(object):
             if util.WaitForProcess(p) == 0:
                 return [candidate]
             util.con_err(util.ConsoleRed,
-                         '{} failed with return code {}'.format(tool_name, p.returncode),
-                         util.ConsoleNormal)
+                         '{} failed with return code {}'.format(tool_name,
+                                                                p.returncode), util.ConsoleNormal)
         raise CompilerNotFoundException(
-                'Unable to find a suitable candidate for {}'.format(tool_name))
+            'Unable to find a suitable candidate for {}'.format(tool_name))
 
     def create_cli(self, cc, cxx, env_data = None):
         # Ensure that the two compilers have the same vendor.

--- a/ambuild2/frontend/v2_2/cpp/detect.py
+++ b/ambuild2/frontend/v2_2/cpp/detect.py
@@ -212,12 +212,15 @@ class CompilerLocator(object):
 
         for candidate in candidates:
             argv = [candidate, '--version']
-            p = util.CreateProcess(argv, no_raise = False)
-            if util.WaitForProcess(p) == 0:
-                return [candidate]
-            util.con_err(util.ConsoleRed,
-                         '{} failed with return code {}'.format(tool_name,
-                                                                p.returncode), util.ConsoleNormal)
+            try:
+                p = util.CreateProcess(argv, no_raise = False)
+                if util.WaitForProcess(p) == 0:
+                    return [candidate]
+                rc = p.returncode
+            except:
+                rc = -1
+            util.con_err(util.ConsoleRed, '{} failed with return code {}'.format(tool_name, rc),
+                         util.ConsoleNormal)
         raise CompilerNotFoundException(
             'Unable to find a suitable candidate for {}'.format(tool_name))
 

--- a/ambuild2/frontend/v2_2/cpp/detect.py
+++ b/ambuild2/frontend/v2_2/cpp/detect.py
@@ -211,7 +211,7 @@ class CompilerLocator(object):
             argv = [candidate, '--version']
             p = util.CreateProcess(argv, no_raise = False)
             if util.WaitForProcess(p) == 0:
-                return argv
+                return [candidate]
             util.con_err(util.ConsoleRed,
                          '{} failed with return code {}'.format(tool_name, p.returncode),
                          util.ConsoleNormal)

--- a/ambuild2/frontend/v2_2/cpp/gcc.py
+++ b/ambuild2/frontend/v2_2/cpp/gcc.py
@@ -17,7 +17,7 @@
 import os
 from ambuild2 import util
 from ambuild2.frontend.v2_2.cpp.deptypes import PchNodes
-from ambuild2.frontend.v2_2.cpp.vendor import Vendor
+from ambuild2.frontend.v2_2.cpp.vendor import Archiver, Linker, Vendor
 
 class GCCLookalike(Vendor):
     def __init__(self, version):
@@ -176,3 +176,17 @@ class Emscripten(Clang):
 
     def staticLinkArgv(self, files, outputFile):
         return ['emar', 'rcs', outputFile] + files
+
+class GccLinker(Linker):
+    def __init__(self):
+        super(GccLinker, self).__init__()
+
+    def like(self, name):
+        return name == 'gcc'
+
+class GccArchiver(Archiver):
+    def __init__(self):
+        super(GccArchiver, self).__init__()
+
+    def like(self, name):
+        return name == 'gcc'

--- a/ambuild2/frontend/v2_2/cpp/gcc.py
+++ b/ambuild2/frontend/v2_2/cpp/gcc.py
@@ -63,9 +63,6 @@ class GCCLookalike(Vendor):
     def makePchArgv(self, source_file, obj_file, source_type):
         return ['-c', '-x', source_type + '-header', source_file, '-o', obj_file]
 
-    def staticLinkArgv(self, files, outputFile):
-        return ['ar', 'rcs', outputFile] + files
-
     def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
         return cmd_argv + files + linkFlags + ['-o', outputFile]
 
@@ -174,9 +171,6 @@ class Emscripten(Clang):
     def debugInfoArgv(self):
         return []
 
-    def staticLinkArgv(self, files, outputFile):
-        return ['emar', 'rcs', outputFile] + files
-
 class GccLinker(Linker):
     def __init__(self):
         super(GccLinker, self).__init__()
@@ -190,3 +184,6 @@ class GccArchiver(Archiver):
 
     def like(self, name):
         return name == 'gcc'
+
+    def makeArgv(self, base_argv, files, outputFile):
+        return base_argv + ['rcs', outputFile] + files

--- a/ambuild2/frontend/v2_2/cpp/msvc.py
+++ b/ambuild2/frontend/v2_2/cpp/msvc.py
@@ -18,7 +18,7 @@ import os
 import re
 from ambuild2 import util
 from ambuild2.frontend.v2_2.cpp.deptypes import PchNodes
-from ambuild2.frontend.v2_2.cpp.vendor import Vendor
+from ambuild2.frontend.v2_2.cpp.vendor import Archiver, Linker, Vendor
 
 # Microsoft Visual C++
 class MSVC(Vendor):
@@ -176,3 +176,17 @@ class MSVC(Vendor):
     @property
     def emits_dependency_file(self):
         return False
+
+class MsvcLinker(Linker):
+    def __init__(self):
+        super(MsvcLinker, self).__init__()
+
+    def like(self, name):
+        return name == 'msvc'
+
+class MsvcArchiver(Archiver):
+    def __init__(self):
+        super(MsvcArchiver, self).__init__()
+
+    def like(self, name):
+        return name == 'msvc'

--- a/ambuild2/frontend/v2_2/cpp/msvc.py
+++ b/ambuild2/frontend/v2_2/cpp/msvc.py
@@ -63,9 +63,6 @@ class MSVC(Vendor):
     def objectArgs(self, sourceFile, objFile):
         return ['/showIncludes', '/nologo', '/c', sourceFile, '/Fo' + objFile]
 
-    def staticLinkArgv(self, files, outputFile):
-        return ['lib', '/OUT:' + outputFile] + files
-
     def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):
         argv = cmd_argv + files
         argv += ['/link']
@@ -190,3 +187,6 @@ class MsvcArchiver(Archiver):
 
     def like(self, name):
         return name == 'msvc'
+
+    def makeArgv(self, base_argv, files, outputFile):
+        return base_argv + ['/OUT:' + outputFile] + files

--- a/ambuild2/frontend/v2_2/cpp/vendor.py
+++ b/ambuild2/frontend/v2_2/cpp/vendor.py
@@ -82,11 +82,6 @@ class Vendor(object):
     def objectArgs(self, sourceFile, objFile):
         raise Exception("Must be implemented")
 
-    # Note: this should return a complete initial argv, not partial.
-    # AMBuild does not detect AR/LIB separately yet.
-    def staticLinkArgv(self, files, outputFile):
-        raise Exception("Must be implemented")
-
     # For this and libLinkArgv(), the symbolFile should not have an extension.
     # The vendor chooses the extension if it supports symbol files at all.
     def programLinkArgv(self, cmd_argv, files, linkFlags, symbolFile, outputFile):

--- a/ambuild2/frontend/v2_2/cpp/vendor.py
+++ b/ambuild2/frontend/v2_2/cpp/vendor.py
@@ -116,3 +116,17 @@ class Vendor(object):
     # If emits_dependency_file is True, this must be implemented.
     def dependencyArgv(self, out_file):
         raise Exception("Must be implemented")
+
+class Linker(object):
+    def __init__(self):
+        super(Linker, self).__init__()
+
+    def like(self, name):
+        raise Exception("Must be implemented")
+
+class Archiver(object):
+    def __init__(self):
+        super(Archiver, self).__init__()
+
+    def like(self, name):
+        raise Exception("Must be implemented")

--- a/ambuild2/run.py
+++ b/ambuild2/run.py
@@ -20,8 +20,8 @@ from optparse import OptionParser
 from ambuild2 import util
 from ambuild2.context import Context
 
-DEFAULT_API = '2.2.2'
-CURRENT_API = '2.2.2'
+DEFAULT_API = '2.2.3'
+CURRENT_API = '2.2.3'
 
 SampleScript = """# vim: set sts=4 ts=8 sw=4 tw=99 et ft=python:
 builder.cxx = builder.DetectCxx()


### PR DESCRIPTION
AMBuild makes it difficult to create both a static and dynamic library from the same object files. Initially, my thought was to make it automatic, but it's a bit difficult because a library may have multiple archives as input, and it's not easy to transitively build a new archive with the current API.

Rather than get too far into the weeds with this, we instead attach "linker" and "archiver" objects as part of DetectCxx(). There are also "linker_argv" and "archiver_argv" variables for manually invoking them.

If AMBuild can't detect both the "ld" and "ar" parts of the toolchain, configuration fails.