### PR TITLE
Fix term color restoration in protoc.py

### DIFF
--- a/ambuild2/frontend/v2_2/tools/protoc.py
+++ b/ambuild2/frontend/v2_2/tools/protoc.py
@@ -202,7 +202,8 @@ def DetectProtoc(**kwargs):
     version = Version(parts[1])
 
     if path not in FoundProtocMap:
-        util.con_out(util.ConsoleHeader, 'found protoc {}-{}'.format(name, version))
+        util.con_out(util.ConsoleHeader, 'found protoc {}-{}'.format(name, version),
+                     util.ConsoleNormal)
         FoundProtocMap.add(path)
 
     return Protoc(path, name, version)


### PR DESCRIPTION
I can see my terminal color changing to magenta after running `configure.py`.