### PR TITLE
Improve VS generation for x64 projects

### DIFF
--- a/ambuild2/frontend/v2_2/vs/cxx.py
+++ b/ambuild2/frontend/v2_2/vs/cxx.py
@@ -114,7 +114,7 @@ class Compiler(compiler.Compiler):
         self.linker = VsLinker()
 
     def clone(self):
-        cc = Compiler(self.vendor)
+        cc = Compiler(self.vendor, self.target.arch)
         cc.inherit(self)
         return cc
 

--- a/ambuild2/frontend/v2_2/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_2/vs/export_vcxproj.py
@@ -82,16 +82,23 @@ def export_body(cm, node, xml):
     with xml.block('ImportGroup', Label = 'ExtensionTargets'):
         pass
 
+def get_target_platform(builder):
+    platform = 'Win32'
+    if builder.compiler.target.arch == 'x86_64':
+        platform = 'x64'
+    return platform
+
 def condition_for(builder):
-    full_tag = '{0}|Win32'.format(builder.tag_)
+    full_tag = '{0}|{1}'.format(builder.tag_, get_target_platform(builder))
     return "'$(Configuration)|$(Platform)'=='{0}'".format(full_tag)
 
 def export_configuration_headers(node, xml):
     for builder in node.project.builders_:
-        full_tag = '{0}|Win32'.format(builder.tag_)
+        platform = get_target_platform(builder)
+        full_tag = '{0}|{1}'.format(builder.tag_, platform)
         with xml.block('ProjectConfiguration', Include = full_tag):
             xml.tag('Configuration', builder.tag_)
-            xml.tag('Platform', 'Win32')
+            xml.tag('Platform', platform)
 
 def export_configuration_properties(node, xml):
     for builder in node.project.builders_:
@@ -268,7 +275,10 @@ def export_configuration_options(node, xml, builder):
         # Parse link flags.
         libs = ['%(AdditionalDependencies)']
         ignore_libs = ['%(IgnoreSpecificDefaultLibraries)']
+
         machine = 'X86'
+        if compiler.target.arch == 'x86_64':
+            machine = 'X64'
         subsystem = 'Windows'
         for flag in link_flags:
             if util.IsString(flag):

--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -149,6 +149,10 @@ class Generator(BaseGenerator):
         return obj
 
     # Overridden.
+    def addCopy(self, context, source, output_path):
+        return (None, (None,))
+
+    # Overridden.
     def addShellCommand(self,
                         context,
                         inputs,


### PR DESCRIPTION
This adds compiler arch lookup to target correct platform arch, so the end project would be correctly generated for x64 projects. Previously it would end up generating x86 vcxproj files no matter what for a few reasons:
1. ``Compiler::clone`` function that's commonly used through out the metamod & sourcemod and other solutions (example: https://github.com/alliedmodders/metamod-source/blob/2261ff4f9c898933e02363f337de4f0dff77e687/AMBuildScript#L347 https://github.com/alliedmodders/sourcemod/blob/20aae06f127d021734ee2ff8b9664907ca7ea752/AMBuildScript#L536-L546 etc) doesn't respect the ``target.arch`` and doesn't pass it to the newly created instance which expects ``target_arch``, resulting in further code in build scripts to target x86 instead of what was asked for. Fixing this correctly respects the target arch of the compiler.
2. There's no specific platform lookup and all the projects were treated as Win32 no matter what, this pr introduces changes to that and lookups the target arch by looking at a current compiler that's being used to generate.