### PR TITLE
Fix VS generator missing addOutputFile definition

### DIFF
--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -154,6 +154,10 @@ class Generator(BaseGenerator):
         return (None, (None,))
 
     # Overridden.
+    def addOutputFile(self, context, path, contents):
+        return None
+
+    # Overridden.
     def addShellCommand(self,
                         context,
                         inputs,

--- a/ambuild2/frontend/vs/gen.py
+++ b/ambuild2/frontend/vs/gen.py
@@ -155,7 +155,7 @@ class Generator(BaseGenerator):
 
     # Overridden.
     def addOutputFile(self, context, path, contents):
-        return None
+        return nodes.Node(context, path)
 
     # Overridden.
     def addShellCommand(self,


### PR DESCRIPTION
Currently trying to generate a VS solution from a buildscripts that calls to AddOutputFile builder api would result in the following error:
```
AttributeError: 'Generator' object has no attribute 'addOutputFile'
```
coming from this location https://github.com/alliedmodders/ambuild/blob/7c2f72f0fe46a7d6137bfe64d9b43b85c3cd30f7/ambuild2/frontend/v2_2/context.py#L242-L243

This pr adds a stub ``addOutputFile`` method to VS generator which resolves the issue.