### PR TITLE
Fix check_output erroring due to incorrect encoding

### DIFF
--- a/ambuild2/frontend/cpp/msvc_utils.py
+++ b/ambuild2/frontend/cpp/msvc_utils.py
@@ -204,7 +204,7 @@ def run_batch(contents):
     try:
         fp.write(contents.encode('ascii'))
         fp.close()
-        return subprocess.check_output([fp.name]).decode('utf-8')
+        return subprocess.check_output([fp.name]).decode(GetCodePage())
     finally:
         os.unlink(fp.name)
 
@@ -251,3 +251,11 @@ def DetectInclusionPattern(text):
         return re.escape(phrase) + r'\s+([A-Za-z]:\\.*)$'
 
     raise Exception('Could not find compiler inclusion pattern')
+
+def GetCodePage():
+    stdout = subprocess.run(
+        "chcp", shell=True,
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL
+    ).stdout
+    return re.match(b".+: (\d+)\s*$", stdout).group(1).decode()


### PR DESCRIPTION
There's no guarantee that the encoding of `subprocess.check_output` is `utf-8`, so characters like `ä` inside the environment will cause `msvc_utils.DeduceEnv` to throw an exception. The PR adds a function that finds the correct code page so the output can be decoded properly.