### PR TITLE
Fix MSVC shared-library dependency linking

### DIFF
--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -469,10 +469,16 @@ class BinaryBuilder(BinaryBuilderBase):
         def resolve(item):
             if hasattr(item, 'path'):
                 if os.path.isabs(item.path):
-                    return item.path
+                    path = item.path
+                else:
+                    local_path = os.path.join(cx.buildFolder, self.localFolder)
+                    path = os.path.relpath(item.path, local_path)
 
-                local_path = os.path.join(cx.buildFolder, self.localFolder)
-                return os.path.relpath(item.path, local_path)
+                # MSVC links against the import library produced alongside a
+                # shared library, not the DLL itself.
+                if self.linker_.behavior == 'msvc' and path.lower().endswith('.dll'):
+                    path = path[:-4] + '.lib'
+                return path
 
             return item
 


### PR DESCRIPTION
Translate shared-library DLL outputs to their corresponding import libraries when resolving MSVC linker inputs.

I'm not sure those are the right places to fix this or if some more proper abstraction is better than those local hacks.
This was required to get hl2sdk-mock to build on Windows.
https://github.com/alliedmodders/hl2sdk-mock/tree/windows_build

Fixes #188