### PR TITLE
Disable the distutils detection code for Python 3.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ if __name__ == '__main__':
     import os
     import multiprocessing as mp
 
-    # Python 3.10+ appears to not be able to pickle detect_distutils for some reason.
-    if sys.version_info.major == 3 and sys.version_info.minor < 10:
+    # Python 3.9+ appears to not be able to pickle detect_distutils for some reason.
+    if sys.version_info.major == 3 and sys.version_info.minor < 9:
         mp.freeze_support()
         proc = mp.Process(target = detect_distutils)
         proc.start()


### PR DESCRIPTION
The pickling error affecting 3.10+ also seems to affect 3.9.13 which is the version used in the windows-2022 and windows-2025 GitHub runners.