### PR TITLE
Do not path split in MakeLexicalFilename

### DIFF
--- a/ambuild2/util.py
+++ b/ambuild2/util.py
@@ -767,4 +767,4 @@ def BuildDictFromTuple(tup):
 
 # Replace anything from a filename that doesn't convert to an identifier.
 def MakeLexicalFilename(file):
-    return re.sub('[^a-zA-Z0-9_]+', '_', os.path.splitext(file)[0])
+    return re.sub('[^a-zA-Z0-9_]+', '_', file)


### PR DESCRIPTION
Prevents files like aa.bb.cpp from getting clobbered