### PR TITLE
Add initial protobuf support.

### DIFF
--- a/ambuild2/frontend/amb2_gen.py
+++ b/ambuild2/frontend/amb2_gen.py
@@ -669,7 +669,8 @@ class Generator(BaseGenerator):
                         dep_type = None,
                         weak_inputs = None,
                         shared_outputs = None,
-                        env_data = None):
+                        env_data = None,
+                        dep_file = None):
         if folder == -1:
             folder = context.localFolder
 
@@ -681,7 +682,12 @@ class Generator(BaseGenerator):
             data = argv
         else:
             node_type = nodetypes.Cxx
-            if dep_type not in ['gcc', 'msvc', 'sun', 'fxc']:
+            if dep_type == 'md':
+                if not dep_file:
+                    util.con_err(util.ConsoleRed, 'Dependency spew type "md" needs a dep_file',
+                                 util.ConsoleNormal)
+                    raise Exception('Dependency spew type "md" needs a dep_file')
+            elif dep_type not in ['gcc', 'msvc', 'sun', 'fxc']:
                 util.con_err(util.ConsoleRed, 'Invalid dependency spew type: ', util.ConsoleBlue,
                              dep_type, util.ConsoleNormal)
                 raise Exception('Invalid dependency spew type')
@@ -689,6 +695,14 @@ class Generator(BaseGenerator):
                 'type': dep_type,
                 'argv': argv,
             }
+            if dep_type == 'md':
+                data['deps'] = ('md', dep_file)
+
+        if dep_type != 'md' and dep_file:
+            util.con_err(util.ConsoleRed,
+                         'dep_file can only be specified with "md" dep_type',
+                         util.ConsoleNormal)
+            raise Exception('dep_file can only be specified with "md" dep_type')
 
         if argv is None:
             raise Exception('argv cannot be None')

--- a/ambuild2/frontend/amb2_gen.py
+++ b/ambuild2/frontend/amb2_gen.py
@@ -699,8 +699,7 @@ class Generator(BaseGenerator):
                 data['deps'] = ('md', dep_file)
 
         if dep_type != 'md' and dep_file:
-            util.con_err(util.ConsoleRed,
-                         'dep_file can only be specified with "md" dep_type',
+            util.con_err(util.ConsoleRed, 'dep_file can only be specified with "md" dep_type',
                          util.ConsoleNormal)
             raise Exception('dep_file can only be specified with "md" dep_type')
 

--- a/ambuild2/frontend/v2_2/context.py
+++ b/ambuild2/frontend/v2_2/context.py
@@ -196,7 +196,8 @@ class BuildContext(BaseContext):
                    dep_type = None,
                    weak_inputs = [],
                    shared_outputs = [],
-                   env_data = None):
+                   env_data = None,
+                   dep_file = None):
         _, entries = self.generator_.addShellCommand(self,
                                                      inputs,
                                                      argv,
@@ -205,7 +206,8 @@ class BuildContext(BaseContext):
                                                      dep_type = dep_type,
                                                      weak_inputs = weak_inputs,
                                                      shared_outputs = shared_outputs,
-                                                     env_data = env_data)
+                                                     env_data = env_data,
+                                                     dep_file = dep_file)
         return entries
 
     def Context(self, name):

--- a/ambuild2/frontend/v2_2/context.py
+++ b/ambuild2/frontend/v2_2/context.py
@@ -162,6 +162,9 @@ class BuildContext(BaseContext):
     def DetectCxx(self, **kwargs):
         return self.generator_.detectCompilers(**kwargs)
 
+    def DetectProtoc(self, **kwargs):
+        return tools.protoc.DetectProtoc(**kwargs)
+
     @property
     def ALWAYS_DIRTY(self):
         return self.cm.ALWAYS_DIRTY

--- a/ambuild2/frontend/v2_2/prep.py
+++ b/ambuild2/frontend/v2_2/prep.py
@@ -57,10 +57,10 @@ class Preparer(object):
             dest = "symbol_files",
             default = False,
             help = "Split debugging symbols from binaries into separate symbol files.")
-        self.options.add_argument(
-            "-o", "--out",
-            default = None,
-            help = "Specify the out/build directory.")
+        self.options.add_argument("-o",
+                                  "--out",
+                                  default = None,
+                                  help = "Specify the out/build directory.")
 
         # Generator specific options.
         self.options.add_argument("--vs-version", type = str, dest = "vs_version", default = "14")
@@ -109,9 +109,9 @@ class Preparer(object):
             util.DisableConsoleColors()
 
         if args.out:
-           build_abspath = os.path.normpath(os.path.abspath(args.out))
+            build_abspath = os.path.normpath(os.path.abspath(args.out))
         else:
-           build_abspath = os.path.normpath(os.path.abspath(self.buildPath))
+            build_abspath = os.path.normpath(os.path.abspath(self.buildPath))
         source_abspath = os.path.normpath(os.path.abspath(self.sourcePath))
 
         if source_abspath == build_abspath:

--- a/ambuild2/frontend/v2_2/tools/__init__.py
+++ b/ambuild2/frontend/v2_2/tools/__init__.py
@@ -1,3 +1,4 @@
 # vim: set ts=2 sw=2 tw=99 et:
 
 from ambuild2.frontend.v2_2.tools.fxc import FxcJob as FXC
+from ambuild2.frontend.v2_2.tools.protoc import DetectProtoc as DetectProtoc

--- a/ambuild2/frontend/v2_2/tools/protoc.py
+++ b/ambuild2/frontend/v2_2/tools/protoc.py
@@ -69,7 +69,9 @@ class ProtocRunner(object):
             if language == 'python':
                 if '.' in proto_name:
                     # This is not supported since it complicates folder entry tracking.
-                    raise Exception('Python proto files cannot contain extra "." characters: {}'.format(proto_name))
+                    raise Exception(
+                        'Python proto files cannot contain extra "." characters: {}'.format(
+                            proto_name))
                 gen_source_names += ['{}_pb2.py'.format(proto_name)]
             elif language == 'cpp':
                 gen_source_names += ['{}.pb.cc'.format(proto_name)]
@@ -99,10 +101,10 @@ class ProtocRunner(object):
         cursor = 0
         for language in self.languages:
             gen_info = gen_file_map[language]
-            gen_sources = gen_entries[cursor : cursor + len(gen_info['sources'])]
+            gen_sources = gen_entries[cursor:cursor + len(gen_info['sources'])]
             cursor += len(gen_sources)
 
-            gen_headers = gen_entries[cursor : cursor + len(gen_info['headers'])]
+            gen_headers = gen_entries[cursor:cursor + len(gen_info['headers'])]
             cursor += len(gen_headers)
 
             self.gen_map[language].setdefault('sources', []).extend(gen_sources)
@@ -110,7 +112,7 @@ class ProtocRunner(object):
                 self.gen_map[language].setdefault('headers', []).extend(gen_headers)
 
         # Should be one entry remaining, for the .d file.
-        assert(cursor == len(gen_entries) - 1)
+        assert (cursor == len(gen_entries) - 1)
 
 class Protoc(object):
     def __init__(self, path, name, version):

--- a/ambuild2/frontend/v2_2/tools/protoc.py
+++ b/ambuild2/frontend/v2_2/tools/protoc.py
@@ -1,0 +1,175 @@
+# vim: set ts=8 sts=4 sw=4 tw=99 et:
+#
+# This file is part of AMBuild.
+#
+# AMBuild is free software: you can Headeristribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# AMBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
+import collections
+import os
+import re
+import subprocess
+from ambuild2 import util
+from ambuild2.frontend.version import Version
+
+class ProtocRunner(object):
+    def __init__(self, protoc, builder, includes):
+        self.protoc = protoc
+        self.builder = builder
+
+        self.argv = [self.protoc.path] + self.protoc.extra_argv
+        self.seen_languages = set()
+
+        for include in self.protoc.includes + includes:
+            if not os.path.isabs(include):
+                include = os.path.join(builder.currentSourcePath, include)
+            self.argv += ['--proto_path={}'.format(include)]
+
+        self.languages = collections.OrderedDict()
+        self.gen_map = {}
+
+    def AddOutput(self, language, folder):
+        if language in self.languages:
+            raise Exception('Output language {} specified twice'.format(language))
+
+        self.languages[language] = {
+            'folder': folder,
+        }
+        self.gen_map[language] = {}
+
+        out_build_path = os.path.relpath(folder.path, self.builder.buildFolder)
+        self.argv += ['--{}_out={}'.format(language, out_build_path)]
+
+    def AddSource(self, source_path):
+        source_name = os.path.basename(source_path)
+        if source_name.endswith('.proto'):
+            proto_name = source_name[:-len('.proto')]
+        else:
+            proto_name = source_name
+
+        gen_file_list = []
+        gen_file_map = {}
+        for language in self.languages:
+            gen_info = gen_file_map.setdefault(language, {
+                'sources': [],
+                'headers': [],
+            })
+            gen_source_names = []
+            gen_header_names = []
+
+            if language == 'python':
+                if '.' in proto_name:
+                    # This is not supported since it complicates folder entry tracking.
+                    raise Exception('Python proto files cannot contain extra "." characters: {}'.format(proto_name))
+                gen_source_names += ['{}_pb2.py'.format(proto_name)]
+            elif language == 'cpp':
+                gen_source_names += ['{}.pb.cc'.format(proto_name)]
+                gen_header_names += ['{}.pb.h'.format(proto_name)]
+            else:
+                raise Exception('Language not supported yet: {}'.format(language))
+
+            gen_file_list += gen_source_names
+            gen_file_list += gen_header_names
+
+            gen_info['sources'] += gen_source_names
+            gen_info['headers'] += gen_header_names
+
+        gen_file_list += ['{}.d'.format(source_name)]
+        argv = self.argv + [
+            '--dependency_out={}'.format(gen_file_list[-1]),
+            source_path,
+        ]
+
+        gen_entries = self.builder.AddCommand(inputs = [source_path],
+                                              argv = argv,
+                                              outputs = gen_file_list,
+                                              dep_type = 'md',
+                                              dep_file = gen_file_list[-1])
+
+        # Translate the list of generated output entries.
+        cursor = 0
+        for language in self.languages:
+            gen_info = gen_file_map[language]
+            gen_sources = gen_entries[cursor : cursor + len(gen_info['sources'])]
+            cursor += len(gen_sources)
+
+            gen_headers = gen_entries[cursor : cursor + len(gen_info['headers'])]
+            cursor += len(gen_headers)
+
+            self.gen_map[language].setdefault('sources', []).extend(gen_sources)
+            if gen_headers:
+                self.gen_map[language].setdefault('headers', []).extend(gen_headers)
+
+        # Should be one entry remaining, for the .d file.
+        assert(cursor == len(gen_entries) - 1)
+
+class Protoc(object):
+    def __init__(self, path, name, version):
+        super(Protoc, self).__init__()
+        self.path = path
+        self.name = name
+        self.version = version
+        self.extra_argv = []
+        self.includes = []
+
+    def clone(self):
+        clone = Protoc(self.path, self.name, self.version)
+        clone.extra_argv = self.extra_argv[:]
+        clone.includes = self.includes[:]
+        return clone
+
+    # Each output entry is either a language, or a tuple of (language, folder_entry).
+    def Generate(self, builder, sources, outputs, includes = []):
+        runner = ProtocRunner(self, builder, includes)
+
+        if not outputs:
+            raise Exception('No output languages were specified')
+
+        # Add outputs for each language, tracking which generated files we expect.
+        for output in outputs:
+            if type(output) is tuple:
+                language, folder = output
+            else:
+                language, folder = (output, builder.localFolder)
+            runner.AddOutput(language, folder)
+
+        # Add sources. Fixup relative paths since we don't run in the source dir.
+        for source in sources:
+            if not os.path.isabs(source):
+                source = os.path.join(builder.currentSourcePath, source)
+            runner.AddSource(source)
+
+        return runner.gen_map
+
+def DetectProtoc(**kwargs):
+    path = kwargs.pop('path', None)
+    if len(kwargs):
+        raise Exception('Unknown argument: {}'.format(kwargs.items()[0]))
+
+    if path is None:
+        path = 'protoc'
+
+    argv = [path, '--version']
+    p = util.CreateProcess(argv)
+    if p is None:
+        raise Exception('Failed to find protobuf compiler {}'.format(path))
+    if util.WaitForProcess(p) != 0:
+        raise Exception('Failed to run protoc: {}'.format(p.returncode))
+
+    text = p.stdoutText.strip()
+    parts = text.split(' ')
+    name = parts[0]
+    version = Version(parts[1])
+
+    util.con_out(util.ConsoleHeader, 'found protoc {}-{}'.format(name, version))
+
+    return Protoc(path, name, version)

--- a/ambuild2/frontend/v2_2/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_2/vs/export_vcxproj.py
@@ -41,18 +41,15 @@ def export_fp(cm, node, fp):
     # Starting from VS2017, schema link is no longer required.
     # Tools version is obsolete in VS2019 and later.
     if version >= 'msvc-1920':
-        scope = xml.block('Project',
-                        DefaultTargets = 'Build')
+        scope = xml.block('Project', DefaultTargets = 'Build')
     elif version >= 'msvc-1910':
-        scope = xml.block('Project',
-                        DefaultTargets = 'Build',
-                        ToolsVersion = toolsVersion)
+        scope = xml.block('Project', DefaultTargets = 'Build', ToolsVersion = toolsVersion)
     else:
         scope = xml.block('Project',
-                        DefaultTargets = 'Build',
-                        ToolsVersion = toolsVersion,
-                        xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003')
-    
+                          DefaultTargets = 'Build',
+                          ToolsVersion = toolsVersion,
+                          xmlns = 'http://schemas.microsoft.com/developer/msbuild/2003')
+
     with scope:
         export_body(cm, node, xml)
 
@@ -68,8 +65,7 @@ def export_body(cm, node, xml):
         if version >= 'msvc-1910':
             win_sdk_version = os.getenv('WindowsSDKVersion', None)
             if win_sdk_version:
-                xml.tag('WindowsTargetPlatformVersion',
-                        win_sdk_version.rstrip('\\'))
+                xml.tag('WindowsTargetPlatformVersion', win_sdk_version.rstrip('\\'))
 
     xml.tag('Import', Project = '$(VCTargetsPath)\Microsoft.Cpp.Default.props')
     export_configuration_properties(node, xml)

--- a/ambuild2/make_parser.py
+++ b/ambuild2/make_parser.py
@@ -40,9 +40,16 @@ class Parser(object):
         self.pos_ = 0
 
     def parse(self):
-        tok = self.lex(':')
-        if tok is None or self.peek() != ':':
+        while True:
+            tok = self.lex(':')
+            if tok is None or tok == ':':
+                break
+            if tok == '\n' or tok == '\r':
+                raise Exception('Unexpected newline in make dependency rules')
+
+        if tok is None:
             raise Exception('No Makefile dependency rules found')
+
         self.pos_ += 1
 
         items = []

--- a/ambuild2/run.py
+++ b/ambuild2/run.py
@@ -20,8 +20,8 @@ from optparse import OptionParser
 from ambuild2 import util
 from ambuild2.context import Context
 
-DEFAULT_API = '2.2.3'
-CURRENT_API = '2.2.3'
+DEFAULT_API = '2.2.4'
+CURRENT_API = '2.2.4'
 
 SampleScript = """# vim: set sts=4 ts=8 sw=4 tw=99 et ft=python:
 builder.cxx = builder.DetectCxx()


### PR DESCRIPTION
This adds a new API, and bumps the API version to 2.2.4.

DetectProtoc() returns a Protoc object. The Generate method on this is a
handy wrapper around builder.AddCommand. It returns a dictionary
mapping where generated sources and headers are. Eg,

    out = protoc.Generate(sources = ['blah.proto'], outputs = ['cpp', 'py'])

Will return a map that looks like:

    {
        'cpp': {
            'sources': Entry('blah.pb.cc'),
            'headers': Entry('blah.pb.h'),
        },
        'python': {
            'sources': Entry('blah_pb2.py'),
        },
    }