### PR TITLE
Add a StaticLibrary() helper to Protoc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.3', '3.10']
+        python-version: ['3.3', '3.12']
         os: [ubuntu-20.04, macos-latest, windows-2019]
         exclude:
          - os: macos-latest

--- a/ambuild2/frontend/cpp/cpp_rules_test.py
+++ b/ambuild2/frontend/cpp/cpp_rules_test.py
@@ -40,13 +40,13 @@ class IsSubPathTests(unittest.TestCase):
             'arch': 'x86_64',
         })
         self.assertIn('CFLAGS', props)
-        self.assertEquals(props['CFLAGS'], ['-m64'])
+        self.assertEqual(props['CFLAGS'], ['-m64'])
 
         props = rp.parse({
             'family': 'msvc',
             'arch': 'x86_64',
         })
-        self.assertEquals(props, {})
+        self.assertEqual(props, {})
 
         props = rp.parse({
             'family': 'gcc',
@@ -54,4 +54,4 @@ class IsSubPathTests(unittest.TestCase):
             'platform': 'mac',
         })
         self.assertIn('CFLAGS', props)
-        self.assertEquals(props['CFLAGS'], ['-m32', '-arch', 'i386'])
+        self.assertEqual(props['CFLAGS'], ['-m32', '-arch', 'i386'])

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# vim: set ts=2 sw=2 tw=99 et:
+# vim: set ts=4 sw=4 tw=99 et:
 
 import sys
 
@@ -21,27 +21,29 @@ if __name__ == '__main__':
     import os
     import multiprocessing as mp
 
-    mp.freeze_support()
-    proc = mp.Process(target = detect_distutils)
-    proc.start()
-    proc.join()
+    # Python 3.10+ appears to not be able to pickle detect_distutils for some reason.
+    if sys.version_info.major == 3 and sys.version_info.minor < 10:
+        mp.freeze_support()
+        proc = mp.Process(target = detect_distutils)
+        proc.start()
+        proc.join()
 
-    if proc.exitcode != 0:
-        sys.stderr.write("You have an older installation of AMBuild. AMBuild must\n")
-        sys.stderr.write("now be installed using pip (see README.md). To prevent\n")
-        sys.stderr.write("conflicts, please remove the old distutils version. You can\n")
-        sys.stderr.write("do this by inspecting the following paths and removing\n")
-        sys.stderr.write("any ambuild folders:\n")
+        if proc.exitcode != 0:
+            sys.stderr.write("You have an older installation of AMBuild. AMBuild must\n")
+            sys.stderr.write("now be installed using pip (see README.md). To prevent\n")
+            sys.stderr.write("conflicts, please remove the old distutils version. You can\n")
+            sys.stderr.write("do this by inspecting the following paths and removing\n")
+            sys.stderr.write("any ambuild folders:\n")
 
-        for path in sys.path[1:]:
-            for subdir in ['ambuild', 'ambuild2']:
-                subpath = os.path.join(path, subdir)
-                if os.path.exists(subpath):
-                    sys.stderr.write('\t{}\n'.format(subpath))
+            for path in sys.path[1:]:
+                for subdir in ['ambuild', 'ambuild2']:
+                    subpath = os.path.join(path, subdir)
+                    if os.path.exists(subpath):
+                        sys.stderr.write('\t{}\n'.format(subpath))
 
-        sys.stderr.write('Aborting installation.\n')
-        sys.stderr.flush()
-        sys.exit(1)
+            sys.stderr.write('Aborting installation.\n')
+            sys.stderr.flush()
+            sys.exit(1)
 
     from setuptools import setup, find_packages
     try:


### PR DESCRIPTION
This also fixes a bug where protoc couldn't be invoked multiple times on the same inputs, because dependency files weren't shared outputs.

It's a little gross to use shared outputs here, but the alternative is putting every .d file in its own subdir, which is even grosser.

Usage:

    cxx = builder.DetectCxx()
    protoc = builder.DetectProtoc()
    out = protoc.StaticLibrary('protos', builder, cxx, ['blah.proto'])

    other_binary = builder.Library('mylibrary')
    other_binary.compiler.sourcedeps += out.headers
    other_binary.compiler.linkflags += [out.lib.binary]
    ...