### PR TITLE
Fix .dll linking on Windows.

### DIFF
--- a/ambuild2/frontend/cpp/cpp_utils.py
+++ b/ambuild2/frontend/cpp/cpp_utils.py
@@ -14,7 +14,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with AMBuild. If not, see <http://www.gnu.org/licenses/>.
+import os
 import uuid
+
+def LinkerInputPath(path, behavior):
+    # Newer MSVC link.exe versions (14.50+) refuse .dll files passed directly
+    # as linker inputs (LNK1107 "invalid or corrupt file"). Historically, the
+    # linker would import from a DLL by reading the import library embedded in
+    # the image, but that is no longer supported. Whenever a shared library is
+    # passed to the linker, use its sibling import library instead.
+    if behavior == 'msvc' and path.lower().endswith('.dll'):
+        return os.path.splitext(path)[0] + '.lib'
+    return path
 
 def CreateUnifiedHeader(header_guard, sources):
     text = ""

--- a/ambuild2/frontend/v2_2/cpp/builders.py
+++ b/ambuild2/frontend/v2_2/cpp/builders.py
@@ -466,13 +466,16 @@ class BinaryBuilder(BinaryBuilderBase):
         return self.linker_
 
     def linkFlags(self, cx):
+        behavior = self.linker_.behavior
+
         def resolve(item):
             if hasattr(item, 'path'):
                 if os.path.isabs(item.path):
-                    return item.path
+                    return cpp_utils.LinkerInputPath(item.path, behavior)
 
                 local_path = os.path.join(cx.buildFolder, self.localFolder)
-                return os.path.relpath(item.path, local_path)
+                rel_path = os.path.relpath(item.path, local_path)
+                return cpp_utils.LinkerInputPath(rel_path, behavior)
 
             return item
 


### PR DESCRIPTION
Sending .dll files to LINK.EXE no longer works, so in linkFlags peek at the output and rewrite them to .lib files.

The graph edge will still show .dll as an input, but in theory this is ok as the .dll and .lib are always generated together.