### PR TITLE
Make naming of name attribute consistent between vs gen and ambuild gen

### DIFF
--- a/ambuild2/frontend/v2_2/vs/cxx.py
+++ b/ambuild2/frontend/v2_2/vs/cxx.py
@@ -37,7 +37,7 @@ def GetProjectFileSuffix(version):
 class Project(object):
     def __init__(self, ctor, name):
         self.ctor_ = ctor
-        self.name_ = name
+        self.name = name
         self.sources = []
         self.include_hotlist = []
         self.builders_ = []
@@ -53,7 +53,7 @@ class Project(object):
         # Attach finish/generate methods to this builder, so it generates a
         # projeet file. This is a wrapper around the older API which does not
         # wrap binaries in projects.
-        builder = self.Configure(compiler, self.name_, 'Default')
+        builder = self.Configure(compiler, self.name, 'Default')
         builder.finish = self.finish
         builder.generate = lambda generator, cx: self.generate(generator, cx)[0]
         return builder
@@ -78,7 +78,7 @@ class Project(object):
     def generate_combined(self, generator, cx):
         outputs = []
         proj_path = paths.Join(cx.localFolder,
-                               self.name_ + GetProjectFileSuffix(generator.vs_vendor.version))
+                               self.name + GetProjectFileSuffix(generator.vs_vendor.version))
         node = nodes.ProjectNode(cx, proj_path, self)
         for builder in self.builders_:
             tag_folder = generator.addFolder(cx, builder.localFolder)

--- a/ambuild2/frontend/v2_2/vs/export_vcxproj.py
+++ b/ambuild2/frontend/v2_2/vs/export_vcxproj.py
@@ -60,7 +60,7 @@ def export_body(cm, node, xml):
     version = cm.generator.vs_vendor.version
     with xml.block('PropertyGroup', Label = 'Globals'):
         xml.tag('ProjectGuid', '{{{0}}}'.format(node.uuid))
-        xml.tag('RootNamespace', node.project.name_)
+        xml.tag('RootNamespace', node.project.name)
         xml.tag('Keyword', 'Win32Proj')
         if version >= 'msvc-1910':
             win_sdk_version = os.getenv('WindowsSDKVersion', None)


### PR DESCRIPTION
Fixes the below issue when using vs gen with current SourceMod code

```
Traceback (most recent call last):
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\prep.py", line 156, in Configure
    if not cm.generate(options.generator):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\context_manager.py", line 93, in generate
    self.parseBuildScripts()
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 50, in parseBuildScripts
    self.execContext(cx)
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 148, in execContext
    exec(code, scriptGlobals)
  File "G:\sm\sourcemod\AMBuildScript", line 590, in <module>
    builder.Build('public/safetyhook/AMBuilder', {'SafetyHook': SafetyHook })
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\context.py", line 160, in Build
    return self.cm.runBuildScript(self, path, vars or {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 68, in runBuildScript
    return self.runBuildScriptImpl(context, path, vars or {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 119, in runBuildScriptImpl
    scriptGlobals = self.execContext(cx)
                    ^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\ambuild2\frontend\v2_2\context_manager.py", line 148, in execContext
    exec(code, scriptGlobals)
  File "G:\sm\sourcemod\public/safetyhook\AMBuilder", line 25, in <module>
    binary = libsafetyhook.Configure(compiler, libsafetyhook.name, 'Release - {0}'.format(compiler.target.arch))
                                               ^^^^^^^^^^^^^^^^^^
AttributeError: 'Project' object has no attribute 'name'. Did you mean: 'name_'?
Configure failed: 'Project' object has no attribute 'name'
```