### PR TITLE
Generate compile_commands.json for Clangd

### DIFF
--- a/ambuild2/frontend/v2_2/prep.py
+++ b/ambuild2/frontend/v2_2/prep.py
@@ -41,6 +41,12 @@ class Preparer(object):
                                   default = False,
                                   help = "List available build system generators, then exit.")
         self.options.add_argument(
+            "--generate-compile-commands",
+            action = "store_true",
+            dest = "generate_compdb",
+            default = True,
+            help = "Generate a JSON Compilation Database for Clangd.")
+        self.options.add_argument(
             "--make-scripts",
             action = "store_true",
             dest = "make_scripts",


### PR DESCRIPTION
Added an option to generate the compile_commands.json file needed for [Clangd](https://clang.llvm.org/docs/JSONCompilationDatabase.html). Makes it basically zero-click to get projects configured with an LSP.