### PR TITLE
fix: Populate __file__ var when evaluating scripts

### DIFF
--- a/ambuild2/frontend/v2_2/context_manager.py
+++ b/ambuild2/frontend/v2_2/context_manager.py
@@ -142,6 +142,7 @@ class ContextManager(context_manager.ContextManager):
 
         # Copy vars so changes don't get inherited.
         scriptGlobals = copy.copy(context.vars_)
+        scriptGlobals['__file__'] = context.script_
 
         self.pushContext(context)
         try:


### PR DESCRIPTION
This change populates the normally built-in `__file__` variable with the path of the script, for `eval`ed scripts.

A current use case is being able to detect the current script path in [hl2sdk-manifests](https://github.com/alliedmodders/hl2sdk-manifests/)'s SdkHelpers.ambuild to then be able to infer the path of the manifests folder beside it.