### PR TITLE
Use native ARM64 MSVC tools if available.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,33 +7,37 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.3, 3.8]
+        python-version: ['3.3', '3.8']
         os: [ubuntu-20.04, macos-latest, windows-2019]
         exclude:
          - os: macos-latest
-           python-version: 3.3
-         - os: windows-2019
-           python-version: 3.3
+           python-version: '3.3'
+         - os: ubuntu-20.04
+           python-version: '3.3'
 
     steps:
-    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install Pip
+      if: runner.os == 'Windows' && matrix.python-version == '3.3'
+      shell: cmd
+      run: curl https://bootstrap.pypa.io/pip/3.3/get-pip.py | python
     - name: Install Deps
       if: runner.os == 'Linux'
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get install lib32stdc++-7-dev lib32z1-dev libc6-dev-i386
         sudo apt-get install g++-multilib
+    - uses: actions/checkout@v3
     - name: Unit Tests
       run: |
         python -m unittest discover ambuild2 "*_test.py"
     - name: Smoke Tests 1
       if: runner.os != 'Windows' # no choco vcvars detection on older APIs
       run: |
-        pip install .
+        python -m pip install .
         mkdir objdir1
         cd objdir1
         python ../tests/staticlib/configure.py
@@ -44,7 +48,7 @@ jobs:
         ambuild
     - name: Smoke Tests 2
       run: |
-        pip install .
+        python -m pip install .
         mkdir objdir3
         cd objdir3
         python ../tests/multiarch/configure.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.3', '3.8']
+        python-version: ['3.3', '3.10']
         os: [ubuntu-20.04, macos-latest, windows-2019]
         exclude:
          - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.3, 3.8]
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
         exclude:
          - os: macos-latest
            python-version: 3.3

--- a/ambuild2/frontend/cpp/msvc_utils.py
+++ b/ambuild2/frontend/cpp/msvc_utils.py
@@ -96,26 +96,26 @@ class MSVCFinder(object):
 
             candidates = []
 
-            cpu = util.NormalizeArchString(platform.machine())
-            if cpu == 'x86':
-                candidates.append(('x86', 'vcvars32.bat'))
-                candidates.append(('x86_64', 'vcvarsx86_amd64.bat'))
-                candidates.append(('arm', 'vcvarsx86_arm.bat'))
-                candidates.append(('arm64', 'vcvarsx86_arm64.bat'))
-            elif cpu == 'x86_64':
-                candidates.append(('x86', 'vcvarsamd64_x86.bat'))
-                candidates.append(('x86_64', 'vcvars64.bat'))
-                candidates.append(('arm', 'vcvarsamd64_arm.bat'))
-                candidates.append(('arm64', 'vcvarsamd64_arm64.bat'))
-            elif cpu == 'arm64':
+            # Prefer native tools but fallback to other executable architectures if not available.
+            if util.IsArchExecutable('arm64'):
                 candidates.append(('x86', 'vcvarsarm64_x86.bat'))
                 candidates.append(('x86_64', 'vcvarsarm64_amd64.bat'))
                 candidates.append(('arm', 'vcvarsarm64_arm.bat'))
                 candidates.append(('arm64', 'vcvarsarm64.bat'))
+            if util.IsArchExecutable('x86_64'):
+                candidates.append(('x86', 'vcvarsamd64_x86.bat'))
+                candidates.append(('x86_64', 'vcvars64.bat'))
+                candidates.append(('arm', 'vcvarsamd64_arm.bat'))
+                candidates.append(('arm64', 'vcvarsamd64_arm64.bat'))
+            if util.IsArchExecutable('x86'):
+                candidates.append(('x86', 'vcvars32.bat'))
+                candidates.append(('x86_64', 'vcvarsx86_amd64.bat'))
+                candidates.append(('arm', 'vcvarsx86_arm.bat'))
+                candidates.append(('arm64', 'vcvarsx86_arm64.bat'))
 
             for target, bat_file in candidates:
                 path = os.path.join(build_path, bat_file)
-                if os.path.exists(path):
+                if target not in install.vcvars and os.path.exists(path):
                     install.vcvars[target] = path
 
             if len(install.vcvars):
@@ -135,19 +135,19 @@ class MSVCFinder(object):
 
         candidates = []
 
-        cpu = util.NormalizeArchString(platform.machine())
-        if cpu == 'x86':
-            candidates.append(('x86', 'vcvars32.bat'))
-            candidates.append(('x86_64', os.path.join('x86_amd64', 'vcvarsx86_amd64.bat')))
-            candidates.append(('arm', os.path.join('arm', 'vcvarsx86_arm.bat')))
-        elif cpu == 'x86_64':
+        # Prefer native tools but fallback to other executable architectures if not available.
+        if util.IsArchExecutable('x86_64'):
             candidates.append(('x86', os.path.join('amd64_x86', 'vcvarsamd64_x86.bat')))
             candidates.append(('x86_64', os.path.join('amd64', 'vcvars64.bat')))
             candidates.append(('arm', os.path.join('amd64_arm', 'vcvarsamd64_arm.bat')))
+        if util.IsArchExecutable('x86'):
+            candidates.append(('x86', 'vcvars32.bat'))
+            candidates.append(('x86_64', os.path.join('x86_amd64', 'vcvarsx86_amd64.bat')))
+            candidates.append(('arm', os.path.join('arm', 'vcvarsx86_arm.bat')))
 
         for target, bat_file in candidates:
             path = os.path.join(path_value, 'bin', bat_file)
-            if os.path.exists(path):
+            if target not in install.vcvars and os.path.exists(path):
                 install.vcvars[target] = path
 
         if len(install.vcvars):

--- a/ambuild2/frontend/cpp/msvc_utils.py
+++ b/ambuild2/frontend/cpp/msvc_utils.py
@@ -33,8 +33,9 @@ except:
         winreg = None
 
 class MSVCInstall(object):
-    def __init__(self, version, path):
+    def __init__(self, version, path, prerelease = False):
         self.version = Version(version)
+        self.prerelease = prerelease
         self.path = path
         self.vcvars = {}
 
@@ -90,8 +91,9 @@ class MSVCFinder(object):
         for obj in data:
             version_parts = obj['installationVersion'].split('.')
             version = version_parts[0] + '.0'
+            prerelease = obj['isPrerelease']
             install_path = obj['installationPath']
-            install = MSVCInstall(version, os.path.join(install_path, 'VC'))
+            install = MSVCInstall(version, os.path.join(install_path, 'VC'), prerelease)
             build_path = os.path.join(install.path, 'Auxiliary', 'Build')
 
             candidates = []

--- a/ambuild2/frontend/cpp/msvc_utils.py
+++ b/ambuild2/frontend/cpp/msvc_utils.py
@@ -74,8 +74,12 @@ class MSVCFinder(object):
             'json',
             '-products',
             '*',
+            '-prerelease',
+            '-requiresAny',
             '-requires',
             'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+            'Microsoft.VisualStudio.Component.VC.Tools.ARM',
+            'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
             '-utf8',
         ]
         try:
@@ -103,6 +107,11 @@ class MSVCFinder(object):
                 candidates.append(('x86_64', 'vcvars64.bat'))
                 candidates.append(('arm', 'vcvarsamd64_arm.bat'))
                 candidates.append(('arm64', 'vcvarsamd64_arm64.bat'))
+            elif cpu == 'arm64':
+                candidates.append(('x86', 'vcvarsarm64_x86.bat'))
+                candidates.append(('x86_64', 'vcvarsarm64_amd64.bat'))
+                candidates.append(('arm', 'vcvarsarm64_arm.bat'))
+                candidates.append(('arm64', 'vcvarsarm64.bat'))
 
             for target, bat_file in candidates:
                 path = os.path.join(build_path, bat_file)

--- a/ambuild2/frontend/v2_1/cpp/detect.py
+++ b/ambuild2/frontend/v2_1/cpp/detect.py
@@ -120,7 +120,10 @@ class CompilerLocator(object):
         force_msvc = self.detect_options_.pop('force_msvc_version', None)
 
         installs = msvc_utils.MSVCFinder().find_all()
+        ignore_prerelease = not self.gen_options_.vs_prerelease
         for install in installs:
+            if install.prerelease and ignore_prerelease:
+                continue
             if force_msvc and install.version != force_msvc:
                 continue
             if self.target_.arch not in install.vcvars:

--- a/ambuild2/frontend/v2_1/prep.py
+++ b/ambuild2/frontend/v2_1/prep.py
@@ -70,6 +70,12 @@ class Preparer(object):
                                 dest = "vs_split",
                                 default = False,
                                 help = SUPPRESS_HELP)
+        self.options.add_option(
+            "--vs-prerelease",
+            action = "store_true",
+            dest = "vs_prerelease",
+            default = False,
+            help = "Consider prerelease versions when detecting installations of Visual Studio.")
 
     @staticmethod
     def default_build_folder(prep):

--- a/ambuild2/frontend/v2_2/cpp/detect.py
+++ b/ambuild2/frontend/v2_2/cpp/detect.py
@@ -291,7 +291,10 @@ class CompilerLocator(object):
             return cxx
 
         installs = msvc_utils.MSVCFinder().find_all()
+        ignore_prerelease = not self.gen_options_.vs_prerelease
         for install in installs:
+            if install.prerelease and ignore_prerelease:
+                continue
             if self.force_msvc_version_ and install.version != self.force_msvc_version_:
                 continue
             if self.target_.arch in install.vcvars:

--- a/ambuild2/frontend/v2_2/prep.py
+++ b/ambuild2/frontend/v2_2/prep.py
@@ -64,6 +64,12 @@ class Preparer(object):
                                   action = 'store_true',
                                   dest = "vs_split",
                                   default = False)
+        self.options.add_argument(
+            "--vs-prerelease",
+            action = "store_true",
+            dest = "vs_prerelease",
+            default = False,
+            help = "Consider prerelease versions when detecting installations of Visual Studio.")
         self.options.add_argument('--refactor',
                                   dest = "refactor",
                                   action = "store_true",

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -21,11 +21,11 @@ INSTALLED_BY_PIP_OR_SETUPTOOLS = True
 
 def NormalizeArchString(arch):
     # We normalize platforms across different operating systems.
-    if arch in ['x86_64', 'AMD64', 'x64', 'amd64']:
+    if arch.lower() in ['x86_64', 'x64', 'amd64']:
         return 'x86_64'
-    if arch in ['x86', 'i386', 'i686', 'x32', 'ia32']:
+    if arch.lower() in ['x86', 'i386', 'i686', 'x32', 'ia32']:
         return 'x86'
-    if arch.startswith('arm64') or arch.startswith('armv8') or arch.startswith('aarch64'):
+    if arch.lower().startswith(('arm64', 'armv8', 'aarch64')):
         return 'arm64'
     if not arch:
         return 'unknown'
@@ -33,17 +33,10 @@ def NormalizeArchString(arch):
 
 # Advanced version - split into (arch, subarch).
 def DecodeArchString(arch):
-    if arch.lower() in ['x86_64', 'x64', 'amd64']:
-        return 'x86_64', ''
-    if arch.lower() in ['x86', 'i386', 'i686', 'x32', 'ia32']:
-        return 'x86', ''
-    if arch.startswith('arm64') or arch.startswith('armv8') or arch.startswith('aarch64'):
-        return 'arm64', ''
-    if arch.startswith('arm'):
-        return 'arm', arch[len('arm'):]
-    if not arch:
-        return 'unknown', ''
-    return arch, ''
+    normalized_arch = NormalizeArchString(arch)
+    if normalized_arch.startswith('arm') and normalized_arch != 'arm64':
+        return 'arm', arch.lower()[len('arm'):]
+    return normalized_arch, ''
 
 Architecture, SubArch = DecodeArchString(platform.machine())
 

--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -437,7 +437,7 @@ elif IsWindows():
         std = None
         if fp == sys.stdout:
             std = STD_OUTPUT_HANDLE
-        elif fp == sys.stdin:
+        elif fp == sys.stderr:
             std = STD_ERROR_HANDLE
         if std is None:
             return


### PR DESCRIPTION
Visual Studio 2022 17.4 (Preview 1) and previous preview versions of 17.3 added native arm64 binaries of cl.exe and other MSVC build tools. These are not currently being used by ambuild. Also note that an arm64 version of Python 3.11 is currently available as a release candidate here: https://www.python.org/downloads/release/python-3110rc1/

I have tested against these on an arm64 Windows 11 VM using the arm64, x64, and x86 versions of Python. I have also tested these changes on an x64 Windows 10 machine.