### PR TITLE
Add VS2022 support, fix broken export if WindowsSDKVersion doesn't exist in environment variables

### DIFF
--- a/ambuild2/frontend/v2_2/vs/cxx.py
+++ b/ambuild2/frontend/v2_2/vs/cxx.py
@@ -126,9 +126,9 @@ class Compiler(compiler.Compiler):
         # Microsoft skipped version 13, of course.
         if vs_version >= 14:
             msvc_version -= 100
-        # In VS 2017, the numbering continues from 1910
-        if vs_version == 15:
-            msvc_version = 1910
+        # Since VS 2017, the numbering continues from 1910 with increments of 10.
+        if vs_version >= 15:
+            msvc_version = 1900 + (vs_version - 14) * 10
         return msvc_version
 
     def Program(self, name):

--- a/ambuild2/frontend/v2_2/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_2/vs/export_vcxproj.py
@@ -38,10 +38,21 @@ def export_fp(cm, node, fp):
     elif version >= 'msvc-1600':
         toolsVersion = '4.0'
 
-    scope = xml.block('Project',
-                      DefaultTargets = 'Build',
-                      ToolsVersion = toolsVersion,
-                      xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003')
+    # Starting from VS2017, schema link is no longer required.
+    # Tools version is obsolete in VS2019 and later.
+    if version >= 'msvc-1920':
+        scope = xml.block('Project',
+                        DefaultTargets = 'Build')
+    elif version >= 'msvc-1910':
+        scope = xml.block('Project',
+                        DefaultTargets = 'Build',
+                        ToolsVersion = toolsVersion)
+    else:
+        scope = xml.block('Project',
+                        DefaultTargets = 'Build',
+                        ToolsVersion = toolsVersion,
+                        xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003')
+    
     with scope:
         export_body(cm, node, xml)
 
@@ -55,8 +66,10 @@ def export_body(cm, node, xml):
         xml.tag('RootNamespace', node.project.name_)
         xml.tag('Keyword', 'Win32Proj')
         if version >= 'msvc-1910':
-            xml.tag('WindowsTargetPlatformVersion',
-                    os.getenv('WindowsSDKVersion', None).rstrip('\\'))
+            win_sdk_version = os.getenv('WindowsSDKVersion', None)
+            if win_sdk_version:
+                xml.tag('WindowsTargetPlatformVersion',
+                        win_sdk_version.rstrip('\\'))
 
     xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.Default.props')
     export_configuration_properties(node, xml)
@@ -110,7 +123,11 @@ def export_configuration_properties(node, xml):
                 xml.tag('WholeProgramOptimization', 'true')
 
             version = builder.compiler.version
-            if version >= 'msvc-1910':
+            if version >= 'msvc-1930':
+                xml.tag('PlatformToolset', 'v143')
+            elif version >= 'msvc-1920':
+                xml.tag('PlatformToolset', 'v142')
+            elif version >= 'msvc-1910':
                 xml.tag('PlatformToolset', 'v141')
             elif version >= 'msvc-1900':
                 xml.tag('PlatformToolset', 'v140')

--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -22,7 +22,7 @@ from ambuild2.frontend import paths
 from ambuild2.frontend.vs import nodes
 from ambuild2.frontend.base_generator import BaseGenerator
 
-SupportedVersions = ['10', '11', '12', '14', '15', '16']
+SupportedVersions = ['10', '11', '12', '14', '15', '16', '17']
 YearMap = {
     '2010': 10,
     '2012': 11,
@@ -30,6 +30,7 @@ YearMap = {
     '2015': 14,
     '2017': 15,
     '2019': 16,
+    '2022': 17,
 }
 
 class Generator(BaseGenerator):


### PR DESCRIPTION
Tested on metamod builds.

Resolves #143 