### PR TITLE
fix: Eval scripts no longer mangle absolute paths

### DIFF
--- a/ambuild2/frontend/v2_2/context_manager.py
+++ b/ambuild2/frontend/v2_2/context_manager.py
@@ -70,10 +70,13 @@ class ContextManager(context_manager.ContextManager):
     def importScriptImpl(self, parent, path, vars):
         assert isinstance(path, util.StringType())
 
-        sourceFolder, _, scriptFile = self.computeScriptPaths(parent, path)
+        sourceFolder, _ = self.computeScriptPaths(parent, path)
 
         # Get the absolute script path.
-        scriptPath = os.path.join(self.sourcePath, scriptFile)
+        if os.path.isabs(path):
+            scriptPath = path
+        else:
+            scriptPath = os.path.join(self.sourcePath, path)
         self.generator.addConfigureFile(parent, scriptPath)
 
         # Make the new context.
@@ -93,10 +96,13 @@ class ContextManager(context_manager.ContextManager):
         if parent is not self.contextStack_[-1]:
             raise Exception('Can only create child build contexts of the currently active context')
 
-        sourceFolder, buildFolder, scriptFile = self.computeScriptPaths(parent, path)
+        sourceFolder, buildFolder = self.computeScriptPaths(parent, path)
 
         # Get the absolute script path.
-        scriptPath = os.path.join(self.sourcePath, scriptFile)
+        if os.path.isabs(path):
+            scriptPath = path
+        else:
+            scriptPath = os.path.join(self.sourcePath, path)
         self.generator.addConfigureFile(parent, scriptPath)
 
         # Make the new context. We allow top-level contexts in the root build
@@ -176,7 +182,7 @@ class ContextManager(context_manager.ContextManager):
             sourceFolder = ''
             buildFolder = ''
 
-        return sourceFolder, buildFolder, os.path.join(sourceFolder, name)
+        return sourceFolder, buildFolder
 
     def getLocalFolder(self, context):
         return context.buildFolder


### PR DESCRIPTION
This fixes an issue on non-Windows platforms, where passing an absolute path to builder.Eval results in broken path handling (with the absolute path being appended to the current relative path).