### PR TITLE
Disable minimal rebuild on VS exports

### DIFF
--- a/ambuild2/frontend/v2_2/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_2/vs/export_vcxproj.py
@@ -224,7 +224,7 @@ def export_configuration_options(node, xml, builder):
         elif '/Ot' in flags:
             xml.tag('FavorSizeOrSpeed', 'Speed')
 
-        xml.tag('MinimalRebuild', 'true')
+        xml.tag('MinimalRebuild', 'false')
 
         if '/RTC1' in flags or '/RTCsu' in flags:
             xml.tag('BasicRuntimeChecks', 'EnableFastChecks')


### PR DESCRIPTION
`/Gm` is not compatible with later versions of VS and on the versions that still support it, the build can sometimes fail to notice changes in header files for whatever reason.