### PR TITLE
Output full path in the directory field of compilation database

### DIFF
--- a/ambuild2/frontend/amb2_gen.py
+++ b/ambuild2/frontend/amb2_gen.py
@@ -761,8 +761,12 @@ class Generator(BaseGenerator):
             cxxData['deps'] = obj.dep_info
 
         if getattr(self.cm.options, 'generate_compdb', False):
+            directory = obj.folderNode.path
+            if not os.path.isabs(directory):
+                directory = os.path.join(self.cm.buildPath, directory)
+            directory = os.path.normpath(directory)
             self.compdb.append({
-                "directory": obj.folderNode.path,
+                "directory": directory,
                 "arguments": obj.argv,
                 "file": str(obj.inputObj),
                 "output": str(obj.outputs[0])


### PR DESCRIPTION
CLion doesn't like it when the directory field of compilation database is not an absolute path. This patch makes it output the full path and this is in line with how CMake outputs compilation database as well.