### PR TITLE
Fix AMBuild for python 3.12

### DIFF
--- a/ambuild2/context.py
+++ b/ambuild2/context.py
@@ -16,7 +16,7 @@
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
 import time
 import traceback
-import os, sys, imp
+import os, sys
 from ambuild2 import util, database, damage
 from ambuild2.builder import Builder
 from ambuild2.frontend.version import Version


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.12.html

- The asynchat, asyncore, and imp modules have been removed, along with several unittest.TestCase method aliases.

https://github.com/alliedmodders/ambuild/blob/417517c1ec86c0a1a90e1ad37faf0b8b68654fa3/ambuild2/context.py#L19

`imp` is being imported in `context.py` but not used, let's strip that ?