### PR TITLE
Fix Windows codepage detection when using language pack

### DIFF
--- a/ambuild2/frontend/cpp/msvc_utils.py
+++ b/ambuild2/frontend/cpp/msvc_utils.py
@@ -260,7 +260,10 @@ def GetCodePage():
                                 stdout = subprocess.PIPE,
                                 stderr = subprocess.DEVNULL,
                                 stdin = subprocess.DEVNULL).stdout
-        codec = 'cp' + re.match(b".+: (\d+)\s*$", stdout).group(1).decode()
+        code_page = re.match(br".+: (\d+)\.?\s*$", stdout)
+        if code_page is None:
+            raise LookupError("Could not determine code page")
+        codec = 'cp' + code_page.group(1).decode()
         codecs.lookup(codec)
         return codec
     except LookupError:


### PR DESCRIPTION
When running `chcp` on a german Windows installation, the output contains a `.` after the code page:

```
> chcp
Aktive Codepage: 850.
```

Allow an optional dot in the output parsing and fallback to utf8 if the output parsing fails.

```
Could not run or analyze C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsamd64_x86.bat: 'NoneType' object has no attribute 'group'
Traceback (most recent call last):
<unknown>:2: SyntaxWarning: invalid escape sequence '\d'
<unknown>:1: SyntaxWarning: invalid escape sequence '\d'
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\v2_2\cpp\detect.py", line 318, in try_msvc_bat
    env_cmds = msvc_utils.DeduceEnv(bat_file, argv)
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\cpp\msvc_utils.py", line 214, in DeduceEnv
    env_before = parse_env(run_batch(contents))
                           ~~~~~~~~~^^^^^^^^^^
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\cpp\msvc_utils.py", line 208, in run_batch
    return subprocess.check_output([fp.name]).decode(GetCodePage())
                                                     ~~~~~~~~~~~^^
  File "C:\Users\Jannik\AppData\Local\Programs\Python\Python313\Lib\site-packages\ambuild2\frontend\cpp\msvc_utils.py", line 263, in GetCodePage
    codec = 'cp' + re.match(b".+: (\d+)\s*$", stdout).group(1).decode()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group'
```