### PR TITLE
Fix cx_paths and autoinclude tests

### DIFF
--- a/tests/autoinclude/AMBuildScript
+++ b/tests/autoinclude/AMBuildScript
@@ -1,7 +1,7 @@
 # vim: set ts=8 sts=2 tw=99 et ft=python: 
 import os, sys
 
-builder.DetectCompilers()
+builder.DetectCxx()
 
 argv = [
   sys.executable,
@@ -23,7 +23,7 @@ cmd_node, (output_header,) = builder.AddCommand(
   outputs = outputs
 )
 
-program = builder.compiler.Library("hello")
+program = builder.cxx.Library("hello")
 program.compiler.includes += [builder.buildPath]
 program.compiler.sourcedeps += [output_header]
 program.sources = [

--- a/tests/cx_paths/AMBuildScript
+++ b/tests/cx_paths/AMBuildScript
@@ -1,9 +1,9 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
-builder.DetectCompilers()
-if builder.compiler.family == 'gcc':
-  builder.compiler.cflags += [
+builder.DetectCxx()
+if builder.cxx.family == 'gcc':
+  builder.cxx.cflags += [
     '-Wall',
     '-Werror'
   ]
 
-builder.RunBuildScript('helper/helper.ambuild')
+builder.Build('helper/helper.ambuild')

--- a/tests/cx_paths/helper/helper.ambuild
+++ b/tests/cx_paths/helper/helper.ambuild
@@ -1,3 +1,3 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 
-builder.RunBuildScript('/program.ambuild')
+builder.Build('/program.ambuild')

--- a/tests/cx_paths/program.ambuild
+++ b/tests/cx_paths/program.ambuild
@@ -1,5 +1,5 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
-program = builder.compiler.Program('sample')
+program = builder.cxx.Program('sample')
 program.sources += [
   'main.cpp',
 ]


### PR DESCRIPTION
I guess these got written before the API 2.1 was finalized.
